### PR TITLE
May Connector extensions

### DIFF
--- a/guidelines.md
+++ b/guidelines.md
@@ -72,7 +72,7 @@ In order to pass this interval to the API, it has to be converted to UTC:
 
 ## Language and Culture
 
-All operations of the API accept language code and culture code. These values are optional and can be used for enforcing of the language and culture. Both of these values must be defined together otherwise default values of the Hotel are used.
+All operations of the API accept language code and culture code. These values are optional and can be used for enforcing of the language and culture. Both of these values must be defined together otherwise default values of the Enterprise are used.
 
 ```javascript
 {
@@ -87,5 +87,5 @@ All operations of the API accept language code and culture code. These values ar
 | --- | --- | --- | --- |
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
-| `LanguageCode` | string | optional | Language code of the language. |
+| `LanguageCode` | string | optional | Language code of the [language](operations/configuration.md#language). |
 | `CultureCode` | string | optional | Culture code of the culture. |

--- a/guidelines.md
+++ b/guidelines.md
@@ -70,3 +70,22 @@ In order to pass this interval to the API, it has to be converted to UTC:
 * StartUtc `2016-12-31T22:00:00Z`
 * EndUtc `2017-01-02T22:00:00Z`
 
+## Language and Culture
+
+All operations of the API accept language code and culture code. These values are optional and can be used for enforcing of the language and culture. Both of these values must be defined together otherwise default values of the Hotel are used.
+
+```javascript
+{
+    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+    "LanguageCode": null,
+    "CultureCode": null 
+}
+```
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `LanguageCode` | string | optional | Language code of the language. |
+| `CultureCode` | string | optional | Culture code of the culture. |

--- a/operations/README.md
+++ b/operations/README.md
@@ -62,7 +62,7 @@ This section describes all operations supported by the API:
   * [Get all bills by ids](finance.md#get-all-bills-by-ids) - returns all bills by their identifiers.
   * [Get all bills by customers](finance.md#get-all-bills-by-customers) - returns all bills of the specified customers.
   * [Get all closed bills](finance.md#get-all-closed-bills) - returns all closed bills in an interval.
-  * [Get all credit cards by ids](finance.md#get-all-credit-cards-by-ids) - return all credit cards by their identifiers.
+  * [Get all credit cards by ids](finance.md#get-all-credit-cards-by-ids) - returns all credit cards by their identifiers.
   * [Get all credit cards by customers](finance.md#get-all-credit-cards-by-customers) - return all credit cards of the specified customers.
   * [Get all preauthorizations by customers](finance.md#get-all-preauthorizations-by-customers) - returns all preauthorizations of the specified customers.
   * [Add credit card payment](finance.md#add-credit-card-payment) - adds a new credit card payment.

--- a/operations/README.md
+++ b/operations/README.md
@@ -62,6 +62,8 @@ This section describes all operations supported by the API:
   * [Get all bills by ids](finance.md#get-all-bills-by-ids) - returns all bills by their identifiers.
   * [Get all bills by customers](finance.md#get-all-bills-by-customers) - returns all bills of the specified customers.
   * [Get all closed bills](finance.md#get-all-closed-bills) - returns all closed bills in an interval.
+  * [Get all credit cards by ids](finance.md#get-all-credit-cards-by-ids) - return all credit cards by their identifiers.
+  * [Get all credit cards by customers](finance.md#get-all-credit-cards-by-customers) - return all credit cards of the specified customers.
   * [Get all preauthorizations by customers](finance.md#get-all-preauthorizations-by-customers) - returns all preauthorizations of the specified customers.
   * [Add credit card payment](finance.md#add-credit-card-payment) - adds a new credit card payment.
   * [Add external payment](finance.md#add-external-payment) - adds a new external payment.

--- a/operations/finance.md
+++ b/operations/finance.md
@@ -570,6 +570,39 @@ Returns all credit cards with the specified ids.
 | --- | --- | --- | --- |
 | CreditCards | array of [Credit card](finance.md#credit-card)s | required | The credit cards. |
 
+#### Credit card
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `Id` | string | required | Unique identifier of the credit card. |
+| `CustomerId` | string | required | Unique identifier of the credit card [owner](customers.md#customer). |
+| `CreatedUtc` | string | required | Creation date and time of the credit card in UTC timezone in ISO 8601 format. |
+| `Expiration` | string | optional | Expiration of the credit card in format `MM/YYYY`. |
+| `IsActive` | boolean | required | Whether the credit card is still active. |
+| `ObfuscatedNumber` | string | optinal | Obfuscated credit card number. At most first six digits and last four digits can be specified, otherwise the digits are replaced with `*`. |
+| `Format` | string [Credit card format](finance.md#credit-card-format)| required | Format of the credit card. |
+| `Kind` | string [Credit card kind](finance.md#credit-card-kind) | required | Kind of the credit card. |
+| `State` | string [Credit card state](finance.md#credit-card-state) | required | State of the credit card. |
+| `Type` | string [Credit card type](finance.md#credit-card-type) | required | Type of the credit card. |
+
+#### Credit card format
+
+* `Physical`
+* `Virtual`
+
+#### Credit card kind
+
+* `Terminal`
+* `Gateway`
+
+#### Credit card state
+
+* `Enabled`
+* `Disabled`
+
+#### Credit card type
+
+* `MasterCard`, `Visa`, `Amex`, `Maestro`, `Discover`, `VPay`, ...
 
 ## Get all credit cards by customers
 
@@ -593,47 +626,15 @@ Returns all credit cards of specified customers.
 | --- | --- | --- | --- |
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
-| `CustomerIds` | array of string | required | Unique identifier of the [Customer](customers.md#customer). |
+| `CustomerIds` | array of string | required | Unique identifier of the [Customer](customers.md#customer)s. |
 
 ### Response
 
-```javascript
-{
-    "CreditCards": [
-        {
-            "CreatedUtc": "2018-05-24T13:45:29Z",
-            "CustomerId": "a3c90426-43f2-4b53-8482-446dfc724bd2",
-            "Expiration": "2020-11",
-            "Format": "Physical",
-            "Id": "f1d94a32-b4be-479b-9e47-a9fcb03d5196",
-            "IsActive": true,
-            "Kind": "Gateway",
-            "ObfuscatedNumber": "************1111",
-            "State": "Enabled",
-            "Type": "Visa"
-        }
-    ]
-}
-```
+Same structure as in [Get all credit cards by ids](finance.md#get-all-credit-cards-by-ids) operation.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | CreditCards | array of [Credit card](finance.md#credit-card)s | required | Credit cards of the specified [Customer](customers.md#customer)s. |
-
-#### Credit card
-
-| Property | Type |  | Description |
-| --- | --- | --- | --- |
-| `Id` | string | required | Unique identifier of the credit card. |
-| `CustomerId` | string | required | Unique identifier of the credit card owner. |
-| `CreatedUtc` | string | required | Creation date and time of the credit card. |
-| `Expiration` | string | optional | Expiration of the credit card. |
-| `IsActive` | boolean | required | Whether the credit card is still active. |
-| `ObfuscatedNumber` | string | optinal | Obfuscated credit card number. At most first six digits and last four digits can be specified, the digits in between should be replaced with `*`. |
-| `Format` | string | required | Format of the credit card, one of the: `Physical`, `Virtual`. |
-| `Kind` | string | required | Kind of the credit card, one of the: `Terminal`, `Gateway`. |
-| `State` | string | required | State of the credit card, one of the: `Enabled`, `Disabled`. |
-| `Type` | string | required | Type of the credit card, one of the: `MasterCard`, `Visa`, `Amex`, `Discover`, `DinersClub`, `Jcb`, `Maestro`, `UnionPay`, `VPay`, `RuPay`, `Dankort`, `Mir`, `Verve`, `Troy`, `PostFinance`, `Giro`, `Bancomat`, `Bc`, `CarteBleue`, `Eftpos`, `Eps`, `Interac`, `Isracard`, `Meps`, `Nets`. |
 
 ## Get all preauthorizations by customers
 

--- a/operations/finance.md
+++ b/operations/finance.md
@@ -314,7 +314,7 @@ Returns all accounting items of the enterprise that were consumed \(posted\) or 
 | `ServiceId` | string | optional | Unique identifier of the [Service](services.md#service) the item belongs to. |
 | `OrderId` | string | optional | Unique identifier of the order \(or [Reservation](reservations.md#reservation) which is a special type of order\) the item belongs to. |
 | `BillId` | string | optional | Unique identifier of the bill the item is assigned to. |
-| `CreditCardId` | string | optional | Unique identifier of the [Credit card](finance.md#credit-card) the item is associated. |
+| `CreditCardId` | string | optional | Unique identifier of the [Credit card](finance.md#credit-card) the item is associated to. |
 | `InvoiceId` | string | optional | Unique identifier of the invoiced [Bill](finance.md#bill) the item is receivable for. |
 | `AccountingCategoryId` | string | optional | Unique identifier of the [Accounting category](finance.md#accounting-category) the item belongs to. |
 | `Amount` | [Currency value](finance.md#currency-value) | required | Amount the item costs, negative amount represents either rebate or a payment. |
@@ -633,8 +633,7 @@ Returns all credit cards of specified customers.
 | `Format` | string | required | Format of the credit card, one of the: `Physical`, `Virtual`. |
 | `Kind` | string | required | Kind of the credit card, one of the: `Terminal`, `Gateway`. |
 | `State` | string | required | State of the credit card, one of the: `Enabled`, `Disabled`. |
-| `Type` | string | required | Type of the credit card, one of the: `MasterCard`, `Visa`, `Amex`, `Discover`, `DinersClub`, `Jcb`, `Maestro`, `UnionPay`, `VPay`, `RuPay`, `Dankort`, `Mir`, `Verve`, `Troy`, `PostFinance`, `Giro`, `Bancomat`, `Bc`, `CarteBleue`, `Eftpos`, `Eps`, `Interac`, `Isracard`, `Meps`, `Nets`.  |
-
+| `Type` | string | required | Type of the credit card, one of the: `MasterCard`, `Visa`, `Amex`, `Discover`, `DinersClub`, `Jcb`, `Maestro`, `UnionPay`, `VPay`, `RuPay`, `Dankort`, `Mir`, `Verve`, `Troy`, `PostFinance`, `Giro`, `Bancomat`, `Bc`, `CarteBleue`, `Eftpos`, `Eps`, `Interac`, `Isracard`, `Meps`, `Nets`. |
 
 ## Get all preauthorizations by customers
 
@@ -653,8 +652,6 @@ Returns all preauthorizations of specified customers.
     ]
 }
 ```
-
-### Response
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |

--- a/operations/finance.md
+++ b/operations/finance.md
@@ -283,6 +283,7 @@ Returns all accounting items of the enterprise that were consumed \(posted\) or 
                 "Value": 2.5
             },
             "BillId": null,
+            "CreditCardId" : null,
             "ClosedUtc": "2017-02-41T10:41:54Z",
             "ConsumptionUtc": "2016-07-27T12:48:39Z",
             "CustomerId": "2a1a4315-7e6f-4131-af21-402cec59b8b9",
@@ -313,6 +314,7 @@ Returns all accounting items of the enterprise that were consumed \(posted\) or 
 | `ServiceId` | string | optional | Unique identifier of the [Service](services.md#service) the item belongs to. |
 | `OrderId` | string | optional | Unique identifier of the order \(or [Reservation](reservations.md#reservation) which is a special type of order\) the item belongs to. |
 | `BillId` | string | optional | Unique identifier of the bill the item is assigned to. |
+| `CreditCardId` | string | optional | Unique identifier of the [Credit card](finance.md#credit-card) the item is associated. |
 | `InvoiceId` | string | optional | Unique identifier of the invoiced [Bill](finance.md#bill) the item is receivable for. |
 | `AccountingCategoryId` | string | optional | Unique identifier of the [Accounting category](finance.md#accounting-category) the item belongs to. |
 | `Amount` | [Currency value](finance.md#currency-value) | required | Amount the item costs, negative amount represents either rebate or a payment. |
@@ -519,6 +521,121 @@ Returns all bills \(both receipts and invoices\) that have been closed in the sp
 
 Same structure as in [Get all bills by ids](finance.md#get-all-bills-by-ids) operation.
 
+## Get all credit cards by ids
+
+Returns all credit cards with the specified ids.
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/creditCards/getAllByIds`
+
+```javascript
+{
+    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+    "CreditCardIds": [
+        "f1d94a32-b4be-479b-9e47-a9fcb03d5196"
+    ]
+}
+```
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `CreditCardIds` | array of string | required | Unique identifier of the [Credit card](finance.md#credit-card). |
+
+### Response
+
+```javascript
+{
+    "CreditCards": [
+        {
+            "CreatedUtc": "2018-05-24T13:45:29Z",
+            "CustomerId": "a3c90426-43f2-4b53-8482-446dfc724bd2",
+            "Expiration": "2020-11",
+            "Format": "Physical",
+            "Id": "f1d94a32-b4be-479b-9e47-a9fcb03d5196",
+            "IsActive": true,
+            "Kind": "Gateway",
+            "ObfuscatedNumber": "************1111",
+            "State": "Enabled",
+            "Type": "Visa"
+        }
+    ]
+}
+```
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| CreditCards | array of [Credit card](finance.md#credit-card)s | required | The credit cards. |
+
+
+## Get all credit cards by customers
+
+Returns all credit cards of specified customers.
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/creditCards/getAllByCustomers`
+
+```javascript
+{
+    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+    "CustomerIds": [
+        "a3c90426-43f2-4b53-8482-446dfc724bd2"
+    ]
+}
+```
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `CustomerIds` | array of string | required | Unique identifier of the [Customer](customers.md#customer). |
+
+### Response
+
+```javascript
+{
+    "CreditCards": [
+        {
+            "CreatedUtc": "2018-05-24T13:45:29Z",
+            "CustomerId": "a3c90426-43f2-4b53-8482-446dfc724bd2",
+            "Expiration": "2020-11",
+            "Format": "Physical",
+            "Id": "f1d94a32-b4be-479b-9e47-a9fcb03d5196",
+            "IsActive": true,
+            "Kind": "Gateway",
+            "ObfuscatedNumber": "************1111",
+            "State": "Enabled",
+            "Type": "Visa"
+        }
+    ]
+}
+```
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| CreditCards | array of [Credit card](finance.md#credit-card)s | required | Credit cards of the specified [Customer](customers.md#customer)s. |
+
+#### Credit card
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `Id` | string | required | Unique identifier of the credit card. |
+| `CustomerId` | string | required | Unique identifier of the credit card owner. |
+| `CreatedUtc` | string | required | Creation date and time of the credit card. |
+| `Expiration` | string | optional | Expiration of the credit card. |
+| `IsActive` | boolean | required | Whether the credit card is still active. |
+| `ObfuscatedNumber` | string | optinal | Obfuscated credit card number. At most first six digits and last four digits can be specified, the digits in between should be replaced with `*`. |
+| `Format` | string | required | Format of the credit card, one of the: `Physical`, `Virtual`. |
+| `Kind` | string | required | Kind of the credit card, one of the: `Terminal`, `Gateway`. |
+| `State` | string | required | State of the credit card, one of the: `Enabled`, `Disabled`. |
+| `Type` | string | required | Type of the credit card, one of the: `MasterCard`, `Visa`, `Amex`, `Discover`, `DinersClub`, `Jcb`, `Maestro`, `UnionPay`, `VPay`, `RuPay`, `Dankort`, `Mir`, `Verve`, `Troy`, `PostFinance`, `Giro`, `Bancomat`, `Bc`, `CarteBleue`, `Eftpos`, `Eps`, `Interac`, `Isracard`, `Meps`, `Nets`.  |
+
+
 ## Get all preauthorizations by customers
 
 Returns all preauthorizations of specified customers.
@@ -536,6 +653,8 @@ Returns all preauthorizations of specified customers.
     ]
 }
 ```
+
+### Response
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
@@ -643,18 +762,18 @@ Adds a new credit card payment to a bill of the specified customer. Note that th
 | `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
 | `BillId` | string | optional | Unique identifier of an open bill of the customer where to assign the payment. |
 | `Amount` | [Currency value](finance.md#currency-value) | required | Amount of the credit card payment. |
-| `CreditCard` | [Credit card](finance.md#credit-card) | required | Credit card details. |
+| `CreditCard` | [Credit card](finance.md#credit-card-parameters) | required | Credit card details. |
 | `Category` | [Accounting category parameters](services.md#accounting-category-parameters) | optional | Accounting category to be assigned to the payment. |
 | `ReceiptIdentifier` | string | optional | Identifier of the payment receipt. |
 | `Notes` | string | optional | Additional payment notes. |
 
-#### Credit card
+#### Credit card parameters
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Type` | string | required | Type of the credit card, one of: `Visa`, `MasterCard`, `Amex`, `Discover`, `DinersClub`, `Jcb`, `EnRoute`, `Maestro`, `UnionPay`. |
 | `Number` | string | required | Obfuscated credit card number. At most first six digits and last four digits can be specified, the digits in between should be replaced with `*`. It is possible to provide even more obfuscated number or just last four digits. **Never provide full credit card number**. For example `411111******1111`. |
-| `Expiration` | string | required | Expiration of the credit card in format `MM/YYYY`, e.g. `12/2016` or `04/2017`. |
+| `Expiration` | string | optional | Expiration of the credit card in format `MM/YYYY`, e.g. `12/2016` or `04/2017`. |
 | `Name` | string | required | Name of the card holder. |
 
 ### Response

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -736,7 +736,7 @@ Updates reservation category requested by the customer to a different one.
 | `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to be updated. |
 | `CategoryId` | string | required | Unique identifier of the [Space category](enterprises.md#space-category). |
 | `Reprice` | bool | required | Whether reservation should be repriced according to new category pricing. |
-| `Overbook` | bool | optional | Default value is `true`. Whether the overbooking is enabled.  |
+| `Overbook` | bool | optional | Whether the overbooking is enabled. Default value is `true`. |
 
 ### Response
 

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -724,7 +724,8 @@ Updates reservation category requested by the customer to a different one.
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "ReservationId": "e6ea708c-2a2a-412f-a152-b6c76ffad49b",
     "CategoryId": "773d5e42-de1e-43a0-9ce6-f940faf2303f",
-    "Reprice": false
+    "Reprice": false,
+    "Overbook": "true"
 }
 ```
 
@@ -735,6 +736,7 @@ Updates reservation category requested by the customer to a different one.
 | `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to be updated. |
 | `CategoryId` | string | required | Unique identifier of the [Space category](enterprises.md#space-category). |
 | `Reprice` | bool | required | Whether reservation should be repriced according to new category pricing. |
+| `Overbook` | bool | optional | Default value is `true`. Whether the overbooking is enabled.  |
 
 ### Response
 
@@ -816,7 +818,8 @@ Adds a new product order of the specified product to the reservation.
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "ReservationId": "c2e37cec-11a0-4fe7-8467-fbc50b54722f",
     "ProductId": "3dc5d79b-67ce-48ed-9238-47fcf5d1a59f",
-    "Count": 1
+    "Count": 1,
+    "UnitCost": null
 }
 ```
 
@@ -827,6 +830,7 @@ Adds a new product order of the specified product to the reservation.
 | `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
 | `ProductId` | string | required | Unique identifier of the [Product](services.md#product). |
 | `Count` | int | required | The amount of the products to be added. Note that if the product is charged e.g. per night, count 1 means a single product every night. Count 2 means two products every night. |
+| `UnitCost` | [Cost](services.md#cost) | optional | Unit cost of the product that overrides the cost defined in Mews. |
 
 ### Response
 

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -725,7 +725,7 @@ Updates reservation category requested by the customer to a different one.
     "ReservationId": "e6ea708c-2a2a-412f-a152-b6c76ffad49b",
     "CategoryId": "773d5e42-de1e-43a0-9ce6-f940faf2303f",
     "Reprice": false,
-    "Overbook": "true"
+    "Overbook": true
 }
 ```
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -223,6 +223,7 @@ Raturns all products offered together with the specified services.
 * `Once`
 * `PerTimeUnit`
 * `PerPersonPerTimeUnit`
+* `PerPerson`
 
 ## Get all business segments
 


### PR DESCRIPTION
```
* Extended [API](guidelines.md#language-and-culture) parameters with optional `Language` and `Culture`.
* Added [Get all credit cards by ids](operations/finance.md#get-all-creditc-cards-by-ids) operation.
* Added [Get all credit cards by customers](operations/finance.md#get-all-creditc-cards-by-customers) operation.
* Extended [Accounting item](operations/finance.md#accounting-item) with `CreditCardId`.
* `Expiration` is optional in [Credit card parameters](operations/finance.md#credit-card-parameters). 
* Extended [Update reservation requested category](operations/reservations.md#update-reservation-requested-category) with `Overbook`.
* Extended [Add reservation product](operations/reservations.md#add-reservation-product) with `UnitCost`.
* Extended [Product charging](operations/services.md#product-charging) with `PerPerson`.
```