### PR TITLE
AssignedSpaceId in ReservationEvent.

### DIFF
--- a/websockets.md
+++ b/websockets.md
@@ -67,6 +67,7 @@ If the Connector integration is configured to receive reservation updates, it wi
 | `State` | string [Reservation state](operations/reservations.md#reservation-state) | required | State of the reservation. |
 | `StartUtc` | string | required | Start of the reservation \(arrival\) in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | Endof the reservation \(departure\) in UTC timezone in ISO 8601 format. |
+| `AssignedSpaceId` | string | optional | Unique identifier of the [operations/enterprises#space](Space) assigned to the reservation. |
 
 #### Space event
 


### PR DESCRIPTION
```
* [Reservation event](websockets.md#reservation-event) extended with `AssignedSpaceId`.
```

### Summary
Alraedy implemented, just the documentation wasn't updated.