### PR TITLE
Attach credit card to reservation in Connector

### DIFF
--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -584,7 +584,7 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | `TimeUnitAmount` | [Amount](services.md#amount-parameters) | optional | Amount of each night of the reservation. |
 | `TimeUnitPrices` | array of [Time unit amount parameters](reservations.md#time-unit-amount-parameters) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. |
 | `ProductOrders` | array of [Product order parameters](services.md#product-order-parameters) | optional | Parameters of the products ordered together with the reservation. |
-| `CreditCardId` | string | optional | Identifier of credit card belonging to [Customer](customers.md#customer) who owns the reservation. |
+| `CreditCardId` | string | optional | Identifier of [Credit card](finance.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation. |
 
 ### Response
 
@@ -732,7 +732,7 @@ Updates information about a reservation. Note that if any of the fields are sent
 | `RateId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the reservation [Rate](services.md#rate) \(or `null` if the rate should not be updated). |
 | `BookerId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the booker should not be updated). |
 | `TimeUnitPrices` | [Time unit amount update value](reservations.md#time-unit-amount-update-value) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. \(or `null` if the unit amounts should not be updated). |
-| `CreditCardId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the credit card should not be updated). |
+| `CreditCardId` | [String update value](reservations.md#string-update-value) | optional | Identifier of [Credit card](finance.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation.  \(or `null` if the credit card should not be updated). |
 
 #### String update value
 

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -584,7 +584,7 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | `TimeUnitAmount` | [Amount](services.md#amount-parameters) | optional | Amount of each night of the reservation. |
 | `TimeUnitPrices` | array of [Time unit amount parameters](reservations.md#time-unit-amount-parameters) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. |
 | `ProductOrders` | array of [Product order parameters](services.md#product-order-parameters) | optional | Parameters of the products ordered together with the reservation. |
-| `CreditCardId` | string | optional | Identifier of credit card belonging to Customer who owns the reservation. |
+| `CreditCardId` | string | optional | Identifier of credit card belonging to [Customer](customers.md#customer) who owns the reservation. |
 
 ### Response
 

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -543,7 +543,8 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
                 {
                     "ProductId": "3dc5d79b-67ce-48ed-9238-47fcf5d1a59f"
                 }
-            ]
+            ],
+            "CreditCardId": "5d802a8f-3238-42b2-94be-ab0300ab2b6c"
         }
     ]
 }
@@ -583,6 +584,7 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | `TimeUnitAmount` | [Amount](services.md#amount-parameters) | optional | Amount of each night of the reservation. |
 | `TimeUnitPrices` | array of [Time unit amount parameters](reservations.md#time-unit-amount-parameters) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. |
 | `ProductOrders` | array of [Product order parameters](services.md#product-order-parameters) | optional | Parameters of the products ordered together with the reservation. |
+| `CreditCardId` | string | optional | Identifier of credit card belonging to Customer who owns the reservation. |
 
 ### Response
 
@@ -607,6 +609,7 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
                     "b22bf671-ccdf-40aa-a7e6-b20a4f91d79a"
                 ],
                 "CompanyId": null,
+                "CreditCardId": "5d802a8f-3238-42b2-94be-ab0300ab2b6c",
                 "CreatedUtc": "2017-08-03T13:32:35Z",
                 "CustomerId": "b22bf671-ccdf-40aa-a7e6-b20a4f91d79a",
                 "EndUtc": "2018-01-02T09:00:00Z",
@@ -700,6 +703,9 @@ Updates information about a reservation. Note that if any of the fields are sent
                 }
             }
         ]
+    },
+     "CreditCardId": {
+        "Value": "5d802a8f-3238-42b2-94be-ab0300ab2b6c"
     }
 
 }
@@ -726,6 +732,7 @@ Updates information about a reservation. Note that if any of the fields are sent
 | `RateId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the reservation [Rate](services.md#rate) \(or `null` if the rate should not be updated). |
 | `BookerId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the booker should not be updated). |
 | `TimeUnitPrices` | [Time unit amount update value](reservations.md#time-unit-amount-update-value) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. \(or `null` if the unit amounts should not be updated). |
+| `CreditCardId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the credit card should not be updated). |
 
 #### String update value
 


### PR DESCRIPTION
`[TDR-1765](https://mews.myjetbrains.com/youtrack/issue/TDR-1765): Attach credit card to reservation in Connector`

Accompanying gitbook PR to main mews repository PR #14858

#### Change log notes 

* Added optional parameter `CreditCardId` for Reservation object in `/api/connector/v1/reservations/add`
* Added optional parameter `CreditCardId` for Reservation update object in `/api/connector/v1/reservations/update`

#### Check during review

- JSON example extended.
