### PR TITLE
customers/getAll consolidation

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -57,10 +57,7 @@ This section describes all operations supported by the API:
   * [Delete reservation companion](reservations.md#delete-reservation-companion) - deletes a companion from a reservation.
   * [Add reservation product](reservations.md#add-reservation-product) - adds a new product to the reservation.
 * [Customers](customers.md) - operations for retrieval and modifications of customers.
-  * [Get all customers](customers.md#get-all-customers) - returns all customers in an interval.
-  * [Get all customers by ids](customers.md#get-all-customers-by-ids) - returns all customers by their identifiers.
-  * [Get all customers by emails](customers.md#get-all-customers-by-emails) - returns all customers by their emails.
-  * [Get all customers by name](customers.md#get-all-customers-by-name) - returns all customers by their name.
+  * [Get all customers](customers.md#get-all-customers) - returns all customers by filters.
   * [Search customers](customers.md#search-customers) - searches among active customers.
   * [Get customers open items](customers.md#get-customers-open-items) - returns open items of customers.
   * [Add customer](customers.md#add-customer) - adds a new customer.

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -49,7 +49,7 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 | `TimeFilter` | string [Customer time filter](customers.md#customer-time-filter) | optional | Time filter of the interval. |
 | `StartUtc` | string | optional | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | End of the interval in UTC timezone in ISO 8601 format. |
-| `Extent` | [Customer extent](customers.md#customer-extent) | optional | Extent of data to be returned. If not specified, no extent is used. |
+| `Extent` | [Customer extent](customers.md#customer-extent) | required | Extent of data to be returned. If not specified, no extent is used. |
 
 #### Customer time filter
 

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -51,8 +51,8 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 | `Emails` | array of string | optional | Emails of the [Customer](customers.md#customer)s. |
 | `FirstNames` | array of string | optional | First names of the [Customer](customers.md#customer)s. |
 | `LastNames` | array of string | optional | Last names of the [Customer](customers.md#customer)s. |
-| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of [Customer](customers.md#customer) creation date and time. |
-| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of [Customer](customers.md#customer) last update date and time. |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which [Customer](customers.md#customer) was created. |
+| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which [Customer](customers.md#customer) was updated. |
 | `Extent` | [Customer extent](customers.md#customer-extent) | required | Extent of data to be returned. If not specified, no extent is used. |
 
 #### Customer extent

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -2,7 +2,7 @@
 
 ## Get all customers
 
-Returns all customers filtered by at least one of these properties: customer identifier, email, first name, last name, time when was customer created or updated.
+Returns all customers filtered by identifiers, emails, names and other filters.
 
 ### Request
 
@@ -32,7 +32,7 @@ Returns all customers filtered by at least one of these properties: customer ide
     "Extent" : {
         "Customers": "true",
         "Documents": "true",
-        "Addresses": "true"
+        "Addresses": "false"
     }
 }
 ```
@@ -42,14 +42,14 @@ Returns all customers filtered by at least one of these properties: customer ide
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `CustomerIds` | array of string | optional | Identifiers of [Customer](customers.md#customer)s to use as a filter. |
-| `Emails` | array of string | optional | Emails of the [Customer](customers.md#customer)s to use as a filter. |
-| `FirstNames` | array of string | optional | First names of the [Customer](customers.md#customer)s to use as a filter. |
-| `LastNames` | array of string | optional | Last names of the [Customer](customers.md#customer)s to use as a filter. |
+| `CustomerIds` | array of string | optional | Identifiers of [Customer](customers.md#customer)s. Required if no other filter is provided. |
+| `Emails` | array of string | optional | Emails of the [Customer](customers.md#customer)s. |
+| `FirstNames` | array of string | optional | First names of the [Customer](customers.md#customer)s. |
+| `LastNames` | array of string | optional | Last names of the [Customer](customers.md#customer)s. |
 | `TimeFilter` | string [Customer time filter](customers.md#customer-time-filter) | optional | Time filter of the interval. |
 | `StartUtc` | string | optional | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | End of the interval in UTC timezone in ISO 8601 format. |
-| `Extent` | [Customer extent](customers.md#customer-extent) | optional | Extent of data to be returned. In case no extent is provided all data will be returned. |
+| `Extent` | [Customer extent](customers.md#customer-extent) | optional | Extent of data to be returned. If not specified, no extent is used. |
 
 #### Customer time filter
 
@@ -105,6 +105,7 @@ Returns all customers filtered by at least one of these properties: customer ide
     ],
     "Documents": [
         {
+            "Id": "e8a72a69-c20b-4278-b699-ab0400a32ecc",
             "CustomerId": "35d4b117-4e60-44a3-9580-c582117eff98",
             "Type": "IdentityCard",
             "Number": "123456",
@@ -166,7 +167,8 @@ Returns all customers filtered by at least one of these properties: customer ide
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `CustomerId` | string | required | Identification of [Customer](customers.md#customer) who own the document. |
+| `Id` | string | required | Unique identifier of the document. |
+| `CustomerId` | string | required | Identifier of the [Customer](customers.md#customer). |
 | `Type` | string [Document type](customers.md#document-type) | required | Type of the document. |
 | `Number` | string | optional | Number of the document \(e.g. passport number\). |
 | `Expiration` | string | optional | Expiration date in ISO 8601 format. |

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -74,7 +74,9 @@ Returns all customers filtered by identifiers, emails, names and other filters.
                 "Line2": null,
                 "City": "Christchurch",
                 "PostalCode": "BH23 3PY",
-                "CountryCode": "GB"
+                "CountryCode": "GB",
+                "Latitude": null,
+                "Longitude": null
             },
             "BirthDate": null,
             "BirthPlace": null,
@@ -110,9 +112,7 @@ Returns all customers filtered by identifiers, emails, names and other filters.
             "Number": "123456",
             "Expiration": "2020-01-01",
             "Issuance": "2016-01-01",
-            "IssuingCountryCode": "CZ",
-            "ExpirationUtc": "2020-01-01T12:00:00Z",
-            "IssuanceUtc": "2016-01-01T12:00:00Z"
+            "IssuingCountryCode": "CZ"
         }
     ]
 }

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -42,7 +42,7 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `CustomerIds` | array of string | optional | Identifiers of [Customer](customers.md#customer)s. Required if no other filter is provided. |
+| `CustomerIds` | array of string | optional | Unique identifiers of [Customer](customers.md#customer)s. Required if no other filter is provided. |
 | `Emails` | array of string | optional | Emails of the [Customer](customers.md#customer)s. |
 | `FirstNames` | array of string | optional | First names of the [Customer](customers.md#customer)s. |
 | `LastNames` | array of string | optional | Last names of the [Customer](customers.md#customer)s. |

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -26,9 +26,14 @@ Returns all customers filtered by identifiers, emails, names and other filters.
     "LastNames": [
         "Doe"
     ],
-    "TimeFilter": "Created",
-    "StartUtc": "2016-01-01T00:00:00Z",
-    "EndUtc": "2016-01-07T00:00:00Z",
+    "CreatedUtc": {
+        "StartUtc": "2019-12-05T00:00:00Z",
+        "EndUtc": "2019-12-10T00:00:00Z"
+    },
+    "UpdatedUtc": {
+        "StartUtc": "2019-12-10T00:00:00Z",
+        "EndUtc": "2019-12-17T00:00:00Z"
+    }
     "Extent" : {
         "Customers": "true",
         "Documents": "true",
@@ -46,15 +51,9 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 | `Emails` | array of string | optional | Emails of the [Customer](customers.md#customer)s. |
 | `FirstNames` | array of string | optional | First names of the [Customer](customers.md#customer)s. |
 | `LastNames` | array of string | optional | Last names of the [Customer](customers.md#customer)s. |
-| `TimeFilter` | string [Customer time filter](customers.md#customer-time-filter) | optional | Time filter of the interval. |
-| `StartUtc` | string | optional | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | optional | End of the interval in UTC timezone in ISO 8601 format. |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of [Customer](customers.md#customer) creation date and time. |
+| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of [Customer](customers.md#customer) last update date and time. |
 | `Extent` | [Customer extent](customers.md#customer-extent) | required | Extent of data to be returned. If not specified, no extent is used. |
-
-#### Customer time filter
-
-* `Created` - customer created within the interval.
-* `Updated` - customer updated or created within the interval.
 
 #### Customer extent
 

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -42,10 +42,10 @@ Returns all customers filtered by at least one of these properties: customer ide
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `CustomerIds` | array of string | optional | Identifiers of [Customer](customers.md#customer)s to use as filter. |
-| `Emails` | array of string | optional | Emails of the [Customer](customers.md#customer)s to use as filter. |
-| `FirstNames` | array of string | optional | First names of the [Customer](customers.md#customer) to use as filter. |
-| `LastNames` | array of string | optional | Last names of the [Customer](customers.md#customer) to use as filter. |
+| `CustomerIds` | array of string | optional | Identifiers of [Customer](customers.md#customer)s to use as a filter. |
+| `Emails` | array of string | optional | Emails of the [Customer](customers.md#customer)s to use as a filter. |
+| `FirstNames` | array of string | optional | First names of the [Customer](customers.md#customer)s to use as a filter. |
+| `LastNames` | array of string | optional | Last names of the [Customer](customers.md#customer)s to use as a filter. |
 | `TimeFilter` | string [Customer time filter](customers.md#customer-time-filter) | optional | Time filter of the interval. |
 | `StartUtc` | string | optional | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | End of the interval in UTC timezone in ISO 8601 format. |

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -2,7 +2,7 @@
 
 ## Get all customers
 
-Returns all customers from the specified interval according to the time filter \(e.g. customers created in that interval\).
+Returns all customers filtered by at least one of these properties: customer identifier, email, first name, last name, time when was customer created or updated.
 
 ### Request
 
@@ -13,9 +13,27 @@ Returns all customers from the specified interval according to the time filter \
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
+    "CustomerIds": [
+        "35d4b117-4e60-44a3-9580-c582117eff98"
+    ],
+    "Emails": [
+        "john@doe.com"
+    ],
+    "FirstNames": [
+        "John",
+        "Jane"
+    ],
+    "LastNames": [
+        "Doe"
+    ],
     "TimeFilter": "Created",
     "StartUtc": "2016-01-01T00:00:00Z",
-    "EndUtc": "2016-01-07T00:00:00Z"
+    "EndUtc": "2016-01-07T00:00:00Z",
+    "Extent" : {
+        "Customers": "true",
+        "Documents": "true",
+        "Addresses": "true"
+    }
 }
 ```
 
@@ -24,14 +42,27 @@ Returns all customers from the specified interval according to the time filter \
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `TimeFilter` | string [Customer time filter](customers.md#customer-time-filter) | required | Time filter of the interval. |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
+| `CustomerIds` | array of string | optional | Identifiers of [Customer](customers.md#customer)s to use as filter. |
+| `Emails` | array of string | optional | Emails of the [Customer](customers.md#customer)s to use as filter. |
+| `FirstNames` | array of string | optional | First names of the [Customer](customers.md#customer) to use as filter. |
+| `LastNames` | array of string | optional | Last names of the [Customer](customers.md#customer) to use as filter. |
+| `TimeFilter` | string [Customer time filter](customers.md#customer-time-filter) | optional | Time filter of the interval. |
+| `StartUtc` | string | optional | Start of the interval in UTC timezone in ISO 8601 format. |
+| `EndUtc` | string | optional | End of the interval in UTC timezone in ISO 8601 format. |
+| `Extent` | [Customer extent](customers.md#customer-extent) | optional | Extent of data to be returned. In case no extent is provided all data will be returned. |
 
 #### Customer time filter
 
 * `Created` - customer created within the interval.
 * `Updated` - customer updated or created within the interval.
+
+#### Customer extent
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `Customers` | bool | optional | Whether the response should contain information about customers. |
+| `Documents` | bool | optional | Whether the response should contain identity documents of customers. |
+| `Addresses` | bool | optional | Whether the response should contain addresses of customers. |
 
 ### Response
 
@@ -39,7 +70,13 @@ Returns all customers from the specified interval according to the time filter \
 {
     "Customers": [
         {
-            "Address": null,
+            "Address": {
+                "Line1": "Somerford Road Hello House/135",
+                "Line2": null,
+                "City": "Christchurch",
+                "PostalCode": "BH23 3PY",
+                "CountryCode": "GB"
+            },
             "BirthDate": null,
             "BirthPlace": null,
             "CategoryId": null,
@@ -59,13 +96,23 @@ Returns all customers from the specified interval according to the time filter \
             "Notes": "",
             "Options": [],
             "Number": "1",
-            "Passport": null,
             "Phone": "00420123456789",
             "SecondLastName": null,
             "TaxIdentificationNumber": null,
             "Title": null,
             "UpdatedUtc": "2016-01-01T00:00:00Z",
-            "Visa": null
+        }
+    ],
+    "Documents": [
+        {
+            "CustomerId": "35d4b117-4e60-44a3-9580-c582117eff98",
+            "Type": "IdentityCard",
+            "Number": "123456",
+            "Expiration": "2020-01-01",
+            "Issuance": "2016-01-01",
+            "IssuingCountryCode": "CZ",
+            "ExpirationUtc": "2020-01-01T12:00:00Z",
+            "IssuanceUtc": "2016-01-01T12:00:00Z"
         }
     ]
 }
@@ -74,6 +121,7 @@ Returns all customers from the specified interval according to the time filter \
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Customers` | array of [Customer](customers.md#customer) | required | The customers. |
+| `Documents` | array of [Document](customers.md#document) | required | The identity documents of customers. |
 
 #### Customer
 
@@ -99,10 +147,6 @@ Returns all customers from the specified interval according to the time filter \
 | `Notes` | string | optional | Internal notes about the customer. |
 | `Classifications` | array of [Customer classification](customers.md#customer-classification) | required | Classifications of the customer. |
 | `Options` | array of [Customer option](customers.md#customer-option) | required | Options of the customer. |
-| `Passport` | [Document](customers.md#document) | optional | Passport details of the customer. |
-| `IdentityCard` | [Document](customers.md#document) | optional | Identity card details of the customer. |
-| `Visa` | [Document](customers.md#document) | optional | Visa details of the customer. |
-| `DriversLicense` | [Document](customers.md#document) | optional | Drivers license  details of the customer. |
 | `Address` | [Address](configuration.md#address) | optional | Address of the customer. |
 | `CreatedUtc` | string | required | Creation date and time of the customer in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the customer in UTC timezone in ISO 8601 format. |
@@ -122,10 +166,19 @@ Returns all customers from the specified interval according to the time filter \
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
+| `CustomerId` | string | required | Identification of [Customer](customers.md#customer) who own the document. |
+| `Type` | string [Document type](customers.md#document-type) | required | Type of the document. |
 | `Number` | string | optional | Number of the document \(e.g. passport number\). |
 | `Expiration` | string | optional | Expiration date in ISO 8601 format. |
 | `Issuance` | string | optional | Date of issuance in ISO 8601 format. |
 | `IssuingCountryCode` | string | optional | ISO 3166-1 code of the [Country](configuration.md#country). |
+
+#### Document type
+
+* `Passport`
+* `IdentityCard`
+* `Visa`
+* `DriversLicense`
 
 #### Customer classification
 
@@ -150,96 +203,6 @@ Returns all customers from the specified interval according to the time filter \
 
 * `SendMarketingEmails`
 * ...
-
-## Get all customers by ids
-
-Returns all customers with the specified ids.
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/customers/getAllByIds`
-
-```javascript
-{
-    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",
-    "CustomerIds": [
-        "35d4b117-4e60-44a3-9580-c582117eff98"
-    ]
-}
-```
-
-| Property | Type |  | Description |
-| --- | --- | --- | --- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `CustomerIds` | array of string | required | Identifiers of [Customer](customers.md#customer)s. |
-
-### Response
-
-Same structure as in [Get all customers](customers.md#get-all-customers) operation.
-
-## Get all customers by emails
-
-Returns all customers with the specified emails.
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/customers/getAllByEmails`
-
-```javascript
-{
-    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",
-    "Emails": [
-        "john@doe.com"
-    ]
-}
-```
-
-| Property | Type |  | Description |
-| --- | --- | --- | --- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `Emails` | array of string | required | Emails of the [Customer](customers.md#customer)s. |
-
-### Response
-
-Same structure as in [Get all customers](customers.md#get-all-customers) operation.
-
-## Get all customers by name
-
-Returns all customers with the specified first name and last name.
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/customers/getAllByName`
-
-```javascript
-{
-    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",
-    "FirstName": "John",
-    "LastName": "Doe"
-}
-```
-
-| Property | Type |  | Description |
-| --- | --- | --- | --- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `FirstName` | string | required | First name of the [Customer](customers.md#customer). |
-| `LastName` | string | required | Last name of the [Customer](customers.md#customer). |
-
-### Response
-
-Same structure as in [Get all customers](customers.md#get-all-customers) operation.
 
 ## Search customers
 


### PR DESCRIPTION
#### Change log notes 

```
* Added new parameters to [Get all customers](operations/customers.md#get-all-customers) operation: `CustomerIds`, `Emails`, `FirstNames`, `LastNames`, `CreatedUtc`, `UpdatedUtc`, `Extent`.
* Operation `customers/getAllByIds` is now deprecated and will be removed once.
* Operation `customers/getAllByEmails` is now deprecated and will be removed once.
* Operation `customers/getAllByName` is now deprecated and will be removed once.
```

#### Check during review

- JSON example extended.
- New operation added in the list of all operations.
