### PR TITLE
Add geo location to configuration/get response

### DIFF
--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -28,11 +28,13 @@ Returns configuration of the enterprise and the client.
 {
     "Enterprise": {
         "Address": {
-            "City": "Prague",
-            "CountryCode": "CZ",
+            "Id": "8c2c4371-5d42-40a9-b551-ab0b00d75076",
             "Line1": "Anenské nám. 1",
             "Line2": "Ahoj",
+            "City": "Prague",
             "PostalCode": "110 00",
+            "CountryCode": "CZ",
+            "CountrySubdivisionCode": null,
             "Latitude": 50.085180,
             "Longitude": 14.414926
         },
@@ -98,14 +100,15 @@ Returns configuration of the enterprise and the client.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
+| `Id` | string | required | Unique identifier of the address. |
 | `Line1` | string | optional | First line of the address. |
 | `Line2` | string | optional | Second line of the address. |
 | `City` | string | optional | The city. |
 | `PostalCode` | string | optional | Postal code. |
 | `CountryCode` | string | optional | ISO 3166-1 code of the [Country](configuration.md#country). |
 | `CountrySubdivisionCode` | string | optional | ISO 3166-2 code of the administrative division, e.g. `DE-BW`. |
-| `Latitude` | number | optional | The latitude (output only, can't be set from API call) |
-| `Longitude` | number | optional | The longtitude (output only, can't be set from API call) |
+| `Latitude` | number | optional | The latitude |
+| `Longitude` | number | optional | The longtitude |
 
 #### Accepted currency
 

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -107,8 +107,8 @@ Returns configuration of the enterprise and the client.
 | `PostalCode` | string | optional | Postal code. |
 | `CountryCode` | string | optional | ISO 3166-1 code of the [Country](configuration.md#country). |
 | `CountrySubdivisionCode` | string | optional | ISO 3166-2 code of the administrative division, e.g. `DE-BW`. |
-| `Latitude` | number | optional | The latitude |
-| `Longitude` | number | optional | The longtitude |
+| `Latitude` | number | optional | The latitude. |
+| `Longitude` | number | optional | The longtitude. |
 
 #### Accepted currency
 

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -32,7 +32,9 @@ Returns configuration of the enterprise and the client.
             "CountryCode": "CZ",
             "Line1": "Anenské nám. 1",
             "Line2": "Ahoj",
-            "PostalCode": "110 00"
+            "PostalCode": "110 00",
+            "Latitude": 50.085180,
+            "Longitude": 14.414926
         },
         "ChainId": "8ddea57b-6a5c-4eec-8c4c-24467dce118e",
         "CoverImageId": null,
@@ -102,6 +104,8 @@ Returns configuration of the enterprise and the client.
 | `PostalCode` | string | optional | Postal code. |
 | `CountryCode` | string | optional | ISO 3166-1 code of the [Country](configuration.md#country). |
 | `CountrySubdivisionCode` | string | optional | ISO 3166-2 code of the administrative division, e.g. `DE-BW`. |
+| `Latitude` | number | optional | The latitude (output only, can't be set from API call) |
+| `Longitude` | number | optional | The longtitude (output only, can't be set from API call) |
 
 #### Accepted currency
 

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -108,7 +108,7 @@ Returns configuration of the enterprise and the client.
 | `CountryCode` | string | optional | ISO 3166-1 code of the [Country](configuration.md#country). |
 | `CountrySubdivisionCode` | string | optional | ISO 3166-2 code of the administrative division, e.g. `DE-BW`. |
 | `Latitude` | number | optional | The latitude. |
-| `Longitude` | number | optional | The longtitude. |
+| `Longitude` | number | optional | The longitude. |
 
 #### Accepted currency
 
@@ -570,4 +570,3 @@ Returns URLs of the specified images.
 | --- | --- | --- | --- |
 | `ImageId` | string | required | Unique identifier of the image. |
 | `Url` | string | required | URL of the image. |
-

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -457,11 +457,11 @@ Adds a new customer to the system and returns details of the added customer. If 
 | `Passport` | [Document](customers.md#document) | optional | Passport details of the customer. |
 | `Visa` | [Document](customers.md#document) | optional | Visa details of the customer. |
 | `DriversLicense` | [Document](customers.md#document) | optional | Drivers license details of the customer. |
-| `Address` | [AddressParameters](customers.md#addressparameters) | optional | Address of the customer. |
+| `Address` | [Address parameters](customers.md#address-parameters) | optional | Address of the customer. |
 | `Classifications` | array of [Customer classification](customers.md#customer-classification) | optional | Classifications of the customer. |
 | `Options` | array of [Customer option](customers.md#customer-option) | optional | Options of the customer. |
 
-#### AddressParameters
+#### Address parameters
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
@@ -536,7 +536,7 @@ Updates personal information of a customer. Note that if any of the fields is le
 | `Passport` | [Document](customers.md#document) | optional | New passport details. |
 | `Visa` | [Document](customers.md#document) | optional | New visa details. |
 | `DriversLicense` | [Document](customers.md#document) | optional | New drivers license details. |
-| `Address` | [AddressParameters](customers.md#addressparameters)  | optional | New address details. |
+| `Address` | [Address parameters](customers.md#address-parameters)  | optional | New address details. |
 | `Classifications` | array of [Customer classification](customers.md#customer-classification) | optional | New classifications of the customer. |
 | `Options` | array of [Customer option](customers.md#customer-option) | optional | Options of the customer. |
 

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -422,7 +422,15 @@ Adds a new customer to the system and returns details of the added customer. If 
     },
     "Passport": null,
     "Visa": null,
-    "DriversLicense": null
+    "DriversLicense": null,
+    "Address": {
+        "Line1": "Astronautů 2",
+        "Line2": "",
+        "City": "Havířov",
+        "PostalCode": "736 01",
+        "CountryCode": "CZ",
+        "CountrySubdivisionCode": null,
+    }
 }
 ```
 
@@ -449,9 +457,20 @@ Adds a new customer to the system and returns details of the added customer. If 
 | `Passport` | [Document](customers.md#document) | optional | Passport details of the customer. |
 | `Visa` | [Document](customers.md#document) | optional | Visa details of the customer. |
 | `DriversLicense` | [Document](customers.md#document) | optional | Drivers license details of the customer. |
-| `Address` | [Address](configuration.md#address) | optional | Address of the customer. |
+| `Address` | [AddressParameters](configuration.md#addressparameters) | optional | Address of the customer. |
 | `Classifications` | array of [Customer classification](customers.md#customer-classification) | optional | Classifications of the customer. |
 | `Options` | array of [Customer option](customers.md#customer-option) | optional | Options of the customer. |
+
+#### AddressParameters
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `Line1` | string | optional | First line of the address. |
+| `Line2` | string | optional | Second line of the address. |
+| `City` | string | optional | The city. |
+| `PostalCode` | string | optional | Postal code. |
+| `CountryCode` | string | optional | ISO 3166-1 code of the [Country](configuration.md#country). |
+| `CountrySubdivisionCode` | string | optional | ISO 3166-2 code of the administrative division, e.g. `DE-BW`. |
 
 ### Response
 
@@ -517,7 +536,7 @@ Updates personal information of a customer. Note that if any of the fields is le
 | `Passport` | [Document](customers.md#document) | optional | New passport details. |
 | `Visa` | [Document](customers.md#document) | optional | New visa details. |
 | `DriversLicense` | [Document](customers.md#document) | optional | New drivers license details. |
-| `Address` | [Address](configuration.md#address) | optional | New address details. |
+| `Address` | [AddressParameters](configuration.md#addressparameters)  | optional | New address details. |
 | `Classifications` | array of [Customer classification](customers.md#customer-classification) | optional | New classifications of the customer. |
 | `Options` | array of [Customer option](customers.md#customer-option) | optional | Options of the customer. |
 

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -457,7 +457,7 @@ Adds a new customer to the system and returns details of the added customer. If 
 | `Passport` | [Document](customers.md#document) | optional | Passport details of the customer. |
 | `Visa` | [Document](customers.md#document) | optional | Visa details of the customer. |
 | `DriversLicense` | [Document](customers.md#document) | optional | Drivers license details of the customer. |
-| `Address` | [AddressParameters](configuration.md#addressparameters) | optional | Address of the customer. |
+| `Address` | [AddressParameters](customers.md#addressparameters) | optional | Address of the customer. |
 | `Classifications` | array of [Customer classification](customers.md#customer-classification) | optional | Classifications of the customer. |
 | `Options` | array of [Customer option](customers.md#customer-option) | optional | Options of the customer. |
 
@@ -536,7 +536,7 @@ Updates personal information of a customer. Note that if any of the fields is le
 | `Passport` | [Document](customers.md#document) | optional | New passport details. |
 | `Visa` | [Document](customers.md#document) | optional | New visa details. |
 | `DriversLicense` | [Document](customers.md#document) | optional | New drivers license details. |
-| `Address` | [AddressParameters](configuration.md#addressparameters)  | optional | New address details. |
+| `Address` | [AddressParameters](customers.md#addressparameters)  | optional | New address details. |
 | `Classifications` | array of [Customer classification](customers.md#customer-classification) | optional | New classifications of the customer. |
 | `Options` | array of [Customer option](customers.md#customer-option) | optional | Options of the customer. |
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -729,7 +729,7 @@ Adds a new company to the enterprise.
 | `AdditionalTaxIdentifier` | string | optional | Additional tax identifer of the company. |
 | `BillingCode` | string | optional | Billing code of the company. |
 | `AccountingCode` | string | optional | Accounting code of the company. |
-| `Address` | [AddressParameters](customers.md#addressparameters)  | optional | Address of the company. |
+| `Address` | [Address parameters](customers.md#address-parameters)  | optional | Address of the company. |
 
 ### Response
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -729,7 +729,7 @@ Adds a new company to the enterprise.
 | `AdditionalTaxIdentifier` | string | optional | Additional tax identifer of the company. |
 | `BillingCode` | string | optional | Billing code of the company. |
 | `AccountingCode` | string | optional | Accounting code of the company. |
-| `Address` | [AddressParameters](configuration.md#addressparameters)  | optional | Address of the company. |
+| `Address` | [AddressParameters](customers.md#addressparameters)  | optional | Address of the company. |
 
 ### Response
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -32,11 +32,15 @@ Returns all company profiles of the enterprise, possible filtered by their ident
             "AccountingCode": "",
             "AdditionalTaxIdentifier": "",
             "Address": {
-                "City": "Dortmund",
-                "CountryCode": "DE",
+                "Id": "bab7441c-4b82-43bc-8001-ab0400a346ec",
                 "Line1": "Rheinlanddamm 207-209",
                 "Line2": "",
+                "City": "Dortmund",
                 "PostalCode": "44137"
+                "CountryCode": "DE",
+                "CountrySubdivisionCode": null,
+                "Latitude": null,
+                "Longitude": null
             },
             "ElectronicInvoiceIdentifier": "",
             "Id": "207b9da3-1c2a-45df-af20-54e57a13368c",
@@ -725,7 +729,7 @@ Adds a new company to the enterprise.
 | `AdditionalTaxIdentifier` | string | optional | Additional tax identifer of the company. |
 | `BillingCode` | string | optional | Billing code of the company. |
 | `AccountingCode` | string | optional | Accounting code of the company. |
-| `Address` | [Address](configuration.md#address) | optional | Address of the company. |
+| `Address` | [AddressParameters](configuration.md#addressparameters)  | optional | Address of the company. |
 
 ### Response
 


### PR DESCRIPTION
#### Change log notes 

```
* Renamed [Address](operations/configuration.md#address) input object to [AddressParameters](operations/customers.md#addressparameters), no parameters have been changed.
* Extended [Address](operations/configuration.md#address) output object with `Latitude` and `Longitude`.
```

#### Check during review

- JSON example extended.
