### PR TITLE
New time filter format for restrictions/getAll

### DIFF
--- a/operations/services.md
+++ b/operations/services.md
@@ -544,14 +544,24 @@ Returns all restrictions of the default service provided by the enterprise.
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
-    "StartUtc": "2016-01-01T00:00:00Z",
-    "EndUtc": "2016-01-07T00:00:00Z",
     "SpaceCategoryIds": [
         "34c29e73-c8db-4e93-b51b-981e42655e03"
     ],
     "RateIds": [
         "ed4b660b-19d0-434b-9360-a4de2ea42eda"
-    ]
+    ],
+    "CollidingUtc": {
+        "StartUtc": "2020-02-15T00:00:00Z",
+        "EndUtc": "2020-02-20T00:00:00Z"
+    },
+    "CreatedUtc": {
+        "StartUtc": "2020-02-05T00:00:00Z",
+        "EndUtc": "2020-02-15T00:00:00Z"
+    },
+    "UpdatedUtc": {
+        "StartUtc": "2020-02-05T00:00:00Z",
+        "EndUtc": "2020-02-15T00:00:00Z"
+    }
 }
 ```
 
@@ -560,16 +570,11 @@ Returns all restrictions of the default service provided by the enterprise.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `TimeFilter` | [Restriction time filter](services.md#restriction-time-filter) | optional | Time filter of the interval. If not specified, restrictions `Created` within the interval are returned. |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 | `SpaceCategoryIds` | array of string | optional | Unique identifiers of [Space categories](enterprises.md#space-category). |
 | `RateIds` | array of string | optional | Unique identifiers of [Rate](services.md#rate)s. |
-
-#### Restriction time filter
-
-* `Applicable` - restrictions whose intervals collide with the specified interval.
-* `Created` - restrictions created within the specified interval.
+| `CollidingUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which the restriction is active. |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of restriction creation time. |
+| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of last restriction update time. |
 
 ### Response
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -549,7 +549,7 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 
 ## Get all restrictions
 
-Returns all restrictions of the default service provided by the enterprise possibly filtered by filters.
+Returns all restrictions of the default service provided by the enterprise.
 
 ### Request
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -533,7 +533,7 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 
 ## Get all restrictions
 
-Returns all restrictions of the default service provided by the enterprise.
+Returns all restrictions of the default service provided by the enterprise filtered by filters.
 
 ### Request
 
@@ -572,7 +572,7 @@ Returns all restrictions of the default service provided by the enterprise.
 | `Client` | string | required | Name and version of the client application. |
 | `SpaceCategoryIds` | array of string | optional | Unique identifiers of [Space categories](enterprises.md#space-category). |
 | `RateIds` | array of string | optional | Unique identifiers of [Rate](services.md#rate)s. |
-| `CollidingUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which the restriction is active. |
+| `CollidingUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which the restriction is active. Required if no other filter is provided. |
 | `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of restriction creation time. |
 | `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of last restriction update time. |
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -549,7 +549,7 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 
 ## Get all restrictions
 
-Returns all restrictions of the default service provided by the enterprise filtered by filters.
+Returns all restrictions of the default service provided by the enterprise possibly filtered by filters.
 
 ### Request
 
@@ -588,9 +588,9 @@ Returns all restrictions of the default service provided by the enterprise filte
 | `Client` | string | required | Name and version of the client application. |
 | `SpaceCategoryIds` | array of string | optional | Unique identifiers of [Space categories](enterprises.md#space-category). |
 | `RateIds` | array of string | optional | Unique identifiers of [Rate](services.md#rate)s. |
-| `CollidingUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which the restriction is active. Required if no other filter is provided. |
-| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of restriction creation time. |
-| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of last restriction update time. |
+| `CollidingUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Restriction](#restriction) is active. Required if no other filter is provided. |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Restriction](#restriction) was created. |
+| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Restriction](#restriction) was updated. |
 
 ### Response
 


### PR DESCRIPTION
#### Change log notes 

```
* Extended [Get all restrictions](operations/services.md#get-all-restrictions) parameters with `CollidingUtc`, `CreatedUtc` and `UpdatedUtc` time filters.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to correct place of the JSON.
- [ ] New properties in the table are added to correct place.  
- [ ] New operation added in the list of all operations.
- [ ] Correct formatting
  - [ ] Spacing bettween titles, sections, tables, ...
  - [ ] Correct JSON format - intedation
- [ ] DateTime properties should be allways defined like ISO format
