### PR TITLE
New time filters outletItems/getAll

### DIFF
--- a/operations/finance.md
+++ b/operations/finance.md
@@ -1145,5 +1145,5 @@ Adds new outlet bills with their items.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `OutletBillIds` | array of string | required | List of unique identifiers of the added bills. |
+| `OutletBillIds` | array of string | required | List of unique identifiers of the added [Outlet bills](#outlet-bill). |
 

--- a/operations/finance.md
+++ b/operations/finance.md
@@ -1133,6 +1133,14 @@ Adds new outlet bills with their items.
 ### Response
 
 ```javascript
-{}
+{
+    "OutletBillIds": [
+        "f2ee1bd2-dd55-4cd3-bab1-ab6800bf0301"
+    ]
+}
 ```
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `OutletBillIds` | array of string | required | List of unique identifiers of the added bills. |
 

--- a/operations/finance.md
+++ b/operations/finance.md
@@ -1145,5 +1145,4 @@ Adds new outlet bills with their items.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `OutletBillIds` | array of string | required | List of unique identifiers of the added [Outlet bills](#outlet-bill). |
-
+| `OutletBillIds` | array of string | required | Array of unique identifiers of the added [Outlet bills](#outlet-bill). |

--- a/operations/finance.md
+++ b/operations/finance.md
@@ -554,8 +554,15 @@ Returns all outlet items of the enterprise that were consumed \(posted\) or will
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
-    "StartUtc": "2017-01-01T00:00:00Z",
-    "EndUtc": "2017-02-01T00:00:00Z"
+    "ConsumedUtc": {
+        "StartUtc": "2020-01-05T00:00:00Z",
+        "EndUtc": "2020-01-10T00:00:00Z"
+    },
+    "ClosedUtc": {
+        "StartUtc": "2020-01-05T00:00:00Z",
+        "EndUtc": "2020-01-10T00:00:00Z"
+    },
+    "Currency": "EUR"
 }
 ```
 
@@ -564,15 +571,9 @@ Returns all outlet items of the enterprise that were consumed \(posted\) or will
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `TimeFilter` | string [Outlet item time filter](finance.md#outlet-item-time-filter) | optional | Time filter of the interval. If not specified, items `Consumed` in the interval are returned. |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
+| `ConsumedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which the outlet item was consumed. Required if no other filter is provided. |
+| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which the outlet bill was closed. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](configuration.md#currency) the item costs should be converted to. |
-
-#### Outlet item time filter
-
-* `Consumed` - items consumed in the interval.
-* `Closed` - items whose bills have been closed in the interval.
 
 ### Response
 

--- a/operations/finance.md
+++ b/operations/finance.md
@@ -571,8 +571,8 @@ Returns all outlet items of the enterprise that were consumed \(posted\) or will
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ConsumedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which the outlet item was consumed. Required if no other filter is provided. |
-| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which the outlet bill was closed. |
+| `ConsumedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Outlet item](#outlet-item) was consumed. Required if no other filter is provided. |
+| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Outlet bill](#outlet-bill) was closed. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](configuration.md#currency) the item costs should be converted to. |
 
 ### Response


### PR DESCRIPTION
#### Change log notes 

```
* Extended [Get all outlet items](operations/finance.md#get-all-outlet-items) parameters with `ClosedUtc` and `ConsumedUtc` time filters.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to correct place of the JSON.
- [ ] New properties in the table are added to correct place.  
- [ ] New operation added in the list of all operations.
- [ ] Correct formatting
  - [ ] Spacing bettween titles, sections, tables, ...
  - [ ] Correct JSON format - intedation
- [ ] DateTime properties should be allways defined like ISO format
