### PR TITLE
New time filter format for bills/getAll

### DIFF
--- a/operations/finance.md
+++ b/operations/finance.md
@@ -454,7 +454,7 @@ Returns all bills, possible filtered by customers, identifiers and other filters
         "StartUtc": "2020-02-05T00:00:00Z",
         "EndUtc": "2020-02-10T00:00:00Z"
     },
-    "DueDateUtc": null,
+    "DueUtc": null,
     "PaidUtc": null,
     "Extent": {
         "Items": false
@@ -472,7 +472,7 @@ Returns all bills, possible filtered by customers, identifiers and other filters
 | `State` | string | optional | [Bill state](finance.md#bill-state) the bills should be in. If not specified `Open` and `Closed` bills are returned. |
 | `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill was closed. |
 | `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill was created. |
-| `DueDateUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill is due to be paid. |
+| `DueUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill is due to be paid. |
 | `PaidUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill was paid. |
 | `Extent` | [Bill extent](finance.md#bill-extent) | optional | Extent of data to be returned. E.g. it is possible to specify that together with the bills, payments and revenue items should be also returned. If not specified, no extent is used. |
 

--- a/operations/finance.md
+++ b/operations/finance.md
@@ -446,9 +446,16 @@ Returns all bills, possible filtered by customers, identifiers and other filters
         "fe795f96-0b64-445b-89ed-c032563f2bac"
     ],
     "State": "Open",
-    "TimeFilter": "Created",
-    "StartUtc": null,
-    "EndUtc": null,
+    "ClosedUtc": {
+        "StartUtc": "2020-02-05T00:00:00Z",
+        "EndUtc": "2020-02-10T00:00:00Z"
+    },
+    "CreatedUtc": {
+        "StartUtc": "2020-02-05T00:00:00Z",
+        "EndUtc": "2020-02-10T00:00:00Z"
+    },
+    "DueDateUtc": null,
+    "PaidUtc": null,
     "Extent": {
         "Items": false
     }
@@ -460,25 +467,19 @@ Returns all bills, possible filtered by customers, identifiers and other filters
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `BillIds` | array of string | optional | Unique identifiers of the [Bill](finance.md#bill)s. |
+| `BillIds` | array of string | optional | Unique identifiers of the [Bill](finance.md#bill)s. Required if no other filter is provided. |
 | `CustomerIds` | array of string | optional | Unique identifiers of the [Customer](customers.md#customer)s. |
 | `State` | string | optional | [Bill state](finance.md#bill-state) the bills should be in. If not specified `Open` and `Closed` bills are returned. |
-| `TimeFilter` | string | optional | [Time filter](finance.md#bill-time-filter) of the interval. |
-| `StartUtc` | string | optional | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | optional | End of the interval in UTC timezone in ISO 8601 format. |
+| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill was closed. |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill was created. |
+| `DueDateUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill is due to be paid. |
+| `PaidUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill was paid. |
 | `Extent` | [Bill extent](finance.md#bill-extent) | optional | Extent of data to be returned. E.g. it is possible to specify that together with the bills, payments and revenue items should be also returned. If not specified, no extent is used. |
 
 #### Bill state
 
 * `Open`
 * `Closed`
-
-#### Bill time filter
-
-* `Created` - bills created in the interval.
-* `Closed` - bills closed in the interval.
-* `Paid` - bills paid in the interval.
-* `DueDate` - bills having a due date in the interval.
 
 #### Bill extent
 

--- a/operations/finance.md
+++ b/operations/finance.md
@@ -470,10 +470,10 @@ Returns all bills, possible filtered by customers, identifiers and other filters
 | `BillIds` | array of string | optional | Unique identifiers of the [Bill](finance.md#bill)s. Required if no other filter is provided. |
 | `CustomerIds` | array of string | optional | Unique identifiers of the [Customer](customers.md#customer)s. |
 | `State` | string | optional | [Bill state](finance.md#bill-state) the bills should be in. If not specified `Open` and `Closed` bills are returned. |
-| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill was closed. |
-| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill was created. |
-| `DueUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill is due to be paid. |
-| `PaidUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval during which bill was paid. |
+| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Bill](#bill) was closed. |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Bill](#bill) was created. |
+| `DueUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Bill](#bill) is due to be paid. |
+| `PaidUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Bill](#bill) was paid. |
 | `Extent` | [Bill extent](finance.md#bill-extent) | optional | Extent of data to be returned. E.g. it is possible to specify that together with the bills, payments and revenue items should be also returned. If not specified, no extent is used. |
 
 #### Bill state


### PR DESCRIPTION
#### Change log notes 

```
* Extended [Get all bills](operations/finance.md#get-all-bills) parameters with `ClosedUtc`, `CreatedUtc`, `DueDateUtc` and `PaidUtc` time filters.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to correct place of the JSON.
- [ ] New properties in the table are added to correct place.  
- [ ] New operation added in the list of all operations.
- [ ] Correct formatting
  - [ ] Spacing bettween titles, sections, tables, ...
  - [ ] Correct JSON format - intedation
- [ ] DateTime properties should be allways defined like ISO format
