### PR TITLE
Past price updates not allowed

### DIFF
--- a/operations/services.md
+++ b/operations/services.md
@@ -496,7 +496,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 
 ## Update rate price
 
-Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Space category](enterprises.md#space-category), otherwise updates the base price for all space categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`, future updates aren't restricted.
+Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Space category](enterprises.md#space-category), otherwise updates the base price for all space categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`, future updates are allowed for up to 5 years.
 
 ### Request
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -496,7 +496,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 
 ## Update rate price
 
-Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Space category](enterprises.md#space-category), otherwise updates the base price for all space categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`).
+Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Space category](enterprises.md#space-category), otherwise updates the base price for all space categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`, future updates aren't restricted.
 
 ### Request
 


### PR DESCRIPTION
#### Change log notes 

```
* Restricted [Update rate price](operations/services.md#update-rate-price) operation to accept only future updates and past updates within `EditableHistoryInterval`.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to correct place of the JSON.
- [ ] New properties in the table are added to correct place.  
- [ ] New operation added in the list of all operations.
- [ ] Correct formatting
  - [ ] Spacing bettween titles, sections, tables, ...
  - [ ] Correct JSON format - intedation
- [ ] DateTime properties should be allways defined like ISO format
