### PR TITLE
Fix amount value references

### DIFF
--- a/operations/finance.md
+++ b/operations/finance.md
@@ -423,9 +423,9 @@ Returns all accounting items of the enterprise that were consumed \(posted\) or 
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the credit card transaction. |
 | `PaymentId` | string | required | Unique identifier of the [Accounting item](#accounting-item). |
-| `ChargedAmount` | [Amount](finance.md#amount-value) | required | Charged amount of the transaction. |
-| `SettledAmount` | [Amount](finance.md#amount-value) | optional | Settled amount of the transaction. |
-| `Fee` | [Amount](finance.md#amount-value) | optional | Fee of the transaction. |
+| `ChargedAmount` | [Amount value](finance.md#amount-value) | required | Charged amount of the transaction. |
+| `SettledAmount` | [Amount value](finance.md#amount-value) | optional | Settled amount of the transaction. |
+| `Fee` | [Amount value](finance.md#amount-value) | optional | Fee of the transaction. |
 | `SettlementId` | string | optional | Identifier of the settlement. |
 | `SettledUtc` | string | optional | Settlement date and time in UTC timezone in ISO 8601 format. |
 
@@ -653,7 +653,7 @@ Returns all outlet items of the enterprise that were consumed \(posted\) or will
 | `Type` | string [Outlet item type](finance.md#outlet-item-type) | required | Type of the item. |
 | `Name` | string | required | Name of the item. |
 | `UnitCount` | number | required | Unit count of the item. |
-| `UnitAmount` | [Amount](finance.md#amount-value) | required | Unit amount of the item. |
+| `UnitAmount` | [Amount value](finance.md#amount-value) | required | Unit amount of the item. |
 | `CreatedUtc` | string | optional | Date and time of the item creation in UTC timezone in ISO 8601 format. |
 | `ConsumedUtc` | string | required | Date and time of the item consumption in UTC timezone in ISO 8601 format. |
 | `Notes` | string | optional | Additional notes. |


### PR DESCRIPTION
#### Changelog notes 

```
* Fixed the label of the fields referring to Amount Value
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
