### PR TITLE
external identifier added to restrictions

### DIFF
--- a/operations/services.md
+++ b/operations/services.md
@@ -75,7 +75,7 @@ Returns all services offered by the enterprise.
 | `StartTime` | string | optional | Default start time of the service orders in ISO 8601 duration format. |
 | `EndTime` | string | optional | Default end time of the service orders in ISO 8601 duration format. |
 | `Promotions` | [Promotions](services.md#promotions) | required | Promotions of the service. |
-| `Type` | string | [Service type](#services.md#service-type) | required | Type of the service. |
+| `Type` | string | [Service type](services.md#service-type) | required | Type of the service. |
 
 #### Promotions
 
@@ -599,6 +599,7 @@ Returns all restrictions of the default service provided by the enterprise.
    "Restrictions": [  
       {  
          "Id": "40c24757-c16e-4094-91d3-4ca952e488a1",
+         "ExternalIdentifier": "5678",
          "Conditions": {  
             "Type": "Stay",
             "ExactRateId": "7c7e89d6-69c0-4cce-9d42-35443f2193f3",
@@ -630,6 +631,7 @@ Returns all restrictions of the default service provided by the enterprise.
       },
       {  
          "Id": "b40ac4a8-f5da-457d-88fe-7a895e1580ab",
+         "ExternalIdentifier": "5678",
          "Conditions": {  
             "Type": "Start",
             "ExactRateId": null,
@@ -669,6 +671,7 @@ Returns all restrictions of the default service provided by the enterprise.
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the restriction. |
+| `ExternalIdentifier` | string | optional | External identifier of the restriction. |
 | `Conditions` | string | required | [Conditions](services.md#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
 | `Exceptions` | string | optional | [Exceptions](services.md#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
 
@@ -728,6 +731,7 @@ Adds new restrictions with the specified conditions.
    "Restrictions": [  
       {  
          "Identifier": "1234",
+         "ExternalIdentifier": "5678",
          "Conditions": {  
             "Type": "Start",
             "ExactRateId": "7c7e89d6-69c0-4cce-9d42-35443f2193f3",
@@ -745,6 +749,7 @@ Adds new restrictions with the specified conditions.
       },
       {  
          "Identifier": "1235",
+         "ExternalIdentifier": "5678",
          "Conditions": {  
             "Type": "Start",
             "BaseRateId": "e5b538b1-36e6-43a0-9f5c-103204c7f68e",
@@ -774,6 +779,7 @@ Adds new restrictions with the specified conditions.
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Identifier` | string | optional | Identifier of the restriction within the transaction. |
+| `ExternalIdentifier` | string | optional | External identifier of the restriction. |
 | `Conditions` | string | required | [Conditions](services.md#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
 | `Exceptions` | string | optional | [Exceptions](services.md#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
 
@@ -786,6 +792,7 @@ Adds new restrictions with the specified conditions.
          "Identifier": "1234",
          "Restriction": {
             "Id": "40c24757-c16e-4094-91d3-4ca952e488a1",
+            "ExternalIdentifier": "5678",
             "Conditions": {
                "Type": "Stay",
                "ExactRateId": "7c7e89d6-69c0-4cce-9d42-35443f2193f3",
@@ -814,6 +821,7 @@ Adds new restrictions with the specified conditions.
          "Identifier": "1235",
          "Restriction": {
             "Id": "b40ac4a8-f5da-457d-88fe-7a895e1580ab",
+            "ExternalIdentifier": "5678",
             "Conditions": {
                "Type": "Start",
                "ExactRateId": null,


### PR DESCRIPTION
#### Changelog notes 

* Extended [Get all restrictions](https://mews-systems.gitbook.io/connector-api/operations/services#get-all-restrictions) & [Add restriction](https://mews-systems.gitbook.io/connector-api/operations/services#add-restrictions) with `ExternalIdentifier`.

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
