### PR TITLE
multiple services

### DIFF
--- a/operations/customers.md
+++ b/operations/customers.md
@@ -207,7 +207,7 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 
 ## Search customers
 
-Searches for customers that are active at the moment in the enterprise \(e.g. companions of on checked-in reservations or paymasters\).
+Searches for customers that are active at the moment in the enterprise \(e.g. companions of checked-in reservations or paymasters\).
 
 ### Request
 
@@ -228,7 +228,7 @@ Searches for customers that are active at the moment in the enterprise \(e.g. co
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `Name` | string | optional | Name to search by \(applies to first name, last name and full name\). |
-| `SpaceId` | string | optional | Identifier of [Space](enterprises.md#space) to search by \(members of [Reservation](reservations.md#reservation) assigned there will be returned\). |
+| `ResourceId` | string | optional | Identifier of [Resource](enterprises.md#resource) to search by \(members of [Reservation](reservations.md#reservation) assigned there will be returned\). |
 
 ### Response
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -36,10 +36,10 @@ Returns all company profiles of the enterprise, possibly filtered by identifiers
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `Ids` | array of string | optional | Unique identifiers of [Companies](#company). |
-| `Names` | array of string | optional | Names of [Companies](#company). |
-| `CreatedUtc` | [Time interval](#time-interval) | optional | Interval of [Company](#company) creation date and time. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional | Interval of [Company](#company) last update date and time. |
+| `Ids` | array of string | optional | Unique identifiers of [Companies](enterprises.md#company). |
+| `Names` | array of string | optional | Names of [Companies](enterprises.md#company). |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of [Company](enterprises.md#company) creation date and time. |
+| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of [Company](enterprises.md#company) last update date and time. |
 
 #### Time interval
 
@@ -94,7 +94,7 @@ Returns all company profiles of the enterprise, possibly filtered by identifiers
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Companies` | array of [Company](#company) | required | The company profiles of the enterprise. |
+| `Companies` | array of [Company](enterprises.md#company) | required | The company profiles of the enterprise. |
 
 #### Company
 
@@ -152,14 +152,14 @@ Returns all contracts between the enterprise and other companies.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `TravelAgencyContracts` | array of [Travel agency contract](#travel-agency-contract) | required | The travel agency contracts. |
+| `TravelAgencyContracts` | array of [Travel agency contract](enterprises.md#travel-agency-contract) | required | The travel agency contracts. |
 
 #### Travel agency contract
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the contract. |
-| `CompanyId` | string | required | Unique identifier of the contracted [Company](#company). |
+| `CompanyId` | string | required | Unique identifier of the contracted [Company](enterprises.md#company). |
 | `IsActive` | boolean | required | Whether the contract is still active. |
 | `CommissionIncluded` | boolean | optional | Whether commission of the travel agency is included in the rate. |
 | `Commission` | number | optional | Commission of the travel agency. |
@@ -207,7 +207,7 @@ Returns all departments of an enterprise associated with the connector integrati
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Departments` | array of [Department](#department) | required | The departments of the enterprise. |
+| `Departments` | array of [Department](enterprises.md#department) | required | The departments of the enterprise. |
 
 #### Department
 
@@ -260,7 +260,7 @@ Returns all outlets of an enterprise associated with the connector integration.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Outlets` | array of [Outlet](#outlet) | required | The outlets of the enterprise. |
+| `Outlets` | array of [Outlet](enterprises.md#outlet) | required | The outlets of the enterprise. |
 
 #### Outlet
 
@@ -410,7 +410,7 @@ Returns all resources of an enterprise associated with the connector integration
 | `ResourceCategoryAssignments` | array of [Resource feature assignment](#resource-category-assignment) | optional | Assignments of resources to categories. |
 | `ResourceCategoryImageAssignments` | array of [Resource category assignment](#resource-category-image-assignment) | optional | Assignments of images to categories. |
 | `ResourceFeatures` | array of [Resource feature](#resource-feature) | optional | Features of resources in the enterprise. |
-| `ResourceFeatureAssignments` | array of [Resource feature assignment](#resource-feature-assignment) | optional | Assignments of resource features to resources. |
+| `ResourceFeatureAssignments` | array of [Resource feature assignment](resource-feature-assignment) | optional | Assignments of resource features to resources. |
 
 #### Resource
 
@@ -544,9 +544,9 @@ Updates resources.
 | `Id` | string | required | Unique identifier of the category. |
 | `IsActive` | bool | required | Whether the category is still active. |
 | `Type` | string [Resource category type](#resource-category-type) | required | Type of the category. |
-| `Names` | [Localized text](#localized-text) | required | All translations of the name. |
-| `ShortNames` | [Localized text](#localized-text) | required | All translations of the short name. |
-| `Descriptions` | [Localized text](#localized-text) | required | All translations of the description. |
+| `Names` | [Localized text](enterprises.md#localized-text) | required | All translations of the name. |
+| `ShortNames` | [Localized text](enterprises.md#localized-text) | required | All translations of the short name. |
+| `Descriptions` | [Localized text](enterprises.md#localized-text) | required | All translations of the description. |
 | `Ordering` | number | required | Ordering of the category, lower number corresponds to lower category \(note that uniqueness nor continuous sequence is guaranteed\). |
 | `Capacity` | number | required | Capacity that can be accommodated \(e.g. bed count\). |
 | `ExtraCapacity` | number | required | Extra capacity that can be accommodated \(e.g. extra bed count\). |
@@ -584,9 +584,9 @@ An object where keys are the [Language](configuration.md#language) codes and val
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service). |
 | `IsActive` | bool | required | Whether the resource feature is still active. |
 | `Classification` | [Resource feature classification](#resource-feature-classification) | required | Classification of the feature. |
-| `Names` | [Localized text](#localized-text) | required | All translations of the name. |
-| `ShortNames` | [Localized text](#localized-text) | required | All translations of the short name. |
-| `Descriptions` | [Localized text](#localized-text) | required | All translations of the description. |
+| `Names` | [Localized text](enterprises.md#localized-text) | required | All translations of the name. |
+| `ShortNames` | [Localized text](enterprises.md#localized-text) | required | All translations of the short name. |
+| `Descriptions` | [Localized text](enterprises.md#localized-text) | required | All translations of the description. |
 
 #### Resource feature classification
 
@@ -663,9 +663,9 @@ Returns all resource blocks \(out of order blocks or internal use blocks\).
 | `Client` | string | required | Name and version of the client application. |
 | `ResourceBlockIds` | array of string | optional | Unique identifiers of the requested [Resource block](#resource-block)s. |
 | `AssignedResourceIds` | array of string | optional | Unique identifiers of the requested Assigned [Resource](#resource)s. |
-| `CollidingUtc` | [Time interval](#time-interval) | optional | Interval in which the [Resource block](#resource-block) is active. |
-| `CreatedUtc` | [Time interval](#time-interval) | optional | Interval in which the [Resource block](#resource-block) was created. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional | Interval in which the [Resource block](#resource-block) was updated. |
+| `CollidingUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Resource block](#resource-block) is active. |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Resource block](#resource-block) was created. |
+| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Resource block](#resource-block) was updated. |
 | `Extent` | [Resource block extent](#resource-block-extent) | required | Extent of data to be returned. |
 
 #### Resource block extent
@@ -849,7 +849,7 @@ Adds a new task to the enterprise, optionally to a specified department.
 | `Description` | string | optional | Further decription of the task. |
 | `DeadlineUtc` | string | required | Deadline of the task in UTC timezone in ISO 8601 format. |
 | `ServiceOrderId` | string | optional | Unique identifier of the order (for example a [Reservation](reservations.md#reservation) or [Product order](services.md#add-order)) the task is linked with. |
-| `DepartmentId` | string | optional | Unique identifier of the [Department](#department) the task is addressed to. |
+| `DepartmentId` | string | optional | Unique identifier of the [Department](enterprises.md#department) the task is addressed to. |
 
 ### Response
 
@@ -905,12 +905,12 @@ Returns all tasks of the enterprise, filtered by identifiers or other filters.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `TaskIds` | array of string | optional | Unique identifiers of [Task](#task)s. |
-| `DepartmentIds` | array of string | optional | Unique identifiers of [Department](#department)s. Not possible to be used standalone, needs to be used in combination with other filters. |
+| `TaskIds` | array of string | optional | Unique identifiers of [Task](enterprises.md#task)s. |
+| `DepartmentIds` | array of string | optional | Unique identifiers of [Department](enterprises.md#department)s. Not possible to be used standalone, needs to be used in combination with other filters. |
 | `ServiceOrderIds` | array of string  | optional | Unique identifiers of Service orders (for example a [Reservation](reservations.md#reservation) or [Product order](services#add-order)). |
-| `CreatedUtc` | [Time interval](#time-interval) | optional | Interval in which the [Task](#task) was created. |
-| `ClosedUtc` | [Time interval](#time-interval) | optional | Interval in which the [Task](#task) was closed. |
-| `DeadlineUtc` | [Time interval](#time-interval) | optional | Interval in which the [Task](#task) has a deadline. |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](enterprises.md#task) was created. |
+| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](enterprises.md#task) was closed. |
+| `DeadlineUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](enterprises.md#task) has a deadline. |
 
 ### Response
 
@@ -934,7 +934,7 @@ Returns all tasks of the enterprise, filtered by identifiers or other filters.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Tasks` | array of [Task](#task) | required | The filtered tasks. |
+| `Tasks` | array of [Task](enterprises.md#task) | required | The filtered tasks. |
 
 #### Task
 
@@ -942,9 +942,9 @@ Returns all tasks of the enterprise, filtered by identifiers or other filters.
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the task. |
 | `Name` | string | required | Name \(or title\) of the task. |
-| `State` | string [Task state](#task-state) | required | State of the task. |
+| `State` | string [Task state](enterprises.md#task-state) | required | State of the task. |
 | `Description` | string | optional | Further decription of the task. |
-| `DepartmentId` | string | optional | Unique identifier of the [Department](#department) the task is addressed to. |
+| `DepartmentId` | string | optional | Unique identifier of the [Department](enterprises.md#department) the task is addressed to. |
 | `ServiceOrderId` | string | optional | Unique identifier of the order (for example a [Reservation](reservations.md#reservation) or [Product order](services#add-order)) the task is linked with. |
 | `CreatedUtc` | string | required | Creation date and time of the task in UTC timezone in ISO 8601 format. |
 | `DeadlineUtc` | string | required | Deadline date and time of the task in UTC timezone in ISO 8601 format. |
@@ -1006,7 +1006,7 @@ Adds a new company to the enterprise.
 
 ### Response
 
-Same structure as in [Get all companies](#get-all-companies) operation.
+Same structure as in [Get all companies](enterprises.md#get-all-companies) operation.
 
 ## Update company
 
@@ -1071,4 +1071,4 @@ Updates information of the company.
 
 ### Response
 
-Same structure as in [Get all companies](#get-all-companies) operation.
+Same structure as in [Get all companies](enterprises.md#get-all-companies) operation.

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -36,10 +36,10 @@ Returns all company profiles of the enterprise, possibly filtered by identifiers
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `Ids` | array of string | optional | Unique identifiers of [Companies](enterprises.md#company). |
-| `Names` | array of string | optional | Names of [Companies](enterprises.md#company). |
-| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of [Company](enterprises.md#company) creation date and time. |
-| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval of [Company](enterprises.md#company) last update date and time. |
+| `Ids` | array of string | optional | Unique identifiers of [Companies](#company). |
+| `Names` | array of string | optional | Names of [Companies](#company). |
+| `CreatedUtc` | [Time interval](#time-interval) | optional | Interval of [Company](#company) creation date and time. |
+| `UpdatedUtc` | [Time interval](#time-interval) | optional | Interval of [Company](#company) last update date and time. |
 
 #### Time interval
 
@@ -94,7 +94,7 @@ Returns all company profiles of the enterprise, possibly filtered by identifiers
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Companies` | array of [Company](enterprises.md#company) | required | The company profiles of the enterprise. |
+| `Companies` | array of [Company](#company) | required | The company profiles of the enterprise. |
 
 #### Company
 
@@ -152,14 +152,14 @@ Returns all contracts between the enterprise and other companies.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `TravelAgencyContracts` | array of [Travel agency contract](enterprises.md#travel-agency-contract) | required | The travel agency contracts. |
+| `TravelAgencyContracts` | array of [Travel agency contract](#travel-agency-contract) | required | The travel agency contracts. |
 
 #### Travel agency contract
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the contract. |
-| `CompanyId` | string | required | Unique identifier of the contracted [Company](enterprises.md#company). |
+| `CompanyId` | string | required | Unique identifier of the contracted [Company](#company). |
 | `IsActive` | boolean | required | Whether the contract is still active. |
 | `CommissionIncluded` | boolean | optional | Whether commission of the travel agency is included in the rate. |
 | `Commission` | number | optional | Commission of the travel agency. |
@@ -207,7 +207,7 @@ Returns all departments of an enterprise associated with the connector integrati
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Departments` | array of [Department](enterprises.md#department) | required | The departments of the enterprise. |
+| `Departments` | array of [Department](#department) | required | The departments of the enterprise. |
 
 #### Department
 
@@ -260,7 +260,7 @@ Returns all outlets of an enterprise associated with the connector integration.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Outlets` | array of [Outlet](enterprises.md#outlet) | required | The outlets of the enterprise. |
+| `Outlets` | array of [Outlet](#outlet) | required | The outlets of the enterprise. |
 
 #### Outlet
 
@@ -270,13 +270,13 @@ Returns all outlets of an enterprise associated with the connector integration.
 | `IsActive` | boolean | required | Whether the outlet is still active. |
 | `Name` | string | required | Name of the outlet. |
 
-## Get all spaces
+## Get all resources
 
-Returns all spaces of an enterprise associated with the connector integration.
+Returns all resources of an enterprise associated with the connector integration.
 
 ### Request
 
-`[PlatformAddress]/api/connector/v1/spaces/getAll`
+`[PlatformAddress]/api/connector/v1/resources/getAll`
 
 ```javascript
 {
@@ -284,9 +284,12 @@ Returns all spaces of an enterprise associated with the connector integration.
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
     "Extent": {
-        "Spaces": true,
-        "SpaceCategories": false,
-        "SpaceFeatures": false,
+        "Resources": true,
+        "ResourceCategories": false,
+        "ResourceCategoryAssignments": false,
+        "ResourceCategoryImageAssignments": false,
+        "ResourceFeatures": false,
+        "ResourceFeatureAssignments": false,
         "Inactive": false
     }
 }
@@ -297,86 +300,104 @@ Returns all spaces of an enterprise associated with the connector integration.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `Extent` | [Space extent](enterprises.md#space-extent) | required | Extent of data to be returned. |
+| `Extent` | [Resource extent](#resource-extent) | required | Extent of data to be returned. |
 
-#### Space extent
+#### Resource extent
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Spaces` | bool | optional | Whether the response should contain spaces. |
-| `SpaceCategories` | bool | optional | Whether the response should contain space categories. |
-| `SpaceFeatures` | bool | optional | Whether the response should contain space features and their assignments. |
+| `Resources` | bool | optional | Whether the response should contain resources. |
+| `ResourceCategories` | bool | optional | Whether the response should contain categories. |
+| `ResourceCategoryAssignments` | bool | optional | Whether the response should contain assignments of the resources to categories. |
+| `ResourceCategoryImageAssignments` | bool | optional | Whether the response should contain assignments of the images to categories. |
+| `ResourceFeatures` | bool | optional | Whether the response should contain resource features. |
+| `ResourceFeatureAssignments` | bool | optional | Whether the response should contain assignments of the resources to features. |
 | `Inactive` | bool | optional | Whether the response should contain inactive entities. |
 
 ### Response
 
 ```javascript
 {
-    "Spaces": [
+    "Resources": [
         {
-            "BuildingNumber": null,
-            "CategoryId": "773d5e42-de1e-43a0-9ce6-f940faf2303f",
-            "FloorNumber": "1",
             "Id": "5ee074b1-6c86-48e8-915f-c7aa4702086f",
             "IsActive": true,
-            "Number": "101",
-            "ParentSpaceId": null,
+            "Name": "101",
+            "ParentResourceId": null,
             "State": "Dirty",
-            "Type": "Room"
+            "Descriptions": {},
+            "Data": {
+                "Discriminator": "Space",
+                "Value": {
+                    "FloorNumber": "3"
+                }
+            }
         },
         {
-            "BuildingNumber": null,
-            "CategoryId": "773d5e42-de1e-43a0-9ce6-f940faf2303f",
-            "FloorNumber": "1",
             "Id": "c32386aa-1cd2-414a-a823-489325842fbe",
             "IsActive": true,
-            "Number": "102",
-            "ParentSpaceId": null,
+            "Name": "102",
+            "ParentResourceId": null,
             "State": "Inspected",
-            "Type": "Room"
+            "Descriptions": {
+                "en-US": "Resource description"
+            },
+            "Data": {
+                "Discriminator": "Space",
+                "Value": {
+                    "FloorNumber": "3"
+                }
+            }
         }
     ],
-    "SpaceCategories": [
+    "ResourceCategories": [
         {
             "Id": "aaed6e21-1c1f-4644-9872-e53f96a21bf9",
+            "ServiceId": "24e2ead5-65a8-4ed9-8286-abdb00f08a1f",
             "IsActive": true,
-            "Name": "Best Room",
             "Names": {
                 "en-US": "Best Room"
-            },
-            "ShortName": "BR",
             "ShortNames":{
                 "en-US": "BR"
             },
-            "Description": "",
             "Descriptions": {},
             "Ordering": 0,
-            "UnitCount": 2,
-            "ExtraUnitCount": 0
-            "ImageIds": [],
+            "Capacity": 2,
+            "ExtraCapacity": 0
         }
     ],
-    "SpaceFeatures": [
+    "ResourceCategoryAssignments": [
+        {
+            "ResourceId": "5ee074b1-6c86-48e8-915f-c7aa4702086f",
+            "CategoryId": "aaed6e21-1c1f-4644-9872-e53f96a21bf9"
+        }
+    ],
+
+    "ResourceCategoryImageAssignments": [
+        {
+            "CategoryId": "aaed6e21-1c1f-4644-9872-e53f96a21bf9",
+            "ImageId": "8cd435e0-f024-44a0-84fd-abe300b8ae1c"
+        }
+    ],
+    "ResourceFeatures": [
         {
             "Id": "a693dd8c-21fe-4dae-b450-ea3bd9ab3bb0",
+            "ServiceId": "24e2ead5-65a8-4ed9-8286-abdb00f08a1f",
             "IsActive": true,
             "Classification": "AccessibleBathroom",
-            "Name": "Accessible Bathroom"
             "Names": {
                 "en-US": "Accessible Bathroom"
             },
-            "ShortName": "AccessBath",
             "ShortNames": {
                 "en-US": "AccessBath"
             },
-            "Description": null,
             "Descriptions": {}
         }
     ],
-    "SpaceFeatureAssignments": [
+    "ResourceFeatureAssignments": [
         {
-            "SpaceFeatureId": "a693dd8c-21fe-4dae-b450-ea3bd9ab3bb0",
-            "SpaceId": "18019693-c66f-4be8-a893-c3d89fd291cc"
+            "ResourceId": "18019693-c66f-4be8-a893-c3d89fd291cc",
+            "FeatureId": "a693dd8c-21fe-4dae-b450-ea3bd9ab3bb0"
         }
     ]
 }
@@ -384,33 +405,25 @@ Returns all spaces of an enterprise associated with the connector integration.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Spaces` | array of [Space](enterprises.md#space) | required | The spaces of the enterprise. |
-| `SpaceCategories` | array of [Space category](enterprises.md#space-category) | required | Categories of spaces in the enterprise. |
-| `SpaceFeatures` | array of [Space feature](enterprises.md#space-feature) | optional | Features of spaces in the enterprise. |
-| `SpaceFeatureAssignments` | array of [Space feature assignment](enterprises.md#space-feature-assignment) | optional | Assignments of space features to spaces. |
+| `Resources` | array of [Resource](#resource) | required | The resources of the enterprise. |
+| `ResourceCategories` | array of [Resource category](#resource-category) | required | Categories of resources in the enterprise. |
+| `ResourceCategoryAssignments` | array of [Resource feature assignment](#resource-category-assignment) | optional | Assignments of resources to categories. |
+| `ResourceCategoryImageAssignments` | array of [Resource category assignment](#resource-category-image-assignment) | optional | Assignments of images to categories. |
+| `ResourceFeatures` | array of [Resource feature](#resource-feature) | optional | Features of resources in the enterprise. |
+| `ResourceFeatureAssignments` | array of [Resource feature assignment](#resource-feature-assignment) | optional | Assignments of resource features to resources. |
 
-#### Space
+#### Resource
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Id` | string | required | Unique identifier of the space. |
-| `IsActive` | bool | required | Whether the space is still active. |
-| `Type` | string [Space type](enterprises.md#space-type) | required | Type of the space. |
-| `Number` | string | required | Number of the space \(e.g. room number\). |
-| `FloorNumber` | string | optional | Number of the floor the space is on. |
-| `BuildingNumber` | string | optional | Number of the building the space is in. |
-| `ParentSpaceId` | string | optional | Identifier of the parent [Space](enterprises.md#space) \(e.g. room of a bed\). |
-| `CategoryId` | string | required | Identifier of the [Space category](enterprises.md#space-category) assigned to the space. |
-| `State` | string [Space state](enterprises.md#space-state) | required | State of the room. |
+| `Id` | string | required | Unique identifier of the resource. |
+| `IsActive` | bool | required | Whether the resource is still active. |
+| `Name` | string | required | Name of the resource \(e.g. room number\). |
+| `ParentResourceId` | string | optional | Identifier of the parent [Resource](#resource) \(e.g. room of a bed\). |
+| `State` | string [Resource state](#resource-state) | required | State of the resource. |
+| `Data` | [Resource data](#resource-data) | required | Additional data of the resource. |
 
-#### Space type
-
-* `Room`
-* `Dorm`
-* `Bed`
-* ...
-
-#### Space state
+#### Resource state
 
 * `Dirty`
 * `Clean`
@@ -418,42 +431,153 @@ Returns all spaces of an enterprise associated with the connector integration.
 * `OutOfService`
 * `OutOfOrder`
 
-#### Space category
+#### Resource data
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `Discriminator` | string [Resource data discriminator](#resource-data-discriminator) | required | Defines the type of the resource. |
+| `Value` | object | required | Based on the resource data discriminator provides additional data of the resource. Eg. [Space resource data](#space-resource-data)  |
+
+#### Resource data discriminator
+* `Space`
+
+#### Space resource data
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `FloorNumber` | string | required | Number of the floor the space is on |
+
+## Update resource
+
+Updates resource.
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/resources/update`
+
+```javascript
+{
+    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+    "Client": "Sample Client 1.0.0",
+    "ResourceUpdates": [
+        {
+            "ResourceId": "5ee074b1-6c86-48e8-915f-c7aa4702086f",
+            "Name": {
+                "Value": "0101"
+            },
+            "ParentResourceId": null,
+            "Data": 
+            {
+                "Value": {
+                    "Discriminator": "Space",
+                    "Value": {
+                        "FloorNumber": "1"
+                    }
+                }
+            },
+            "State": {
+                "Value": "Clean"
+            },
+            "StateReason": {
+                "Value": "Sample reason"
+            }
+        }
+    ]
+}
+```
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
+| `ResourceUpdates` | array of [Resource update](#resource-update) | required | Resource updates. |
+| `State` | string [Resource state](#resource-state) | required | New state of the resource \(`Dirty`, `Clean`, `Inspected` or `OutOfService`\). |
+
+#### Resource update
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `ResourceId` | string | required | Unique identifier of the [Resource](#resource) which is updated. |
+| `Name` | [String update value](#string-update-value) | optional | New name of the resource \(e.g. room number\). |
+| `ParentResourceId` | [String update value](#string-update-value) | optional | Identifier of the new parent [Resource](#resource). |
+| `Data` | [Resource data update value](#resource-data-update-value) | optional | New additional data of the resource. |
+| `State` | [String update value](#string-update-value) | optional | New state of the resource \(`Dirty`, `Clean`, `Inspected` or `OutOfService`\). |
+| `StateReason` | [String update value](#string-update-value) | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
+
+#### String update value
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `Value` | string | optional | Value which is to be updated. |
+
+#### Resource data update value
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `Value` | [Resource data](#resource-data) | optional | Value which is to be updated. |
+
+
+### Response
+
+```javascript
+{}
+```
+
+#### Resource category
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the category. |
-| `IsActive` | bool | required | Whether the space category is still active. |
-| `Name` | string | required | Name of the category. |
-| `Names` | [Localized text](enterprises.md#localized-text) | required | All translations of the name. |
-| `ShortName` | string | optional | Short name \(e.g. code\) of the category. |
-| `ShortNames` | [Localized text](enterprises.md#localized-text) | required | All translations of the short name. |
-| `Description` | string | optional | Description of the category. |
-| `Descriptions` | [Localized text](enterprises.md#localized-text) | required | All translations of the description. |
+| `IsActive` | bool | required | Whether the category is still active. |
+| `Type` | string [Resource category type](#resource-category-type) | required | Type of the category. |
+| `Names` | [Localized text](#localized-text) | required | All translations of the name. |
+| `ShortNames` | [Localized text](#localized-text) | required | All translations of the short name. |
+| `Descriptions` | [Localized text](#localized-text) | required | All translations of the description. |
 | `Ordering` | number | required | Ordering of the category, lower number corresponds to lower category \(note that uniqueness nor continuous sequence is guaranteed\). |
-| `UnitCount` | number | required | Count of units that can be accommodated \(e.g. bed count\). |
-| `ExtraUnitCount` | number | required | Count of extra units that can be accommodated \(e.g. extra bed count\). |
-| `ImageIds` | array of string | required | Unique identifiers of the space category images. |
+| `Capacity` | number | required | Capacity that can be accommodated \(e.g. bed count\). |
+| `ExtraCapacity` | number | required | Extra capacity that can be accommodated \(e.g. extra bed count\). |
+
+#### Resource category type
+
+* `Room`
+* `Dorm`
+* `Bed`
+* ...
+
+#### Resource category assignment
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `ResourceId` | string | required | Unique identifier of the resource. |
+| `CategoryId` | string | required | Unique identifier of the category that resource is assigned to. |
+
+#### Resource category image assignment
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `CategoryId` | string | required | Unique identifier of the category that image is assigned to. |
+| `ImageId` | string | required | Unique identifier of the image. |
+
 
 #### Localized text
 
 An object where keys are the [Language](configuration.md#language) codes and values texts in respective languages.
 
-#### Space feature
+#### Resource feature
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the feature. |
-| `IsActive` | bool | required | Whether the space feature is still active. |
-| `Classification` | [Space feature classification](enterprises.md#space-feature-classification) | required | Classification of the feature. |
-| `Name` | string | required | Name of the feature. |
-| `Names` | [Localized text](enterprises.md#localized-text) | required | All translations of the name. |
-| `ShortName` | string | optional | Short name \(e.g. code\) of the feature. |
-| `ShortNames` | [Localized text](enterprises.md#localized-text) | required | All translations of the short name. |
-| `Description` | string | optional | Description of the feature. |
-| `Descriptions` | [Localized text](enterprises.md#localized-text) | required | All translations of the description. |
+| `ServiceId` | string | required | Unique identifier of the [Service](services.md#service). |
+| `IsActive` | bool | required | Whether the resource feature is still active. |
+| `Classification` | [Resource feature classification](#resource-feature-classification) | required | Classification of the feature. |
+| `Names` | [Localized text](#localized-text) | required | All translations of the name. |
+| `ShortNames` | [Localized text](#localized-text) | required | All translations of the short name. |
+| `Descriptions` | [Localized text](#localized-text) | required | All translations of the description. |
 
-#### Space feature classification
+#### Resource feature classification
 
 * `AccessibleBathroom`
 * `AccessibleRoom`
@@ -477,26 +601,32 @@ An object where keys are the [Language](configuration.md#language) codes and val
 * `SeaView`
 * `...`
 
-#### Space feature assignment
+#### Resource feature assignment
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `SpaceId` | string | required | Unique identifier [Space](enterprises.md#space). |
-| `SpaceFeatureId` | string | required | Unique identifier [Space feature](enterprises.md#space-feature). |
+| `ResourceId` | string | required | Unique identifier of the [Resource](#resource). |
+| `FeatureId` | string | required | Unique identifier of the [Resource feature](#resource-feature). |
 
-## Get all space blocks
+## Get all resource blocks
 
-Returns all space blocks \(out of order blocks or house use blocks\).
+Returns all resource blocks \(out of order blocks or internally used blocks\).
 
 ### Request
 
-`[PlatformAddress]/api/connector/v1/spaceBlocks/getAll`
+`[PlatformAddress]/api/connector/v1/resourceBlocks/getAll`
 
 ```javascript
 {
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
+    "ResourceBlockIds": [
+        "c478f1b3-7edb-4ccc-8f07-dd32fae1ca70"
+    ],
+    "AssignedResourceIds": [
+        "b64f088d-49b5-4d5f-9766-2e27c4b75e27"
+    ],
     "CollidingUtc": {
         "StartUtc": "2020-01-25T00:00:00Z",
         "EndUtc": "2020-01-30T00:00:00Z"
@@ -520,12 +650,14 @@ Returns all space blocks \(out of order blocks or house use blocks\).
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `CollidingUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Space block](#space-block) is active. |
-| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Space block](#space-block) was created. |
-| `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Space block](#space-block) was updated. |
-| `Extent` | [Space block extent](#space-block-extent) | required | Extent of data to be returned. |
+| `ResourceBlockIds` | array of string | optional | Unique identifiers of the requested [Resource block](#resource-block)s. |
+| `AssignedResourceIds` | array of string | optional | Unique identifiers of the requested Assigned [Resource](#resource)s. |
+| `CollidingUtc` | [Time interval](#time-interval) | optional | Interval in which the [Resource block](#resource-block) is active. |
+| `CreatedUtc` | [Time interval](#time-interval) | optional | Interval in which the [Resource block](#resource-block) was created. |
+| `UpdatedUtc` | [Time interval](#time-interval) | optional | Interval in which the [Resource block](#resource-block) was updated. |
+| `Extent` | [Resource block extent](#resource-block-extent) | required | Extent of data to be returned. |
 
-#### Space block extent
+#### Resource block extent
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
@@ -535,19 +667,19 @@ Returns all space blocks \(out of order blocks or house use blocks\).
 
 ```javascript
 {
-    "SpaceBlocks": [
+    "ResourceBlocks": [
         {
-            "AssignedSpaceId": "5ee074b1-6c86-48e8-915f-c7aa4702086f",
+            "AssignedResourceId": "5ee074b1-6c86-48e8-915f-c7aa4702086f",
             "CreatedUtc": "2016-03-29T22:02:34Z",
             "EndUtc": "2016-01-01T16:00:00Z",
             "Id": "5ab9d519-2485-4d77-85c4-2a619cbdc4e7",
             "IsActive": true,
             "StartUtc": "2016-01-01T10:00:00Z",
-            "Type": "HouseUse",
+            "Type": "InternalUse",
             "UpdatedUtc": "2016-03-29T22:02:34Z"
         },
         {
-            "AssignedSpaceId": "f7c4b4f5-ac83-4977-a41a-63d27cc6e3e9",
+            "AssignedResourceId": "f7c4b4f5-ac83-4977-a41a-63d27cc6e3e9",
             "CreatedUtc": "2016-03-29T15:14:06Z",
             "EndUtc": "2016-01-01T16:00:00Z",
             "Id": "4d98ad40-a726-409e-8bf3-2c12ff3c0331",
@@ -562,45 +694,50 @@ Returns all space blocks \(out of order blocks or house use blocks\).
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `SpaceBlocks` | array of [Space block](enterprises.md#space-block) | required | The space blocks colliding with the interval. |
+| `ResourceBlocks` | array of [Resource block](#resource-block) | required | The resource blocks colliding with the interval or matching the Id parameters. |
 
-#### Space block
+#### Resource block
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the block. |
-| `AssignedSpaceId` | string | required | Unique identifier of the assigned [Space](enterprises.md#space). |
+| `AssignedResourceId` | string | required | Unique identifier of the assigned [Resource](#resource). |
 | `IsActive` | bool | required | Whether the block is still active. |
-| `Type` | string [Space block type](enterprises.md#space-block-type) | required | Type of the space block. |
+| `Type` | string [Resource block type](#resource-block-type) | required | Type of the resource block. |
 | `StartUtc` | string | required | Start of the block in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the block in UTC timezone in ISO 8601 format. |
 | `CreatedUtc` | string | required | Creation date and time of the block in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the block in UTC timezone in ISO 8601 format. |
 
-#### Space block type
+#### Resource block type
 
 * `OutOfOrder`
-* `HouseUse`
+* `InternalUse`
 
-## Add space block
+## Add resource block
 
-Adds a new space block to the specified space for a defined period of time.
+Adds a new resource block to the specified resource for a defined period of time.
 
 ### Request
 
-`[PlatformAddress]/api/connector/v1/spaceBlocks/add`
+`[PlatformAddress]/api/connector/v1/resourceBlocks/add`
 
 ```javascript
 {
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
-    "SpaceId": "0d71d44e-3d85-4506-9b6f-aab500b69c52",
-    "Name": "Space block 1",
-    "StartUtc": "2019-10-15T10:00:00Z",
-    "EndUtc": "2019-10-20T10:00:00Z",
-    "Type": "OutOfOrder",
-    "Notes": "Note"
+    "ResourceBlocks": [
+        {
+            "ResourceId": "0d71d44e-3d85-4506-9b6f-aab500b69c52",
+            "Name": "Resource block 1",
+            "StartUtc": "2019-10-15T10:00:00Z",
+            "EndUtc": "2019-10-20T10:00:00Z",
+            "Type": "OutOfOrder",
+            "Notes": "Note"
+        }
+    ]
+    
 }
 ```
 
@@ -609,39 +746,50 @@ Adds a new space block to the specified space for a defined period of time.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `SpaceId` | string | required | Unique identifier of [Space](#space). |
-| `Name` | string | required | Name of the space block. |
+| `ResourceId` | string | required | Unique identifier of [Resource](#resource). |
+| `Name` | string | required | Name of the resource block. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
-| `Type` | string [Space block type](#space-block-type) | required | Type of the space block. |
-| `Notes` | string | optional | Note describing the space block. |
+| `Type` | string [Resource block type](#resource-block-type) | required | Type of the resource block. |
+| `Notes` | string | optional | Note describing the resource block. |
 
 ### Response
 
 ```javascript
 {
-    "SpaceBlockId": "bf1e10b7-8a03-4675-9e27-05fc84312a58"
+    "ResourceBlocks": [
+        {
+            "Id": "0913bd1d-69fc-4bcb-82d3-5a40520c8fb0",
+            "Name": "Resource block 1",
+            "StartUtc": "2019-10-15T10:00:00Z",
+            "EndUtc": "2019-10-20T10:00:00Z",
+            "Type": "OutOfOrder",
+            "Notes": "Note",
+            "CreatedUtc": "2016-06-01T15:14:06Z",
+            "UpdatedUtc": "2016-06-01T15:14:06Z"
+        }
+    ]
 }
 ```
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `SpaceBlockId` | string | required | Unique identifier of added [Space block](enterprises.md#space-block). |
+| `ResourceBlocks` | array of [Resource block](#resource-block)s | required | Resource blocks added. |
 
-## Delete space blocks
+## Delete resource blocks
 
-Removes specified space blocks from the spaces.
+Removes specified resource blocks from the resources.
 
 ### Request
 
-`[PlatformAddress]/api/connector/v1/spaceBlocks/delete`
+`[PlatformAddress]/api/connector/v1/resourceBlocks/delete`
 
 ```javascript
 {
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
-    "SpaceBlockIds": [
+    "ResourceBlockIds": [
         "bf1e10b7-8a03-4675-9e27-05fc84312a58",
         "e8fb6bfb-d64a-4e7c-acfe-ab0400d01183"
     ]
@@ -653,39 +801,7 @@ Removes specified space blocks from the spaces.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `SpaceBlockIds` | array of string | required | Unique identifier of [Space block](enterprises.md#space-block)s to be removed. |
-
-### Response
-
-```javascript
-{}
-```
-
-## Update space state
-
-Updates state of the specified space. Note that the state is also updated on the child spaces of the specified space. So if e.g. dorm space is set to `Dirty`, ale subspaces \(beds\) are also set to `Dirty`.
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/spaces/updateState`
-
-```javascript
-{
-    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",
-    "SpaceId": "41b3e3a2-3400-4d72-86d4-1e341ccf8977",
-    "State": "Inspected"
-}
-```
-
-| Property | Type |  | Description |
-| --- | --- | --- | --- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `SpaceId` | string | required | Unique identifier of the [Space](enterprises.md#space) to be updated. |
-| `State` | string [Space state](enterprises.md#space-state) | required | New state of the space \(`Dirty`, `Clean`, `Inspected` or `OutOfService`\). |
+| `ResourceBlockIds` | array of string | required | Unique identifier of [Resource block](#resource-block)s to be removed. |
 
 ### Response
 
@@ -723,7 +839,7 @@ Adds a new task to the enterprise, optionally to a specified department.
 | `Description` | string | optional | Further decription of the task. |
 | `DeadlineUtc` | string | required | Deadline of the task in UTC timezone in ISO 8601 format. |
 | `ServiceOrderId` | string | optional | Unique identifier of the order (for example a [Reservation](reservations.md#reservation) or [Product order](services.md#add-order)) the task is linked with. |
-| `DepartmentId` | string | optional | Unique identifier of the [Department](enterprises.md#department) the task is addressed to. |
+| `DepartmentId` | string | optional | Unique identifier of the [Department](#department) the task is addressed to. |
 
 ### Response
 
@@ -880,7 +996,7 @@ Adds a new company to the enterprise.
 
 ### Response
 
-Same structure as in [Get all companies](enterprises.md#get-all-companies) operation.
+Same structure as in [Get all companies](#get-all-companies) operation.
 
 ## Update company
 
@@ -945,4 +1061,4 @@ Updates information of the company.
 
 ### Response
 
-Same structure as in [Get all companies](enterprises.md#get-all-companies) operation.
+Same structure as in [Get all companies](#get-all-companies) operation.

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -447,9 +447,9 @@ Returns all resources of an enterprise associated with the connector integration
 | --- | --- | --- | --- |
 | `FloorNumber` | string | required | Number of the floor the space is on |
 
-## Update resource
+## Update resources
 
-Updates resource.
+Updates resources.
 
 ### Request
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -908,9 +908,9 @@ Returns all tasks of the enterprise, filtered by identifiers or other filters.
 | `TaskIds` | array of string | optional | Unique identifiers of [Task](#task)s. |
 | `DepartmentIds` | array of string | optional | Unique identifiers of [Department](#department)s. Not possible to be used standalone, needs to be used in combination with other filters. |
 | `ServiceOrderIds` | array of string  | optional | Unique identifiers of Service orders (for example a [Reservation](reservations.md#reservation) or [Product order](services#add-order)). |
-| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](#task) was created. |
-| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](#task) was closed. |
-| `DeadlineUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](#task) has a deadline. |
+| `CreatedUtc` | [Time interval](#time-interval) | optional | Interval in which the [Task](#task) was created. |
+| `ClosedUtc` | [Time interval](#time-interval) | optional | Interval in which the [Task](#task) was closed. |
+| `DeadlineUtc` | [Time interval](#time-interval) | optional | Interval in which the [Task](#task) has a deadline. |
 
 ### Response
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -439,13 +439,16 @@ Returns all resources of an enterprise associated with the connector integration
 | `Value` | object | required | Based on the resource data discriminator provides additional data of the resource. Eg. [Space resource data](#space-resource-data)  |
 
 #### Resource data discriminator
+
 * `Space`
+* `Object`
+* `Person`
 
 #### Space resource data
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `FloorNumber` | string | required | Number of the floor the space is on |
+| `FloorNumber` | string | required | Number of the floor the space is on. |
 
 ## Update resources
 
@@ -500,24 +503,24 @@ Updates resources.
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `ResourceId` | string | required | Unique identifier of the [Resource](#resource) which is updated. |
-| `Name` | [String update value](#string-update-value) | optional | New name of the resource \(e.g. room number\). |
-| `ParentResourceId` | [String update value](#string-update-value) | optional | Identifier of the new parent [Resource](#resource). |
-| `Data` | [Resource data update value](#resource-data-update-value) | optional | New additional data of the resource. |
-| `State` | [String update value](#string-update-value) | optional | New state of the resource \(`Dirty`, `Clean`, `Inspected` or `OutOfService`\). |
-| `StateReason` | [String update value](#string-update-value) | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
+| `Name` | [String update value](reservations.md#string-update-value) | optional | New name of the resource \(e.g. room number\). |
+| `ParentResourceId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the new parent [Resource](#resource). |
+| `Data` | [Resource data update](#resource-data-update) | optional | New additional data of the resource. |
+| `State` | [String update value](reservations.md#string-update-value) | optional | New state of the resource \(`Dirty`, `Clean`, `Inspected` or `OutOfService`\). |
+| `StateReason` | [String update value](reservations.md#string-update-value) | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
 
-#### String update value
-
-| Property | Type |  | Description |
-| --- | --- | --- | --- |
-| `Value` | string | optional | Value which is to be updated. |
-
-#### Resource data update value
+#### Resource data update
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Value` | [Resource data](#resource-data) | optional | Value which is to be updated. |
+| `Discriminator` | string [Resource data discriminator](#resource-data-discriminator) | required | Defines the type of the resource. |
+| `Value` | object | required | Based on the resource data discriminator provides new additional data updates of the resource. Eg. [Space resource data update](#space-resource-data-update) |
 
+#### Space resource data update
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `FloorNumber` | [String update value](reservations.md#string-update-value) | required | New number of the floor the space is on. |
 
 ### Response
 
@@ -559,7 +562,6 @@ Updates resources.
 | --- | --- | --- | --- |
 | `CategoryId` | string | required | Unique identifier of the category that image is assigned to. |
 | `ImageId` | string | required | Unique identifier of the image. |
-
 
 #### Localized text
 
@@ -610,7 +612,7 @@ An object where keys are the [Language](configuration.md#language) codes and val
 
 ## Get all resource blocks
 
-Returns all resource blocks \(out of order blocks or internally used blocks\).
+Returns all resource blocks \(out of order blocks or internal use blocks\).
 
 ### Request
 
@@ -736,8 +738,7 @@ Adds a new resource block to the specified resource for a defined period of time
             "Type": "OutOfOrder",
             "Notes": "Note"
         }
-    ]
-    
+    ]   
 }
 ```
 
@@ -1046,18 +1047,18 @@ Updates information of the company.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `Name` | [String update value](reservations.md#string-update-value) | optional | Name of the company \(or `null` if the name should not be updated\). |
-| `MotherCompanyId` | [String update value](reservations.md#string-update-value) | optional | Unique identifier of the mother company \(or `null` if the mother company should not be updated\). |
-| `Identifier` | [String update value](reservations.md#string-update-value) | optional | Identifier of the company, e.g. legal identifier \(or `null` if the identifier should not be updated\). |
-| `TaxIdentifier` | [String update value](reservations.md#string-update-value) | optional | Tax identification number of the company \(or `null` if the tax identifier should not be updated\). |
-| `AdditionalTaxIdentifier` | [String update value](reservations.md#string-update-value) | optional | Additional tax identifer of the company \(or `null` if the additional tax identifier should not be updated\). |
-| `BillingCode` | [String update value](reservations.md#string-update-value) | optional | Billing code of the company \(or `null` if the billing code should not be updated\). |
-| `AccountingCode` | [String update value](reservations.md#string-update-value) | optional | Accounting code of the company \(or `null` if the acounting code should not be updated\). |
-| `InvoiceDueInterval` | [String update value](reservations.md#string-update-value) | optional | The maximum time, when the invoice has to be be paid in ISO 8601 duration format. |
-| `ContactPerson` | [String update value](reservations.md#string-update-value) | optional | Contact person of the company. |
-| `Contact` | [String update value](reservations.md#string-update-value) | optional | Contact of the company. |
-| `Notes` | [String update value](reservations.md#string-update-value) | optional | Notes of the company. |
-| `Iata` | [String update value](reservations.md#string-update-value) | optional | Iata of the company. |
+| `Name` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Name of the company \(or `null` if the name should not be updated\). |
+| `MotherCompanyId` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Unique identifier of the mother company \(or `null` if the mother company should not be updated\). |
+| `Identifier` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Identifier of the company, e.g. legal identifier \(or `null` if the identifier should not be updated\). |
+| `TaxIdentifier` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Tax identification number of the company \(or `null` if the tax identifier should not be updated\). |
+| `AdditionalTaxIdentifier` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Additional tax identifer of the company \(or `null` if the additional tax identifier should not be updated\). |
+| `BillingCode` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Billing code of the company \(or `null` if the billing code should not be updated\). |
+| `AccountingCode` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Accounting code of the company \(or `null` if the acounting code should not be updated\). |
+| `InvoiceDueInterval` | [String update value](reservations.mdreservations.md#string-update-value) | optional | The maximum time, when the invoice has to be be paid in ISO 8601 duration format. |
+| `ContactPerson` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Contact person of the company. |
+| `Contact` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Contact of the company. |
+| `Notes` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Notes of the company. |
+| `Iata` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Iata of the company. |
 
 ### Response
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -435,8 +435,8 @@ Returns all resources of an enterprise associated with the connector integration
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Discriminator` | string [Resource data discriminator](#resource-data-discriminator) | required | Defines the type of the resource. |
-| `Value` | object | required | Based on the resource data discriminator provides additional data of the resource. Eg. [Space resource data](#space-resource-data)  |
+| `Discriminator` | string [Resource data discriminator](#resource-data-discriminator) | required | If resource is space, object or person. |
+| `Value` | object | required | Based on Resource data discriminator, e.g. [Space resource data](#space-resource-data)  |
 
 #### Resource data discriminator
 
@@ -449,6 +449,16 @@ Returns all resources of an enterprise associated with the connector integration
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `FloorNumber` | string | required | Number of the floor the space is on. |
+
+#### Object resource data
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+
+#### Person resource data
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
 
 ## Update resources
 
@@ -472,10 +482,10 @@ Updates resources.
             "ParentResourceId": null,
             "Data": 
             {
+                "Discriminator": "Space",
                 "Value": {
-                    "Discriminator": "Space",
-                    "Value": {
-                        "FloorNumber": "1"
+                    "FloorNumber": {
+                        "Value": "1"
                     }
                 }
             },
@@ -496,7 +506,6 @@ Updates resources.
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ResourceUpdates` | array of [Resource update](#resource-update) | required | Resource updates. |
-| `State` | string [Resource state](#resource-state) | required | New state of the resource \(`Dirty`, `Clean`, `Inspected` or `OutOfService`\). |
 
 #### Resource update
 
@@ -506,7 +515,7 @@ Updates resources.
 | `Name` | [String update value](reservations.md#string-update-value) | optional | New name of the resource \(e.g. room number\). |
 | `ParentResourceId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the new parent [Resource](#resource). |
 | `Data` | [Resource data update](#resource-data-update) | optional | New additional data of the resource. |
-| `State` | [String update value](reservations.md#string-update-value) | optional | New state of the resource \(`Dirty`, `Clean`, `Inspected` or `OutOfService`\). |
+| `State` | [String update value](reservations.md#string-update-value) | optional | New [State](#resource-state) of the resource except \(`OutOfOrder`\). |
 | `StateReason` | [String update value](reservations.md#string-update-value) | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
 
 #### Resource data update
@@ -514,7 +523,7 @@ Updates resources.
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Discriminator` | string [Resource data discriminator](#resource-data-discriminator) | required | Defines the type of the resource. |
-| `Value` | object | required | Based on the resource data discriminator provides new additional data updates of the resource. Eg. [Space resource data update](#space-resource-data-update) |
+| `Value` | object | required | Based on Resource data discriminator, e.g. [Space resource data update](#space-resource-data-update) |
 
 #### Space resource data update
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -407,10 +407,10 @@ Returns all resources of an enterprise associated with the connector integration
 | --- | --- | --- | --- |
 | `Resources` | array of [Resource](#resource) | required | The resources of the enterprise. |
 | `ResourceCategories` | array of [Resource category](#resource-category) | required | Categories of resources in the enterprise. |
-| `ResourceCategoryAssignments` | array of [Resource feature assignment](#resource-category-assignment) | optional | Assignments of resources to categories. |
+| `ResourceCategoryAssignments` | array of [Resource category assignment](#resource-category-assignment) | optional | Assignments of resources to categories. |
 | `ResourceCategoryImageAssignments` | array of [Resource category assignment](#resource-category-image-assignment) | optional | Assignments of images to categories. |
 | `ResourceFeatures` | array of [Resource feature](#resource-feature) | optional | Features of resources in the enterprise. |
-| `ResourceFeatureAssignments` | array of [Resource feature assignment](resource-feature-assignment) | optional | Assignments of resource features to resources. |
+| `ResourceFeatureAssignments` | array of [Resource feature assignment](#resource-feature-assignment) | optional | Assignments of resource features to resources. |
 
 #### Resource
 
@@ -905,12 +905,12 @@ Returns all tasks of the enterprise, filtered by identifiers or other filters.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `TaskIds` | array of string | optional | Unique identifiers of [Task](enterprises.md#task)s. |
-| `DepartmentIds` | array of string | optional | Unique identifiers of [Department](enterprises.md#department)s. Not possible to be used standalone, needs to be used in combination with other filters. |
+| `TaskIds` | array of string | optional | Unique identifiers of [Task](#task)s. |
+| `DepartmentIds` | array of string | optional | Unique identifiers of [Department](#department)s. Not possible to be used standalone, needs to be used in combination with other filters. |
 | `ServiceOrderIds` | array of string  | optional | Unique identifiers of Service orders (for example a [Reservation](reservations.md#reservation) or [Product order](services#add-order)). |
-| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](enterprises.md#task) was created. |
-| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](enterprises.md#task) was closed. |
-| `DeadlineUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](enterprises.md#task) has a deadline. |
+| `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](#task) was created. |
+| `ClosedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](#task) was closed. |
+| `DeadlineUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Task](#task) has a deadline. |
 
 ### Response
 
@@ -934,7 +934,7 @@ Returns all tasks of the enterprise, filtered by identifiers or other filters.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Tasks` | array of [Task](enterprises.md#task) | required | The filtered tasks. |
+| `Tasks` | array of [Task](#task) | required | The filtered tasks. |
 
 #### Task
 
@@ -942,9 +942,9 @@ Returns all tasks of the enterprise, filtered by identifiers or other filters.
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the task. |
 | `Name` | string | required | Name \(or title\) of the task. |
-| `State` | string [Task state](enterprises.md#task-state) | required | State of the task. |
+| `State` | string [Task state](#task-state) | required | State of the task. |
 | `Description` | string | optional | Further decription of the task. |
-| `DepartmentId` | string | optional | Unique identifier of the [Department](enterprises.md#department) the task is addressed to. |
+| `DepartmentId` | string | optional | Unique identifier of the [Department](#department) the task is addressed to. |
 | `ServiceOrderId` | string | optional | Unique identifier of the order (for example a [Reservation](reservations.md#reservation) or [Product order](services#add-order)) the task is linked with. |
 | `CreatedUtc` | string | required | Creation date and time of the task in UTC timezone in ISO 8601 format. |
 | `DeadlineUtc` | string | required | Deadline date and time of the task in UTC timezone in ISO 8601 format. |
@@ -1056,18 +1056,18 @@ Updates information of the company.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `Name` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Name of the company \(or `null` if the name should not be updated\). |
-| `MotherCompanyId` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Unique identifier of the mother company \(or `null` if the mother company should not be updated\). |
-| `Identifier` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Identifier of the company, e.g. legal identifier \(or `null` if the identifier should not be updated\). |
-| `TaxIdentifier` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Tax identification number of the company \(or `null` if the tax identifier should not be updated\). |
-| `AdditionalTaxIdentifier` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Additional tax identifer of the company \(or `null` if the additional tax identifier should not be updated\). |
-| `BillingCode` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Billing code of the company \(or `null` if the billing code should not be updated\). |
-| `AccountingCode` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Accounting code of the company \(or `null` if the acounting code should not be updated\). |
-| `InvoiceDueInterval` | [String update value](reservations.mdreservations.md#string-update-value) | optional | The maximum time, when the invoice has to be be paid in ISO 8601 duration format. |
-| `ContactPerson` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Contact person of the company. |
-| `Contact` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Contact of the company. |
-| `Notes` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Notes of the company. |
-| `Iata` | [String update value](reservations.mdreservations.md#string-update-value) | optional | Iata of the company. |
+| `Name` | [String update value](reservations.md#string-update-value) | optional | Name of the company \(or `null` if the name should not be updated\). |
+| `MotherCompanyId` | [String update value](reservations.md#string-update-value) | optional | Unique identifier of the mother company \(or `null` if the mother company should not be updated\). |
+| `Identifier` | [String update value](reservations.md#string-update-value) | optional | Identifier of the company, e.g. legal identifier \(or `null` if the identifier should not be updated\). |
+| `TaxIdentifier` | [String update value](reservations.md#string-update-value) | optional | Tax identification number of the company \(or `null` if the tax identifier should not be updated\). |
+| `AdditionalTaxIdentifier` | [String update value](reservations.md#string-update-value) | optional | Additional tax identifer of the company \(or `null` if the additional tax identifier should not be updated\). |
+| `BillingCode` | [String update value](reservations.md#string-update-value) | optional | Billing code of the company \(or `null` if the billing code should not be updated\). |
+| `AccountingCode` | [String update value](reservations.md#string-update-value) | optional | Accounting code of the company \(or `null` if the acounting code should not be updated\). |
+| `InvoiceDueInterval` | [String update value](reservations.md#string-update-value) | optional | The maximum time, when the invoice has to be be paid in ISO 8601 duration format. |
+| `ContactPerson` | [String update value](reservations.md#string-update-value) | optional | Contact person of the company. |
+| `Contact` | [String update value](reservations.md#string-update-value) | optional | Contact of the company. |
+| `Notes` | [String update value](reservations.md#string-update-value) | optional | Notes of the company. |
+| `Iata` | [String update value](reservations.md#string-update-value) | optional | Iata of the company. |
 
 ### Response
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -372,7 +372,6 @@ Returns all resources of an enterprise associated with the connector integration
             "CategoryId": "aaed6e21-1c1f-4644-9872-e53f96a21bf9"
         }
     ],
-
     "ResourceCategoryImageAssignments": [
         {
             "CategoryId": "aaed6e21-1c1f-4644-9872-e53f96a21bf9",
@@ -405,8 +404,8 @@ Returns all resources of an enterprise associated with the connector integration
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Resources` | array of [Resource](#resource) | required | The resources of the enterprise. |
-| `ResourceCategories` | array of [Resource category](#resource-category) | required | Categories of resources in the enterprise. |
+| `Resources` | array of [Resource](#resource) | optional | The resources of the enterprise. |
+| `ResourceCategories` | array of [Resource category](#resource-category) | optional | Categories of resources in the enterprise. |
 | `ResourceCategoryAssignments` | array of [Resource category assignment](#resource-category-assignment) | optional | Assignments of resources to categories. |
 | `ResourceCategoryImageAssignments` | array of [Resource category assignment](#resource-category-image-assignment) | optional | Assignments of images to categories. |
 | `ResourceFeatures` | array of [Resource feature](#resource-feature) | optional | Features of resources in the enterprise. |
@@ -462,7 +461,7 @@ Returns all resources of an enterprise associated with the connector integration
 
 ## Update resources
 
-Updates resources.
+Updates details of the resources.
 
 ### Request
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -562,15 +562,15 @@ Updates resources.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `CategoryId` | string | required | Unique identifier of the [Resource category](#resource-category) that Resource is assigned to. |
-| `ResourceId` | string | required | Unique identifier of the [Resource](#resource). |
+| `CategoryId` | string | required | Unique identifier of the [Resource category](#resource-category). |
+| `ResourceId` | string | required | Unique identifier of the [Resource](#resource) assigned to the Resource category. |
 
 #### Resource category image assignment
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `CategoryId` | string | required | Unique identifier of the [Resource category](#resource-category) that image is assigned to. |
-| `ImageId` | string | required | Unique identifier of the image. |
+| `CategoryId` | string | required | Unique identifier of the [Resource category](#resource-category). |
+| `ImageId` | string | required | Unique identifier of the image assigned to the Resource category. |
 
 #### Localized text
 
@@ -616,8 +616,8 @@ An object where keys are the [Language](configuration.md#language) codes and val
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ResourceId` | string | required | Unique identifier of the [Resource](#resource) that Resource feature is assigned to. |
-| `FeatureId` | string | required | Unique identifier of the [Resource feature](#resource-feature). |
+| `ResourceId` | string | required | Unique identifier of the [Resource](#resource). |
+| `FeatureId` | string | required | Unique identifier of the [Resource feature](#resource-feature) assigned to the Resource. |
 
 ## Get all resource blocks
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -516,7 +516,7 @@ Updates resources.
 | `ParentResourceId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the new parent [Resource](#resource). |
 | `Data` | [Resource data update](#resource-data-update) | optional | New additional data of the resource. |
 | `State` | [String update value](reservations.md#string-update-value) | optional | New [State](#resource-state) of the resource except \(`OutOfOrder`\). |
-| `StateReason` | [String update value](reservations.md#string-update-value) | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
+| `StateReason` | [String update value](reservations.md#string-update-value) | optional | New reason for the state of the resource. |
 
 #### Resource data update
 
@@ -548,8 +548,8 @@ Updates resources.
 | `ShortNames` | [Localized text](enterprises.md#localized-text) | required | All translations of the short name. |
 | `Descriptions` | [Localized text](enterprises.md#localized-text) | required | All translations of the description. |
 | `Ordering` | number | required | Ordering of the category, lower number corresponds to lower category \(note that uniqueness nor continuous sequence is guaranteed\). |
-| `Capacity` | number | required | Capacity that can be accommodated \(e.g. bed count\). |
-| `ExtraCapacity` | number | required | Extra capacity that can be accommodated \(e.g. extra bed count\). |
+| `Capacity` | number | required | Capacity that can be served \(e.g. bed count\). |
+| `ExtraCapacity` | number | required | Extra capacity that can be served \(e.g. extra bed count\). |
 
 #### Resource category type
 
@@ -562,14 +562,14 @@ Updates resources.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ResourceId` | string | required | Unique identifier of the resource. |
-| `CategoryId` | string | required | Unique identifier of the category that resource is assigned to. |
+| `CategoryId` | string | required | Unique identifier of the [Resource category](#resource-category) that Resource is assigned to. |
+| `ResourceId` | string | required | Unique identifier of the [Resource](#resource). |
 
 #### Resource category image assignment
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `CategoryId` | string | required | Unique identifier of the category that image is assigned to. |
+| `CategoryId` | string | required | Unique identifier of the [Resource category](#resource-category) that image is assigned to. |
 | `ImageId` | string | required | Unique identifier of the image. |
 
 #### Localized text
@@ -583,7 +583,7 @@ An object where keys are the [Language](configuration.md#language) codes and val
 | `Id` | string | required | Unique identifier of the feature. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service). |
 | `IsActive` | bool | required | Whether the resource feature is still active. |
-| `Classification` | [Resource feature classification](#resource-feature-classification) | required | Classification of the feature. |
+| `Classification` | string [Resource feature classification](#resource-feature-classification) | required | Classification of the feature. |
 | `Names` | [Localized text](enterprises.md#localized-text) | required | All translations of the name. |
 | `ShortNames` | [Localized text](enterprises.md#localized-text) | required | All translations of the short name. |
 | `Descriptions` | [Localized text](enterprises.md#localized-text) | required | All translations of the description. |
@@ -616,7 +616,7 @@ An object where keys are the [Language](configuration.md#language) codes and val
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ResourceId` | string | required | Unique identifier of the [Resource](#resource). |
+| `ResourceId` | string | required | Unique identifier of the [Resource](#resource) that Resource feature is assigned to. |
 | `FeatureId` | string | required | Unique identifier of the [Resource feature](#resource-feature). |
 
 ## Get all resource blocks
@@ -746,6 +746,14 @@ Adds a new resource block to the specified resource for a defined period of time
             "EndUtc": "2019-10-20T10:00:00Z",
             "Type": "OutOfOrder",
             "Notes": "Note"
+        },
+        {
+            "ResourceId": "f7c4b4f5-ac83-4977-a41a-63d27cc6e3e9",
+            "Name": "Resource block 2",
+            "StartUtc": "2019-10-15T10:00:00Z",
+            "EndUtc": "2019-10-20T10:00:00Z",
+            "Type": "InternalUse",
+            "Notes": "Note"
         }
     ]   
 }
@@ -756,6 +764,12 @@ Adds a new resource block to the specified resource for a defined period of time
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
+| `ResourceBlocks` | array of [Resource block parameter](#resource-block-parameter)s | required | Resource block parameters. |
+
+#### Resource block parameter
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
 | `ResourceId` | string | required | Unique identifier of [Resource](#resource). |
 | `Name` | string | required | Name of the resource block. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
@@ -770,11 +784,21 @@ Adds a new resource block to the specified resource for a defined period of time
     "ResourceBlocks": [
         {
             "Id": "0913bd1d-69fc-4bcb-82d3-5a40520c8fb0",
+            "AssignedResourceId": "0d71d44e-3d85-4506-9b6f-aab500b69c52",
             "Name": "Resource block 1",
             "StartUtc": "2019-10-15T10:00:00Z",
             "EndUtc": "2019-10-20T10:00:00Z",
             "Type": "OutOfOrder",
-            "Notes": "Note",
+            "CreatedUtc": "2016-06-01T15:14:06Z",
+            "UpdatedUtc": "2016-06-01T15:14:06Z"
+        },
+        {
+            "Id": "4d98ad40-a726-409e-8bf3-2c12ff3c0331",
+            "AssignedResourceId": "f7c4b4f5-ac83-4977-a41a-63d27cc6e3e9",
+            "Name": "Resource block 2",
+            "StartUtc": "2019-10-15T10:00:00Z",
+            "EndUtc": "2019-10-20T10:00:00Z",
+            "Type": "InternalUse",
             "CreatedUtc": "2016-06-01T15:14:06Z",
             "UpdatedUtc": "2016-06-01T15:14:06Z"
         }

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -15,6 +15,9 @@ Returns all reservations specified by any identifier, customer or other filter. 
     "Client": "Sample Client 1.0.0",
     "StartUtc": "2016-01-01T00:00:00Z",
     "EndUtc": "2016-01-07T00:00:00Z",
+    "ServiceIds": [
+        "bd26d8db-86da-4f96-9efc-e5a4654a4a94"
+    ],
     "ReservationIds": [
         "db6cad34-9a91-448b-bea1-abbe01240d9c"
     ],
@@ -43,13 +46,14 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `TimeFilter` | string [Reservation time filter](#reservation-time-filter) | optional | Time filter of the interval. If not specified, reservations `Colliding` with the interval are returned. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
-| `ReservationIds` | array of string | optional | Unique identifiers of the requested [Reservation](reservations.md#reservation)s. |
-| `GroupIds` | array of string | optional | Unique identifiers of the requested [Reservation group](reservations.md#reservation-group)s. |
+| `ServiceIds` | array of string | required | Unique identifiers of the [Service](services.md#service)s from which the reservations are requested. |
+| `ReservationIds` | array of string | optional | Unique identifiers of the requested [Reservation](#reservation)s. |
+| `GroupIds` | array of string | optional | Unique identifiers of the requested [Reservation group](#reservation-group)s. |
 | `CustomerIds` | array of string | optional | Unique identifiers of the [Customer](customers.md#customer)s which own the reservations. |
-| `SpaceIds` | array of string | optional | Unique identifiers of [Space](enterprises.md#space)s assigned to the reservations. |
+| `AssignedResourceIds` | array of string | optional | Unique identifiers of [Resource](enterprises.md#resource)s assigned to the reservations. |
 | `RateIds` | array of string | optional | Unique identifiers of [Rate](services.md#rate)s assigned to the reservations. |
 | `BusinessSegmentIds` | array of string | optional | Unique identifiers of [Business segment](services.md#business-segment)s assigned to the reservations. |
-| `Numbers` | array of string | optional | Confirmation numbers of [Reservation](reservations.md#reservation)s. |
+| `Numbers` | array of string | optional | Confirmation numbers of [Reservation](#reservation)s. |
 | `States` | array of string [Reservation state](#reservation-state) | optional | States the reservations should be in. If not specified, reservations in `Confirmed`, `Started` or `Processed` states are returned. |
 | `Extent` | [Reservation extent](#reservation-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the reservations, customers, groups and rates should be also returned. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](configuration.md#currency) the item costs should be converted to. |
@@ -76,7 +80,9 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `Reservations` | bool | optional | Whether the response should contain reservations. |
 | `ReservationGroups` | bool | optional | Whether the response should contain groups of the reservations. |
 | `Services` | bool | optional | Whether the response should contain services reserved by the reservations. |
-| `Spaces` | bool | optional | Whether the response should contain spaces and space categories. |
+| `Resources` | bool | optional | Whether the response should contain resources. |
+| `ResourceCategories` | bool | optional | Whether the response should contain resource categories. |
+| `ResourceCategoryAssignments` | bool | optional | Whether the response should contain assignments of the resources to categories. |
 | `Notes` | bool | optional | Whether the response should contain notes. |
 | `QrCodeData` | bool | optional | Whether the response should contain QR code data. |
 | `AccountingStates` | array of string [Accounting state](finance.md#Accounting-item-state) | optional | States the items should be in. If not specified, items in `Open` or `Closed` states are returned. |
@@ -127,8 +133,8 @@ Returns all reservations specified by any identifier, customer or other filter. 
     "Reservations": [
         {
             "AdultCount": 2,
-            "AssignedSpaceId": "20e00c32-d561-4008-8609-82d8aa525714",
-            "AssignedSpaceLocked": false,
+            "AssignedResourceId": "20e00c32-d561-4008-8609-82d8aa525714",
+            "AssignedResourceLocked": false,
             "BusinessSegmentId": null,
             "CancelledUtc": null,
             "ChannelNumber": "1337614414",
@@ -157,8 +163,9 @@ Returns all reservations specified by any identifier, customer or other filter. 
         }
     ],
     "Services": null,
-    "SpaceCategories": null,
-    "Spaces": null,
+    "Resources": null,
+    "ResourceCategories": null,
+    "ResourceCategoryAssignments": null,
     "Notes": null
 }
 ```
@@ -171,11 +178,12 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `Products` | array of [Product](services.md#product) | optional | Products orderable with reservations. |
 | `RateGroups` | array of [Rate group](services.md#rate-group) | optional | Rate groups of the reservation rates. |
 | `Rates` | array of [Rate](services.md#rate) | optional | Rates of the reservations. |
-| `ReservationGroups` | array of [Reservation group](reservations.md#reservation-group) | optional | Reservation groups that the reservations are members of. |
-| `Reservations` | array of [Reservation](reservations.md#reservation) | optional | The reservations that collide with the specified interval. |
+| `ReservationGroups` | array of [Reservation group](#reservation-group) | optional | Reservation groups that the reservations are members of. |
+| `Reservations` | array of [Reservation](#reservation) | optional | The reservations that collide with the specified interval. |
 | `Services` | array of [Service](services.md#service) | optional | Services that have been reserved. |
-| `SpaceCategories` | array of [Space category](enterprises.md#space-category) | optional | Space categories of the spaces. |
-| `Spaces` | array of [Space](enterprises.md#space) | optional | Assigned spaces of the reservations. |
+| `Resources` | array of [Resource](enterprises.md#resource) | optional | Assigned resources of the reservations. |
+| `ResourceCategories` | array of [Resource category](enterprises.md#resource-category) | optional | Resource categories of the resources. |
+| `ResourceCategoryAssignments` | array of [Resource category assignment](enterprises.md#resource-category-assignment) | optional | Assignments of the resources to categories. |
 | `Notes` | array of [Order note](#order-note) | optional | Notes of the reservations. | 
 | `QrCodeData` | array of [QrCode data](#qrcode-data) | optional | QR code data of the reservations. | 
 
@@ -185,22 +193,22 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the reservation. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) that is reserved. |
-| `GroupId` | string | required | Unique identifier of the [Reservation group](reservations.md#reservation-group). |
+| `GroupId` | string | required | Unique identifier of the [Reservation group](#reservation-group). |
 | `Number` | string | required | Confirmation number of the reservation in Mews. |
 | `ChannelNumber` | string | optional | Number of the reservation within the Channel \(i.e. OTA, GDS, CRS, etc\) in case the reservation group originates there \(e.g. Booking.com confirmation number\). |
 | `ChannelManagerNumber` | string | optional | Unique number of the reservation within the reservation group. |
 | `ChannelManagerGroupNumber` | string | optional | Number of the reservation group within a Channel manager that transferred the reservation from Channel to Mews. |
 | `ChannelManager` | string | optional | Name of the Channel manager \(e.g. AvailPro, SiteMinder, TravelClick, etc\). |
-| `State` | string [Reservation state](reservations.md#reservation-state) | required | State of the reservation. |
-| `Origin` | string [Reservation origin](reservations.md#reservation-origin) | required | Origin of the reservation. |
+| `State` | string [Reservation state](#reservation-state) | required | State of the reservation. |
+| `Origin` | string [Reservation origin](#reservation-origin) | required | Origin of the reservation. |
 | `CreatedUtc` | string | required | Creation date and time of the reservation in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the reservation in UTC timezone in ISO 8601 format. |
 | `StartUtc` | string | required | Start of the reservation \(arrival\) in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the reservation \(departure\) in UTC timezone in ISO 8601 format. |
 | `CancelledUtc` | string | optional | Cancellation date and time in UTC timezone in ISO 8601 format. |
-| `RequestedCategoryId` | string | required | Identifier of the requested [Space category](enterprises.md#space-category). |
-| `AssignedSpaceId` | string | optional | Identifier of the assigned [Space](enterprises.md#space). |
-| `AssignedSpaceLocked` | bool | required | Whether the reservation is locked in the assigned [Space](enterprises.md#space) and cannot be moved. |
+| `RequestedCategoryId` | string | required | Identifier of the requested [Resource category](enterprises.md#resource-category). |
+| `AssignedResourceId` | string | optional | Identifier of the assigned [Resource](enterprises.md#resource). |
+| `AssignedResourceLocked` | bool | required | Whether the reservation is locked in the assigned [Resource](enterprises.md#resource) and cannot be moved. |
 | `BusinessSegmentId` | string | optional | Identifier of the reservation [Business segment](services.md#business-segment). |
 | `CompanyId` | string | optional | Identifier of the [Company](enterprises.md#company) on behalf of which the reservation was made. |
 | `TravelAgencyId` | string | optional | Identifier of the [Company](enterprises.md#company) that mediated the reservation. |
@@ -208,13 +216,13 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `AdultCount` | number | required | Count of adults the reservation was booked for. |
 | `ChildCount` | number | required | Count of children the reservation was booked for. |
 | `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer) who owns the reservation. |
-| `CompanionIds` | array of string | required | Unique identifiers of [Customer](customers.md#customer)s that will occupy the space. |
+| `CompanionIds` | array of string | required | Unique identifiers of [Customer](customers.md#customer)s that will use the resource. |
 
 #### Reservation state
 
 * `Enquired` - Confirmed neither by the customer nor enterprise.
 * `Requested` - Confirmed by the customer but not by the enterprise \(waitlist\).
-* `Optional` - Confirmed by enterprise but not by the guest \(the enterprise is holding space for the guest\).
+* `Optional` - Confirmed by enterprise but not by the guest \(the enterprise is holding resource for the guest\).
 * `Confirmed` - Confirmed by both parties, before check-in.
 * `Started` - Checked in.
 * `Processed` - Checked out.
@@ -288,7 +296,7 @@ Returns all revenue items associated with the specified reservations.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationIds` | array of string | required | Unique identifiers of the [Reservation](reservations.md#reservation)s. |
+| `ReservationIds` | array of string | required | Unique identifiers of the [Reservation](#reservation)s. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](configuration.md#currency) the item costs should be converted to. |
 | `AccountingStates` | array of string [Accounting state](finance.md#Accounting-item-state) | optional | States the items should be in. If not specified, items in `Open` or `Closed` states are returned. |
 
@@ -337,13 +345,13 @@ Returns all revenue items associated with the specified reservations.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Reservations` | array of [Reservation items](reservations.md#reservation-items) | required | The reservations with their items. |
+| `Reservations` | array of [Reservation items](#reservation-items) | required | The reservations with their items. |
 
 #### Reservation items
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
 | `Items` | array of [Accounting item](finance.md#accounting-item) | required | The items associated with the reservation. |
 
 ## Price reservations
@@ -386,7 +394,7 @@ Returns prices of reservations with the specified parameters.
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) to be priced. |
-| `Reservations` | array of [Reservation parameters](reservations.md#reservation-parameters) | required | Parameters of the reservations to price. Note that `CustomerId` is not required when pricing reservations. |
+| `Reservations` | array of [Reservation parameters](#reservation-parameters) | required | Parameters of the reservations to price. Note that `CustomerId` is not required when pricing reservations. |
 
 ### Response
 
@@ -413,7 +421,7 @@ Returns prices of reservations with the specified parameters.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ReservationPrices` | array of [Reservation price](reservations.md#reservation-price) | required | The reservation prices. |
+| `ReservationPrices` | array of [Reservation price](#reservation-price) | required | The reservation prices. |
 
 #### Reservation price
 
@@ -490,9 +498,9 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) to be reserved. |
-| `GroupId` | string | optional | Unique identifier of the [Reservation group](reservations.md#reservation-group) where the reservations are added. If not specified, a new group is created. |
-| `GroupName` | string | optional | Name of the [Reservation group](reservations.md#reservation-group) which the reservations are added to. If `GroupId` is specifed, this field is ignored. If not specified, the group name is automatically created. |
-| `Reservations` | array of [Reservation parameters](reservations.md#reservation-parameters) | required | Parameters of the new reservations. |
+| `GroupId` | string | optional | Unique identifier of the [Reservation group](#reservation-group) where the reservations are added. If not specified, a new group is created. |
+| `GroupName` | string | optional | Name of the [Reservation group](#reservation-group) which the reservations are added to. If `GroupId` is specifed, this field is ignored. If not specified, the group name is automatically created. |
+| `Reservations` | array of [Reservation parameters](#reservation-parameters) | required | Parameters of the new reservations. |
 | `SendConfirmationEmail` | bool | optional | Wheter the confirmation email is sent. Default value is `true`. |
 | `CheckRateApplicability ` | bool | optional | Whether the rate applicability check is checked. Default value is `true`.  |
 | `CheckOverbooking` | bool | optional | Whether reservation overbooking is checked. Default value is `true`.  |
@@ -502,7 +510,7 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Identifier` | string | optional | Identifier of the reservation within the transaction. |
-| `State` | string [Reservation state](reservations.md#reservation-state) | optional | State of the newly created reservation \(either `Optional`, `Enquired` or `Confirmed`\). If not specified, `Confirmed` is used. |
+| `State` | string [Reservation state](#reservation-state) | optional | State of the newly created reservation \(either `Optional`, `Enquired` or `Confirmed`\). If not specified, `Confirmed` is used. |
 | `StartUtc` | string | required | Reservation start in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | Reservation end in UTC timezone in ISO 8601 format. |
 | `ReleasedUtc` | string | optional | Release date and time of an unconfirmed reservation in UTC timezone in ISO 8601 format. |
@@ -510,13 +518,13 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | `ChildCount` | number | required | Count of children the reservation is for. |
 | `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer) who owns the reservation. |
 | `BookerId` | string | optional | Unique identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. |
-| `RequestedCategoryId` | string | required | Identifier of the requested [Space category](enterprises.md#space-category). |
+| `RequestedCategoryId` | string | required | Identifier of the requested [Resource category](enterprises.md#resource-category). |
 | `RateId` | string | required | Identifier of the reservation [Rate](services.md#rate). |
 | `TravelAgencyId` | string | optional | Identifier of the [Company](enterprises.md#company) that mediated the reservation. |
 | `CompanyId` | string | optional | Identifier of the [Company](enterprises.md#company) on behalf of which the reservation was made. |
 | `Notes` | string | optional | Additional notes. |
 | `TimeUnitAmount` | [Amount](services.md#amount-parameters) | optional | Amount of each night of the reservation. |
-| `TimeUnitPrices` | array of [Time unit amount parameters](reservations.md#time-unit-amount-parameters) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. |
+| `TimeUnitPrices` | array of [Time unit amount parameters](#time-unit-amount-parameters) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. |
 | `ProductOrders` | array of [Product order parameters](services.md#product-order-parameters) | optional | Parameters of the products ordered together with the reservation. |
 | `CreditCardId` | string | optional | Identifier of [Credit card](finance.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation. |
 
@@ -530,8 +538,8 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
             "Reservation":
             {
                 "AdultCount": 2,
-                "AssignedSpaceId": "16ce4335-2198-408b-8949-9722894a42fb",
-                "AssignedSpaceLocked": false,
+                "AssignedResourceId": "16ce4335-2198-408b-8949-9722894a42fb",
+                "AssignedResourceLocked": false,
                 "BusinessSegmentId": "7760b5cb-a666-41bb-9758-76bf5d1df399",
                 "CancelledUtc": null,
                 "ChannelManager": "",
@@ -567,14 +575,14 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Reservations` | array of [Added reservation](reservations.md#added-reservation) | required | The added reservations. |
+| `Reservations` | array of [Added reservation](#added-reservation) | required | The added reservations. |
 
 #### Added reservation
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Identifier` | string | optional | Identifier of the reservation within the transaction. |
-| `Reservation` | [Reservation](reservations.md#reservation) | required | The added reservation. |
+| `Reservation` | [Reservation](#reservation) | required | The added reservation. |
 
 ## Update reservation
 
@@ -606,6 +614,9 @@ Updates information about the specified reservation. Note that if any of the fie
             },
             "ChildCount": {
                 "Value": 1
+            },
+             "AssignedResourceId": {
+                "Value": "16ce4335-2198-408b-8949-9722894a42fb"
             },
             "ChannelNumber": null,
             "RequestedCategoryId": null,
@@ -660,25 +671,26 @@ Updates information about the specified reservation. Note that if any of the fie
 | `Reason` | string | optional | Reason for updating the reservation. Required when updating the price of the reservation. |
 | `CheckOverbooking` | bool | optional | Whether reservation overbooking is checked. Default value is `true`.  |
 | `CheckRateApplicability ` | bool | optional | Whether the rate applicability check is checked. Default value is `true`.  |
-| `ReservationUpdates` | array of [Reservation updates](reservations.md#reservation-updates) | required | Array of properties to be updated in each reservation specified. |
+| `ReservationUpdates` | array of [Reservation updates](#reservation-updates) | required | Array of properties to be updated in each reservation specified. |
 
 #### Reservation updates
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
-| `StartUtc` | [String update value](reservations.md#string-update-value) | optional | Reservation start in UTC timezone in ISO 8601 format. \(or `null` if the start time should not be updated). |
-| `EndUtc` | [String update value](reservations.md#string-update-value) | optional | Reservation end in UTC timezone in ISO 8601 format. \(or `null` if the end time should not be updated). |
-| `AdultCount` | [Number update value](reservations.md#number-update-value) | optional | Count of adults the reservation is for. \(or `null` if the adult count should not be updated). |
-| `ChildCount` | [Number update value](reservations.md#number-update-value) | optional | Count of children the reservation is for. \(or `null` if the child count should not be updated). |
-| `ChannelNumber` | [String update value](reservations.md#string-update-value) | optional | Number of the reservation within the Channel (i.e. OTA, GDS, CRS, etc) in case the reservation group originates there (e.g. Booking.com confirmation number) \(or `null` if the channel number should not be updated). |
-| `RequestedCategoryId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the requested [Space category](enterprises.md#space-category) \(or `null` if space category should not be updated). |
-| `TraveAgencyId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Company](enterprises.md#company) that mediated the reservation \(or `null` if travel agency should not be updated). |
-| `CompanyId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Company](enterprises.md#company) on behalf of which the reservation was made \(or `null` if company should not be updated). |
-| `BusinessSegmentId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the reservation [Business segment](services.md#business-segment) \(or `null` if the business segment should not be updated).|
-| `RateId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the reservation [Rate](services.md#rate) \(or `null` if the rate should not be updated). |
-| `BookerId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the booker should not be updated). |
-| `TimeUnitPrices` | [Time unit amount update value](reservations.md#time-unit-amount-update-value) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. \(or `null` if the unit amounts should not be updated). |
-| `CreditCardId` | [String update value](reservations.md#string-update-value) | optional | Identifier of [Credit card](finance.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation.  \(or `null` if the credit card should not be updated). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
+| `StartUtc` | [String update value](#string-update-value) | optional | Reservation start in UTC timezone in ISO 8601 format. \(or `null` if the start time should not be updated). |
+| `EndUtc` | [String update value](#string-update-value) | optional | Reservation end in UTC timezone in ISO 8601 format. \(or `null` if the end time should not be updated). |
+| `AdultCount` | [Number update value](#number-update-value) | optional | Count of adults the reservation is for. \(or `null` if the adult count should not be updated). |
+| `ChildCount` | [Number update value](#number-update-value) | optional | Count of children the reservation is for. \(or `null` if the child count should not be updated). |
+| `AssignedResourceId` | [String update value](#string-update-value) | optional | Identifier of the assigned [Resource](enterprises.md#resource). |
+| `ChannelNumber` | [String update value](#string-update-value) | optional | Number of the reservation within the Channel (i.e. OTA, GDS, CRS, etc) in case the reservation group originates there (e.g. Booking.com confirmation number) \(or `null` if the channel number should not be updated). |
+| `RequestedCategoryId` | [String update value](#string-update-value) | optional | Identifier of the requested [Resource category](enterprises.md#resource-category) \(or `null` if resource category should not be updated). |
+| `TraveAgencyId` | [String update value](#string-update-value) | optional | Identifier of the [Company](enterprises.md#company) that mediated the reservation \(or `null` if travel agency should not be updated). |
+| `CompanyId` | [String update value](#string-update-value) | optional | Identifier of the [Company](enterprises.md#company) on behalf of which the reservation was made \(or `null` if company should not be updated). |
+| `BusinessSegmentId` | [String update value](#string-update-value) | optional | Identifier of the reservation [Business segment](services.md#business-segment) \(or `null` if the business segment should not be updated).|
+| `RateId` | [String update value](#string-update-value) | optional | Identifier of the reservation [Rate](services.md#rate) \(or `null` if the rate should not be updated). |
+| `BookerId` | [String update value](#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the booker should not be updated). |
+| `TimeUnitPrices` | [Time unit amount update value](#time-unit-amount-update-value) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. \(or `null` if the unit amounts should not be updated). |
+| `CreditCardId` | [String update value](#string-update-value) | optional | Identifier of [Credit card](finance.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation.  \(or `null` if the credit card should not be updated). |
 
 #### String update value
 
@@ -702,7 +714,7 @@ Updates information about the specified reservation. Note that if any of the fie
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Value` | array of [Time unit amount parameters](reservations.md#time-unit-amount-parameters) | required | Value which is to be updated. |
+| `Value` | array of [Time unit amount parameters](#time-unit-amount-parameters) | required | Value which is to be updated. |
 
 #### Time unit amount parameters
 
@@ -713,7 +725,7 @@ Updates information about the specified reservation. Note that if any of the fie
 
 ### Response
 
-Same structure as in [Get all reservations](reservations.md#get-all-reservations) operation.
+Same structure as in [Get all reservations](#get-all-reservations) operation.
 
 ## Confirm reservation
 
@@ -739,7 +751,7 @@ Marks all specified reservations as `Confirmed`. Succeeds only if all confirmati
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationIds` | array of string | required | Unique identifier of the [Reservation](reservations.md#reservation)s to confirm. |
+| `ReservationIds` | array of string | required | Unique identifier of the [Reservation](#reservation)s to confirm. |
 | `SendConfirmationEmail` | bool | optional | Wheter the confirmation email is sent. Default value is `true`. |
 
 ### Response
@@ -774,7 +786,7 @@ Marks a reservation as `Started` \(= checked in\). Succeeds only if all starting
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to start. |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation) to start. |
 
 ### Response
 
@@ -807,7 +819,7 @@ Marks a reservation as `Processed` \(= checked out\). Succeeds only if all proce
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to process. |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation) to process. |
 | `CloseBills` | bool | optional | Whether closable bills of the reservation members should be automatically closed. |
 | `AllowOpenBalance` | bool | optional | Whether non-zero consumed balance of all reservation members is allowed. |
 | `Notes` | string | optional | Required if `AllowOpenBalance` set to `true`. Used to provide reason for closing with unbalanced bill. |
@@ -844,7 +856,7 @@ Cancels all reservation with specified identifiers. Succeeds only if the reserva
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationIds` | array of string | required | Unique identifiers of the [Reservation](reservations.md#reservation)s to cancel. |
+| `ReservationIds` | array of string | required | Unique identifiers of the [Reservation](#reservation)s to cancel. |
 | `ChargeCancellationFee` | boolean | required | Whether cancellation fees should be charged according to rate conditions. |
 | `Notes` | string | required | Addiotional notes describing the cancellation. |
 
@@ -881,7 +893,7 @@ Updates customer of a reservation.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to be updated. |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation) to be updated. |
 | `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
 
 ### Response
@@ -915,78 +927,10 @@ Updates reservation interval \(start, end or both\).
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to be updated. |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation) to be updated. |
 | `StartUtc` | string | optional | New reservation start in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | New reservation end in UTC timezone in ISO 8601 format. |
 | `ChargeCancellationFee` | boolean | required | Whether cancellation fee should be charged for potentially canceled nights. |
-
-### Response
-
-```javascript
-{}
-```
-
-## Update reservation space
-
-Updates reservation allocation to space, e.g. to different room.
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/reservations/updateSpace`
-
-```javascript
-{
-    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",
-    "ReservationId": "e6ea708c-2a2a-412f-a152-b6c76ffad49b",
-    "SpaceId": "5ee074b1-6c86-48e8-915f-c7aa4702086f"
-}
-```
-
-| Property | Type |  | Description |
-| --- | --- | --- | --- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to be reassigned. |
-| `SpaceId` | string | required | Unique identifier of the [Space](enterprises.md#space) where the reservation should be assigned. |
-
-### Response
-
-```javascript
-{}
-```
-
-## Update reservation requested category
-
-Updates reservation category requested by the customer to a different one.
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/reservations/updateRequestedCategory`
-
-```javascript
-{
-    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",
-    "ReservationId": "e6ea708c-2a2a-412f-a152-b6c76ffad49b",
-    "CategoryId": "773d5e42-de1e-43a0-9ce6-f940faf2303f",
-    "Reprice": false,
-    "Overbook": true
-}
-```
-
-| Property | Type |  | Description |
-| --- | --- | --- | --- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to be updated. |
-| `CategoryId` | string | required | Unique identifier of the [Space category](enterprises.md#space-category). |
-| `Reprice` | bool | required | Whether reservation should be repriced according to new category pricing. |
-| `Overbook` | bool | optional | Whether the overbooking is enabled. Default value is `true`. |
 
 ### Response
 
@@ -1017,7 +961,7 @@ Adds a customer as a companion to the reservation. Succeeds only if there is spa
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
 | `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
 
 ### Response
@@ -1049,7 +993,7 @@ Removes customer companionship from the reservation. Note that the customer prof
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
 | `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
 
 ### Response
@@ -1089,7 +1033,7 @@ Adds a new product order of the specified product to the reservation.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
 | `ProductId` | string | required | Unique identifier of the [Product](services.md#product). |
 | `Count` | int | required | The amount of the products to be added. Note that if the product is charged e.g. per night, count 1 means a single product every night. Count 2 means two products every night. |
 | `UnitAmount` | [Amount](services.md#amount-parameters) | optional | Price of the product that overrides the price defined in Mews. |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -43,19 +43,19 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `TimeFilter` | string [Reservation time filter](#reservation-time-filter) | optional | Time filter of the interval. If not specified, reservations `Colliding` with the interval are returned. |
+| `TimeFilter` | string [Reservation time filter](reservations.md#reservation-time-filter) | optional | Time filter of the interval. If not specified, reservations `Colliding` with the interval are returned. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 | `ServiceIds` | array of string | required | Unique identifiers of the [Service](services.md#service)s from which the reservations are requested. |
-| `ReservationIds` | array of string | optional | Unique identifiers of the requested [Reservation](#reservation)s. |
-| `GroupIds` | array of string | optional | Unique identifiers of the requested [Reservation group](#reservation-group)s. |
+| `ReservationIds` | array of string | optional | Unique identifiers of the requested [Reservation](reservations.md#reservation)s. |
+| `GroupIds` | array of string | optional | Unique identifiers of the requested [Reservation group](reservations.md#reservation-group)s. |
 | `CustomerIds` | array of string | optional | Unique identifiers of the [Customer](customers.md#customer)s which own the reservations. |
 | `AssignedResourceIds` | array of string | optional | Unique identifiers of [Resource](enterprises.md#resource)s assigned to the reservations. |
 | `RateIds` | array of string | optional | Unique identifiers of [Rate](services.md#rate)s assigned to the reservations. |
 | `BusinessSegmentIds` | array of string | optional | Unique identifiers of [Business segment](services.md#business-segment)s assigned to the reservations. |
-| `Numbers` | array of string | optional | Confirmation numbers of [Reservation](#reservation)s. |
-| `States` | array of string [Reservation state](#reservation-state) | optional | States the reservations should be in. If not specified, reservations in `Confirmed`, `Started` or `Processed` states are returned. |
-| `Extent` | [Reservation extent](#reservation-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the reservations, customers, groups and rates should be also returned. |
+| `Numbers` | array of string | optional | Confirmation numbers of [Reservation](reservations.md#reservation)s. |
+| `States` | array of string [Reservation state](reservations.md#reservation-state) | optional | States the reservations should be in. If not specified, reservations in `Confirmed`, `Started` or `Processed` states are returned. |
+| `Extent` | [Reservation extent](reservations.md#reservation-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the reservations, customers, groups and rates should be also returned. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](configuration.md#currency) the item costs should be converted to. |
 
 #### Reservation time filter
@@ -178,14 +178,14 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `Products` | array of [Product](services.md#product) | optional | Products orderable with reservations. |
 | `RateGroups` | array of [Rate group](services.md#rate-group) | optional | Rate groups of the reservation rates. |
 | `Rates` | array of [Rate](services.md#rate) | optional | Rates of the reservations. |
-| `ReservationGroups` | array of [Reservation group](#reservation-group) | optional | Reservation groups that the reservations are members of. |
-| `Reservations` | array of [Reservation](#reservation) | optional | The reservations that collide with the specified interval. |
+| `ReservationGroups` | array of [Reservation group](reservations.md#reservation-group) | optional | Reservation groups that the reservations are members of. |
+| `Reservations` | array of [Reservation](reservations.md#reservation) | optional | The reservations that collide with the specified interval. |
 | `Services` | array of [Service](services.md#service) | optional | Services that have been reserved. |
 | `Resources` | array of [Resource](enterprises.md#resource) | optional | Assigned resources of the reservations. |
 | `ResourceCategories` | array of [Resource category](enterprises.md#resource-category) | optional | Resource categories of the resources. |
 | `ResourceCategoryAssignments` | array of [Resource category assignment](enterprises.md#resource-category-assignment) | optional | Assignments of the resources to categories. |
-| `Notes` | array of [Order note](#order-note) | optional | Notes of the reservations. | 
-| `QrCodeData` | array of [QrCode data](#qrcode-data) | optional | QR code data of the reservations. | 
+| `Notes` | array of [Order note](reservations.md#order-note) | optional | Notes of the reservations. | 
+| `QrCodeData` | array of [QrCode data](reservations.md#qrcode-data) | optional | QR code data of the reservations. | 
 
 #### Reservation
 
@@ -193,14 +193,14 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the reservation. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) that is reserved. |
-| `GroupId` | string | required | Unique identifier of the [Reservation group](#reservation-group). |
+| `GroupId` | string | required | Unique identifier of the [Reservation group](reservations.md#reservation-group). |
 | `Number` | string | required | Confirmation number of the reservation in Mews. |
 | `ChannelNumber` | string | optional | Number of the reservation within the Channel \(i.e. OTA, GDS, CRS, etc\) in case the reservation group originates there \(e.g. Booking.com confirmation number\). |
 | `ChannelManagerNumber` | string | optional | Unique number of the reservation within the reservation group. |
 | `ChannelManagerGroupNumber` | string | optional | Number of the reservation group within a Channel manager that transferred the reservation from Channel to Mews. |
 | `ChannelManager` | string | optional | Name of the Channel manager \(e.g. AvailPro, SiteMinder, TravelClick, etc\). |
-| `State` | string [Reservation state](#reservation-state) | required | State of the reservation. |
-| `Origin` | string [Reservation origin](#reservation-origin) | required | Origin of the reservation. |
+| `State` | string [Reservation state](reservations.md#reservation-state) | required | State of the reservation. |
+| `Origin` | string [Reservation origin](reservations.md#reservation-origin) | required | Origin of the reservation. |
 | `CreatedUtc` | string | required | Creation date and time of the reservation in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the reservation in UTC timezone in ISO 8601 format. |
 | `StartUtc` | string | required | Start of the reservation \(arrival\) in UTC timezone in ISO 8601 format. |
@@ -250,9 +250,9 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the note. |
-| `OrderId` | string | required | Unique identifier of the order or [Reservation](#reservation). |
+| `OrderId` | string | required | Unique identifier of the order or [Reservation](reservations.md#reservation). |
 | `Text` | string | required | Value of the note. |
-| `Type` | string [Order note type](#order-note-type) | required | Type of the note. |
+| `Type` | string [Order note type](reservations.md#order-note-type) | required | Type of the note. |
 | `CreatedUtc` | string | required | Creation date and time of the note in UTC timezone in ISO 8601 format. |
 
 #### Order note type
@@ -296,7 +296,7 @@ Returns all revenue items associated with the specified reservations.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationIds` | array of string | required | Unique identifiers of the [Reservation](#reservation)s. |
+| `ReservationIds` | array of string | required | Unique identifiers of the [Reservation](reservations.md#reservation)s. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](configuration.md#currency) the item costs should be converted to. |
 | `AccountingStates` | array of string [Accounting state](finance.md#Accounting-item-state) | optional | States the items should be in. If not specified, items in `Open` or `Closed` states are returned. |
 
@@ -345,13 +345,13 @@ Returns all revenue items associated with the specified reservations.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Reservations` | array of [Reservation items](#reservation-items) | required | The reservations with their items. |
+| `Reservations` | array of [Reservation items](reservations.md#reservation-items) | required | The reservations with their items. |
 
 #### Reservation items
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
 | `Items` | array of [Accounting item](finance.md#accounting-item) | required | The items associated with the reservation. |
 
 ## Price reservations
@@ -394,7 +394,7 @@ Returns prices of reservations with the specified parameters.
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) to be priced. |
-| `Reservations` | array of [Reservation parameters](#reservation-parameters) | required | Parameters of the reservations to price. Note that `CustomerId` is not required when pricing reservations. |
+| `Reservations` | array of [Reservation parameters](reservations.md#reservation-parameters) | required | Parameters of the reservations to price. Note that `CustomerId` is not required when pricing reservations. |
 
 ### Response
 
@@ -421,7 +421,7 @@ Returns prices of reservations with the specified parameters.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ReservationPrices` | array of [Reservation price](#reservation-price) | required | The reservation prices. |
+| `ReservationPrices` | array of [Reservation price](reservations.md#reservation-price) | required | The reservation prices. |
 
 #### Reservation price
 
@@ -498,9 +498,9 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) to be reserved. |
-| `GroupId` | string | optional | Unique identifier of the [Reservation group](#reservation-group) where the reservations are added. If not specified, a new group is created. |
-| `GroupName` | string | optional | Name of the [Reservation group](#reservation-group) which the reservations are added to. If `GroupId` is specifed, this field is ignored. If not specified, the group name is automatically created. |
-| `Reservations` | array of [Reservation parameters](#reservation-parameters) | required | Parameters of the new reservations. |
+| `GroupId` | string | optional | Unique identifier of the [Reservation group](reservations.md#reservation-group) where the reservations are added. If not specified, a new group is created. |
+| `GroupName` | string | optional | Name of the [Reservation group](reservations.md#reservation-group) which the reservations are added to. If `GroupId` is specifed, this field is ignored. If not specified, the group name is automatically created. |
+| `Reservations` | array of [Reservation parameters](reservations.md#reservation-parameters) | required | Parameters of the new reservations. |
 | `SendConfirmationEmail` | bool | optional | Wheter the confirmation email is sent. Default value is `true`. |
 | `CheckRateApplicability ` | bool | optional | Whether the rate applicability check is checked. Default value is `true`.  |
 | `CheckOverbooking` | bool | optional | Whether reservation overbooking is checked. Default value is `true`.  |
@@ -510,7 +510,7 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Identifier` | string | optional | Identifier of the reservation within the transaction. |
-| `State` | string [Reservation state](#reservation-state) | optional | State of the newly created reservation \(either `Optional`, `Enquired` or `Confirmed`\). If not specified, `Confirmed` is used. |
+| `State` | string [Reservation state](reservations.md#reservation-state) | optional | State of the newly created reservation \(either `Optional`, `Enquired` or `Confirmed`\). If not specified, `Confirmed` is used. |
 | `StartUtc` | string | required | Reservation start in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | Reservation end in UTC timezone in ISO 8601 format. |
 | `ReleasedUtc` | string | optional | Release date and time of an unconfirmed reservation in UTC timezone in ISO 8601 format. |
@@ -524,7 +524,7 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | `CompanyId` | string | optional | Identifier of the [Company](enterprises.md#company) on behalf of which the reservation was made. |
 | `Notes` | string | optional | Additional notes. |
 | `TimeUnitAmount` | [Amount](services.md#amount-parameters) | optional | Amount of each night of the reservation. |
-| `TimeUnitPrices` | array of [Time unit amount parameters](#time-unit-amount-parameters) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. |
+| `TimeUnitPrices` | array of [Time unit amount parameters](reservations.md#time-unit-amount-parameters) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. |
 | `ProductOrders` | array of [Product order parameters](services.md#product-order-parameters) | optional | Parameters of the products ordered together with the reservation. |
 | `CreditCardId` | string | optional | Identifier of [Credit card](finance.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation. |
 
@@ -575,14 +575,14 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Reservations` | array of [Added reservation](#added-reservation) | required | The added reservations. |
+| `Reservations` | array of [Added reservation](reservations.md#added-reservation) | required | The added reservations. |
 
 #### Added reservation
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Identifier` | string | optional | Identifier of the reservation within the transaction. |
-| `Reservation` | [Reservation](#reservation) | required | The added reservation. |
+| `Reservation` | [Reservation](reservations.md#reservation) | required | The added reservation. |
 
 ## Update reservation
 
@@ -671,26 +671,26 @@ Updates information about the specified reservation. Note that if any of the fie
 | `Reason` | string | optional | Reason for updating the reservation. Required when updating the price of the reservation. |
 | `CheckOverbooking` | bool | optional | Whether reservation overbooking is checked. Default value is `true`.  |
 | `CheckRateApplicability ` | bool | optional | Whether the rate applicability check is checked. Default value is `true`.  |
-| `ReservationUpdates` | array of [Reservation updates](#reservation-updates) | required | Array of properties to be updated in each reservation specified. |
+| `ReservationUpdates` | array of [Reservation updates](reservations.md#reservation-updates) | required | Array of properties to be updated in each reservation specified. |
 
 #### Reservation updates
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
-| `StartUtc` | [String update value](#string-update-value) | optional | Reservation start in UTC timezone in ISO 8601 format. \(or `null` if the start time should not be updated). |
-| `EndUtc` | [String update value](#string-update-value) | optional | Reservation end in UTC timezone in ISO 8601 format. \(or `null` if the end time should not be updated). |
-| `AdultCount` | [Number update value](#number-update-value) | optional | Count of adults the reservation is for. \(or `null` if the adult count should not be updated). |
-| `ChildCount` | [Number update value](#number-update-value) | optional | Count of children the reservation is for. \(or `null` if the child count should not be updated). |
-| `AssignedResourceId` | [String update value](#string-update-value) | optional | Identifier of the assigned [Resource](enterprises.md#resource). |
-| `ChannelNumber` | [String update value](#string-update-value) | optional | Number of the reservation within the Channel (i.e. OTA, GDS, CRS, etc) in case the reservation group originates there (e.g. Booking.com confirmation number) \(or `null` if the channel number should not be updated). |
-| `RequestedCategoryId` | [String update value](#string-update-value) | optional | Identifier of the requested [Resource category](enterprises.md#resource-category) \(or `null` if resource category should not be updated). |
-| `TraveAgencyId` | [String update value](#string-update-value) | optional | Identifier of the [Company](enterprises.md#company) that mediated the reservation \(or `null` if travel agency should not be updated). |
-| `CompanyId` | [String update value](#string-update-value) | optional | Identifier of the [Company](enterprises.md#company) on behalf of which the reservation was made \(or `null` if company should not be updated). |
-| `BusinessSegmentId` | [String update value](#string-update-value) | optional | Identifier of the reservation [Business segment](services.md#business-segment) \(or `null` if the business segment should not be updated).|
-| `RateId` | [String update value](#string-update-value) | optional | Identifier of the reservation [Rate](services.md#rate) \(or `null` if the rate should not be updated). |
-| `BookerId` | [String update value](#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the booker should not be updated). |
-| `TimeUnitPrices` | [Time unit amount update value](#time-unit-amount-update-value) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. \(or `null` if the unit amounts should not be updated). |
-| `CreditCardId` | [String update value](#string-update-value) | optional | Identifier of [Credit card](finance.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation.  \(or `null` if the credit card should not be updated). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
+| `StartUtc` | [String update value](reservations.md#string-update-value) | optional | Reservation start in UTC timezone in ISO 8601 format. \(or `null` if the start time should not be updated). |
+| `EndUtc` | [String update value](reservations.md#string-update-value) | optional | Reservation end in UTC timezone in ISO 8601 format. \(or `null` if the end time should not be updated). |
+| `AdultCount` | [Number update value](reservations.md#number-update-value) | optional | Count of adults the reservation is for. \(or `null` if the adult count should not be updated). |
+| `ChildCount` | [Number update value](reservations.md#number-update-value) | optional | Count of children the reservation is for. \(or `null` if the child count should not be updated). |
+| `AssignedResourceId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the assigned [Resource](enterprises.md#resource). |
+| `ChannelNumber` | [String update value](reservations.md#string-update-value) | optional | Number of the reservation within the Channel (i.e. OTA, GDS, CRS, etc) in case the reservation group originates there (e.g. Booking.com confirmation number) \(or `null` if the channel number should not be updated). |
+| `RequestedCategoryId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the requested [Resource category](enterprises.md#resource-category) \(or `null` if resource category should not be updated). |
+| `TraveAgencyId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Company](enterprises.md#company) that mediated the reservation \(or `null` if travel agency should not be updated). |
+| `CompanyId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Company](enterprises.md#company) on behalf of which the reservation was made \(or `null` if company should not be updated). |
+| `BusinessSegmentId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the reservation [Business segment](services.md#business-segment) \(or `null` if the business segment should not be updated).|
+| `RateId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the reservation [Rate](services.md#rate) \(or `null` if the rate should not be updated). |
+| `BookerId` | [String update value](reservations.md#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the booker should not be updated). |
+| `TimeUnitPrices` | [Time unit amount update value](reservations.md#time-unit-amount-update-value) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. \(or `null` if the unit amounts should not be updated). |
+| `CreditCardId` | [String update value](reservations.md#string-update-value) | optional | Identifier of [Credit card](finance.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation.  \(or `null` if the credit card should not be updated). |
 
 #### String update value
 
@@ -714,18 +714,18 @@ Updates information about the specified reservation. Note that if any of the fie
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Value` | array of [Time unit amount parameters](#time-unit-amount-parameters) | required | Value which is to be updated. |
+| `Value` | array of [Time unit amount parameters](reservations.md#time-unit-amount-parameters) | required | Value which is to be updated. |
 
 #### Time unit amount parameters
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Index` | string | required | Index of the unit. Indexing starts with `0`. E.g the first night of the reservation has index 0. |
-| `Amount` | [Amount](#services.md#amount-parameters) | required | Amount of the unit. |
+| `Amount` | [Amount](reservations.md#services.md#amount-parameters) | required | Amount of the unit. |
 
 ### Response
 
-Same structure as in [Get all reservations](#get-all-reservations) operation.
+Same structure as in [Get all reservations](reservations.md#get-all-reservations) operation.
 
 ## Confirm reservation
 
@@ -751,7 +751,7 @@ Marks all specified reservations as `Confirmed`. Succeeds only if all confirmati
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationIds` | array of string | required | Unique identifier of the [Reservation](#reservation)s to confirm. |
+| `ReservationIds` | array of string | required | Unique identifier of the [Reservation](reservations.md#reservation)s to confirm. |
 | `SendConfirmationEmail` | bool | optional | Wheter the confirmation email is sent. Default value is `true`. |
 
 ### Response
@@ -786,7 +786,7 @@ Marks a reservation as `Started` \(= checked in\). Succeeds only if all starting
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation) to start. |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to start. |
 
 ### Response
 
@@ -819,7 +819,7 @@ Marks a reservation as `Processed` \(= checked out\). Succeeds only if all proce
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation) to process. |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to process. |
 | `CloseBills` | bool | optional | Whether closable bills of the reservation members should be automatically closed. |
 | `AllowOpenBalance` | bool | optional | Whether non-zero consumed balance of all reservation members is allowed. |
 | `Notes` | string | optional | Required if `AllowOpenBalance` set to `true`. Used to provide reason for closing with unbalanced bill. |
@@ -856,7 +856,7 @@ Cancels all reservation with specified identifiers. Succeeds only if the reserva
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationIds` | array of string | required | Unique identifiers of the [Reservation](#reservation)s to cancel. |
+| `ReservationIds` | array of string | required | Unique identifiers of the [Reservation](reservations.md#reservation)s to cancel. |
 | `ChargeCancellationFee` | boolean | required | Whether cancellation fees should be charged according to rate conditions. |
 | `Notes` | string | required | Addiotional notes describing the cancellation. |
 
@@ -893,7 +893,7 @@ Updates customer of a reservation.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation) to be updated. |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to be updated. |
 | `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
 
 ### Response
@@ -927,7 +927,7 @@ Updates reservation interval \(start, end or both\).
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation) to be updated. |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation) to be updated. |
 | `StartUtc` | string | optional | New reservation start in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | New reservation end in UTC timezone in ISO 8601 format. |
 | `ChargeCancellationFee` | boolean | required | Whether cancellation fee should be charged for potentially canceled nights. |
@@ -961,7 +961,7 @@ Adds a customer as a companion to the reservation. Succeeds only if there is spa
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
 | `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
 
 ### Response
@@ -993,7 +993,7 @@ Removes customer companionship from the reservation. Note that the customer prof
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
 | `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
 
 ### Response
@@ -1033,7 +1033,7 @@ Adds a new product order of the specified product to the reservation.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
+| `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
 | `ProductId` | string | required | Unique identifier of the [Product](services.md#product). |
 | `Count` | int | required | The amount of the products to be added. Note that if the product is charged e.g. per night, count 1 means a single product every night. Count 2 means two products every night. |
 | `UnitAmount` | [Amount](services.md#amount-parameters) | optional | Price of the product that overrides the price defined in Mews. |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -208,7 +208,7 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `CancelledUtc` | string | optional | Cancellation date and time in UTC timezone in ISO 8601 format. |
 | `RequestedCategoryId` | string | required | Identifier of the requested [Resource category](enterprises.md#resource-category). |
 | `AssignedResourceId` | string | optional | Identifier of the assigned [Resource](enterprises.md#resource). |
-| `AssignedResourceLocked` | bool | required | Whether the reservation is locked in the assigned [Resource](enterprises.md#resource) and cannot be moved. |
+| `AssignedResourceLocked` | bool | required | Whether the reservation is locked to the assigned [Resource](enterprises.md#resource) and cannot be moved. |
 | `BusinessSegmentId` | string | optional | Identifier of the reservation [Business segment](services.md#business-segment). |
 | `CompanyId` | string | optional | Identifier of the [Company](enterprises.md#company) on behalf of which the reservation was made. |
 | `TravelAgencyId` | string | optional | Identifier of the [Company](enterprises.md#company) that mediated the reservation. |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -43,7 +43,7 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `TimeFilter` | string [Reservation time filter](reservations.md#reservation-time-filter) | optional | Time filter of the interval. If not specified, reservations `Colliding` with the interval are returned. |
+| `TimeFilter` | string [Reservation time filter](#reservation-time-filter) | optional | Time filter of the interval. If not specified, reservations `Colliding` with the interval are returned. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 | `ServiceIds` | array of string | required | Unique identifiers of the [Service](services.md#service)s from which the reservations are requested. |
@@ -54,8 +54,8 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `RateIds` | array of string | optional | Unique identifiers of [Rate](services.md#rate)s assigned to the reservations. |
 | `BusinessSegmentIds` | array of string | optional | Unique identifiers of [Business segment](services.md#business-segment)s assigned to the reservations. |
 | `Numbers` | array of string | optional | Confirmation numbers of [Reservation](reservations.md#reservation)s. |
-| `States` | array of string [Reservation state](reservations.md#reservation-state) | optional | States the reservations should be in. If not specified, reservations in `Confirmed`, `Started` or `Processed` states are returned. |
-| `Extent` | [Reservation extent](reservations.md#reservation-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the reservations, customers, groups and rates should be also returned. |
+| `States` | array of string [Reservation state](#reservation-state) | optional | States the reservations should be in. If not specified, reservations in `Confirmed`, `Started` or `Processed` states are returned. |
+| `Extent` | [Reservation extent](#reservation-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the reservations, customers, groups and rates should be also returned. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](configuration.md#currency) the item costs should be converted to. |
 
 #### Reservation time filter
@@ -184,8 +184,8 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `Resources` | array of [Resource](enterprises.md#resource) | optional | Assigned resources of the reservations. |
 | `ResourceCategories` | array of [Resource category](enterprises.md#resource-category) | optional | Resource categories of the resources. |
 | `ResourceCategoryAssignments` | array of [Resource category assignment](enterprises.md#resource-category-assignment) | optional | Assignments of the resources to categories. |
-| `Notes` | array of [Order note](reservations.md#order-note) | optional | Notes of the reservations. | 
-| `QrCodeData` | array of [QrCode data](reservations.md#qrcode-data) | optional | QR code data of the reservations. | 
+| `Notes` | array of [Order note](#order-note) | optional | Notes of the reservations. | 
+| `QrCodeData` | array of [QrCode data](#qrcode-data) | optional | QR code data of the reservations. | 
 
 #### Reservation
 
@@ -250,9 +250,9 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the note. |
-| `OrderId` | string | required | Unique identifier of the order or [Reservation](reservations.md#reservation). |
+| `OrderId` | string | required | Unique identifier of the order or [Reservation](#reservation). |
 | `Text` | string | required | Value of the note. |
-| `Type` | string [Order note type](reservations.md#order-note-type) | required | Type of the note. |
+| `Type` | string [Order note type](#order-note-type) | required | Type of the note. |
 | `CreatedUtc` | string | required | Creation date and time of the note in UTC timezone in ISO 8601 format. |
 
 #### Order note type
@@ -721,7 +721,7 @@ Updates information about the specified reservation. Note that if any of the fie
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Index` | string | required | Index of the unit. Indexing starts with `0`. E.g the first night of the reservation has index 0. |
-| `Amount` | [Amount](reservations.md#services.md#amount-parameters) | required | Amount of the unit. |
+| `Amount` | [Amount](services.md#amount-parameters) | required | Amount of the unit. |
 
 ### Response
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -63,7 +63,7 @@ Returns all services offered by the enterprise.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Services` | array of [Service](services.md#service) | required | Services offered by the enterprise. |
+| `Services` | array of [Service](#service) | required | Services offered by the enterprise. |
 
 #### Service
 
@@ -74,8 +74,8 @@ Returns all services offered by the enterprise.
 | `Name` | string | required | Name of the service. |
 | `StartTime` | string | optional | Default start time of the service orders in ISO 8601 duration format. |
 | `EndTime` | string | optional | Default end time of the service orders in ISO 8601 duration format. |
-| `Promotions` | [Promotions](services.md#promotions) | required | Promotions of the service. |
-| `Type` | string | [Service type](services.md#service-type) | required | Type of the service. |
+| `Promotions` | [Promotions](#promotions) | required | Promotions of the service. |
+| `Type` | string | [Service type](#service-type) | required | Type of the service. |
 
 #### Promotions
 
@@ -94,7 +94,7 @@ Returns all services offered by the enterprise.
 
 ## Get service availability
 
-Returns availability of a reservation service in the specified interval. Note that response contains availability for all dates that the specified interval intersects.
+Returns availability of a reservable service in the specified interval. Note that response contains availability for all dates that the specified interval intersects.
 
 ### Request
 
@@ -116,7 +116,7 @@ Returns availability of a reservation service in the specified interval. Note th
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) whose availability should be returned. |
+| `ServiceId` | string | required | Unique identifier of the [Service](#service) whose availability should be returned. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
@@ -144,15 +144,15 @@ Returns availability of a reservation service in the specified interval. Note th
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `CategoryAvailabilities` | array of [Space category availability](services.md#space-category-availability) | required | Space category availabilities. |
+| `CategoryAvailabilities` | array of [Resource category availability](#resource-category-availability) | required | Resource category availabilities. |
 | `DatesUtc` | array of string | required | Covered dates in UTC timezone in ISO 8601 format. |
 
-#### Space category availability
+#### Resource category availability
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `CategoryId` | string | required | Unique identifier of the [Space category](enterprises.md#space-category). |
-| `Availabilities` | array of number | required | Availabilities of the space category in the covered dates. |
+| `CategoryId` | string | required | Unique identifier of the [Resource category](enterprises.md#resource-category). |
+| `Availabilities` | array of number | required | Availabilities of the resource category in the covered dates. |
 
 ## Get all products
 
@@ -178,7 +178,7 @@ Returns all products offered together with the specified services.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ServiceIds` | array of string | required | Unique identifiers of the [Service](services.md#service)s. |
+| `ServiceIds` | array of string | required | Unique identifiers of the [Service](#service)s. |
 
 ### Response
 
@@ -226,23 +226,23 @@ Returns all products offered together with the specified services.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Products` | array of [Product](services.md#product) | required | Products offered with the service. |
+| `Products` | array of [Product](#product) | required | Products offered with the service. |
 
 #### Product
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the product. |
-| `ServiceId` | string | required | Unique identifier of the [Service](services.md#service). |
+| `ServiceId` | string | required | Unique identifier of the [Service](#service). |
 | `CategoryId` | string | optional | Unique identifier of the Product category. |
 | `IsActive` | boolean | required | Whether the product is still active. |
 | `Name` | string | required | Name of the product. |
 | `ShortName` | string | required | Short name of the product. |
 | `Description` | string | optional | Description of the product. |
-| `Charging` | string [Product charging](services.md#product-charging) | required | Charging of the product. |
-| `Posting` | string [Product posting](services.md#product-posting) | required | Posting of the product. |
-| `Promotions` | [Promotions](services.md#promotions) | required | Promotions of the service. |
-| `Classifications` | [Product classifications](services.md#product-classifications) | required | Classifications of the service. |
+| `Charging` | string [Product charging](#product-charging) | required | Charging of the product. |
+| `Posting` | string [Product posting](#product-posting) | required | Posting of the product. |
+| `Promotions` | [Promotions](#promotions) | required | Promotions of the service. |
+| `Classifications` | [Product classifications](#product-classifications) | required | Classifications of the service. |
 | `Price` | [Currency value](finance.md#currency-value) | required | Price of the product. |
 
 #### Product charging
@@ -278,7 +278,10 @@ Returns all business segments of the default service provided by the enterprise.
 {
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0"
+    "Client": "Sample Client 1.0.0",
+    "ServiceIds": [
+        "bd26d8db-86da-4f96-9efc-e5a4654a4a94"
+    ]
 }
 ```
 
@@ -287,6 +290,7 @@ Returns all business segments of the default service provided by the enterprise.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
+| `ServiceIds` | array of string | required | Unique identifiers of the [Service](#service)s from which the business segments are requested. |
 
 ### Response
 
@@ -295,11 +299,13 @@ Returns all business segments of the default service provided by the enterprise.
     "BusinessSegments": [
         {
             "Id": "7760b5cb-a666-41bb-9758-76bf5d1df399",
+            "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
             "IsActive": true,
             "Name": "Business"
         },
         {
             "Id": "54ec08b6-e6fc-48e9-b8ae-02943e0ac693",
+            "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
             "IsActive": true,
             "Name": "Leisure"
         }
@@ -309,13 +315,14 @@ Returns all business segments of the default service provided by the enterprise.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `BusinessSegments` | array of [Business segment](services.md#business-segment) | required | Business segments of the default service. |
+| `BusinessSegments` | array of [Business segment](#business-segment) | required | Business segments of the default service. |
 
 #### Business segment
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the segment. |
+| `ServiceId` | string | required | Unique identifier of the [Service](#service). |
 | `IsActive` | boolean | required | Whether the business segment is still active. |
 | `Name` | string | required | Name of the segment. |
 
@@ -332,6 +339,9 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
+    "ServiceIds": [
+        "bd26d8db-86da-4f96-9efc-e5a4654a4a94"
+    ],
     "Extent": {
         "Rates": true,
         "RateGroups": true
@@ -344,7 +354,8 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `Extent` | [Rate extent](services.md#rate-extent) | required | Extent of data to be returned. |
+| `ServiceIds` | array of string | required | Unique identifiers of the [Service](#service)s from which the rates are requested. |
+| `Extent` | [Rate extent](#rate-extent) | required | Extent of data to be returned. |
 
 #### Rate extent
 
@@ -363,6 +374,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
             "BaseRateId": null,
             "GroupId": "c8b866b3-be2e-4a47-9486-034318e9f393",
             "Id": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
+            "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
             "IsActive": true,
             "IsPublic": true,
             "Name": "Fully Flexible",
@@ -375,6 +387,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
     "RateGroups": [
         {
             "Id": "c8b866b3-be2e-4a47-9486-034318e9f393",
+            "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
             "IsActive": true,
             "Name": "Default"
         }
@@ -384,16 +397,17 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Rates` | array of [Rate](services.md#rate) | required | Rates of the default service. |
-| `RateGroups` | array of [Rate group](services.md#rate-group) | required | Rate groups of the default service. |
+| `Rates` | array of [Rate](#rate) | required | Rates of the default service. |
+| `RateGroups` | array of [Rate group](#rate-group) | required | Rate groups of the default service. |
 
 #### Rate
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the rate. |
-| `GroupId` | string | required | Unique identifier of [Rate group](services.md#rate-group) where the rate belongs. |
-| `BaseRateId` | string | required | Unique identifier of the base [Rate](services.md#rate). |
+| `GroupId` | string | required | Unique identifier of [Rate group](#rate-group) where the rate belongs. |
+| `BaseRateId` | string | required | Unique identifier of the base [Rate](#rate). |
+| `ServiceId` | string | required | Unique identifier of the [Service](#service). |
 | `IsActive` | boolean | required | Whether the rate is still active. |
 | `IsPublic` | boolean | required | Whether the rate is publicly available. |
 | `Name` | string | required | Name of the rate. |
@@ -405,6 +419,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the group. |
+| `ServiceId` | string | required | Unique identifier of the [Service](#service). |
 | `IsActive` | boolean | required | Whether the rate group is still active. |
 | `Name` | string | required | Name of the rate group. |
 
@@ -432,7 +447,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `RateId` | string | required | Unique identifier of the [Rate](services.md#rate) whose prices should be returned. |
+| `RateId` | string | required | Unique identifier of the [Rate](#rate) whose prices should be returned. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
@@ -475,32 +490,32 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | `Currency` | string | required | ISO-4217 code of the [Currency](configuration.md#currency). |
 | `DatesUtc` | array of string | required | Covered dates in UTC timezone in ISO 8601 format. |
 | `BasePrices` | array of number | required | Base prices of the rate in the covered dates. |
-| `CategoryPrices` | array of [Space category pricing](services.md#space-category-pricing) | required | Space category prices. |
-| `CategoryAdjustments` | array of [Space category adjustment](services.md#space-category-adjustment) | required | Space category adjustments. |
+| `CategoryPrices` | array of [Resource category pricing](#resource-category-pricing) | required | Resource category prices. |
+| `CategoryAdjustments` | array of [Resource category adjustment](#resource-category-adjustment) | required | Resource category adjustments. |
 | `RelativeAdjustment` | decimal | required | Specific amount which shows the difference between this rate and the base rate. |
 | `AbsoluteAdjustment` | decimal | required | Relative amount which shows the difference between this rate and the base rate. |
-| `EmptyUnitAdjustment` | decimal | required | Price adjustment for when the space booked with this rate is not full to capacity. |
-| `ExtraUnitAdjustment` | decimal | required | Price adjustment for when the space booked with this rate exceeds capacity. |
+| `EmptyUnitAdjustment` | decimal | required | Price adjustment for when the resource booked with this rate is not full to capacity. |
+| `ExtraUnitAdjustment` | decimal | required | Price adjustment for when the resource booked with this rate exceeds capacity. |
 
-#### Space category pricing
-
-| Property | Type |  | Description |
-| --- | --- | --- | --- |
-| `CategoryId` | string | required | Unique identifier of the [Space category](enterprises.md#space-category). |
-| `Prices` | array of number | required | Prices of the rate for the space category in the covered dates. |
-
-#### Space category adjustment
+#### Resource category pricing
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `CategoryId` | string | required | Unique identifier of the adjustment [Space category](enterprises.md#space-category). |
-| `ParentCategoryId` | string | optional | Unique identifier of the parent [Space category](enterprises.md#space-category) that serves as a base price for the current category. |
+| `CategoryId` | string | required | Unique identifier of the [Resource category](enterprises.md#resource-category). |
+| `Prices` | array of number | required | Prices of the rate for the resource category in the covered dates. |
+
+#### Resource category adjustment
+
+| Property | Type |  | Description |
+| --- | --- | --- | --- |
+| `CategoryId` | string | required | Unique identifier of the adjustment [Resource category](enterprises.md#resource-category). |
+| `ParentCategoryId` | string | optional | Unique identifier of the parent [Resource category](enterprises.md#resource-category) that serves as a base price for the current category. |
 | `RelativeValue` | number | required | Relative value of the adjustment \(e.g. `0.5` represents 50% increase\). |
 | `AbsoluteValue` | number | required | Absolute value of the adjustment \(e.g. `50` represents 50 EUR in case the rate currency is `EUR`\). |
 
 ## Update rate price
 
-Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Space category](enterprises.md#space-category), otherwise updates the base price for all space categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`, future updates are allowed for up to 5 years.
+Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Resource category](enterprises.md#resource-category), otherwise updates the base price for all resource categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`, future updates are allowed for up to 5 years.
 
 ### Request
 
@@ -533,14 +548,14 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `RateId` | string | required | Unique identifier of the base [Rate](services.md#rate) to update. |
-| `PriceUpdates` | array of [Price update](services.md#price-update) | required | Price updates. |
+| `RateId` | string | required | Unique identifier of the base [Rate](#rate) to update. |
+| `PriceUpdates` | array of [Price update](#price-update) | required | Price updates. |
 
 #### Price update
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `CategoryId` | string | optional | Unique identifier of the [Space category](enterprises.md#space-category) whose prices to update. If not specified, base price is updated. |
+| `CategoryId` | string | optional | Unique identifier of the [Resource category](enterprises.md#resource-category) whose prices to update. If not specified, base price is updated. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 | `Value` | number | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
@@ -564,7 +579,10 @@ Returns all restrictions of the default service provided by the enterprise.
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
-    "SpaceCategoryIds": [
+    "ServiceIds": [
+        "bd26d8db-86da-4f96-9efc-e5a4654a4a94"
+    ],
+    "ResourceCategoryIds": [
         "34c29e73-c8db-4e93-b51b-981e42655e03"
     ],
     "RateIds": [
@@ -590,8 +608,9 @@ Returns all restrictions of the default service provided by the enterprise.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `SpaceCategoryIds` | array of string | optional | Unique identifiers of [Space categories](enterprises.md#space-category). |
-| `RateIds` | array of string | optional | Unique identifiers of [Rate](services.md#rate)s. |
+| `ServiceIds` | array of string | required | Unique identifiers of the [Service](#service)s from which the restrictions are requested. |
+| `ResourceCategoryIds` | array of string | optional | Unique identifiers of [Resource categories](enterprises.md#resource-category). |
+| `RateIds` | array of string | optional | Unique identifiers of [Rate](#rate)s. |
 | `CollidingUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Restriction](#restriction) is active. Required if no other filter is provided. |
 | `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Restriction](#restriction) was created. |
 | `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Restriction](#restriction) was updated. |
@@ -603,14 +622,15 @@ Returns all restrictions of the default service provided by the enterprise.
    "Restrictions": [  
       {  
          "Id": "40c24757-c16e-4094-91d3-4ca952e488a1",
+         "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
          "ExternalIdentifier": "5678",
          "Conditions": {  
             "Type": "Stay",
             "ExactRateId": "7c7e89d6-69c0-4cce-9d42-35443f2193f3",
             "BaseRateId": null,
             "RateGroupId": null,
-            "SpaceCategoryId": "86336EAC-4168-46B1-A544-2A47251BF864",
-            "SpaceType": null,
+            "ResourceCategoryId": "86336EAC-4168-46B1-A544-2A47251BF864",
+            "ResourceCategoryType": null,
             "StartUtc": "2018-10-09T00:00:00Z",
             "EndUtc": "2018-10-31T00:00:00Z",
             "Days": [  
@@ -635,14 +655,15 @@ Returns all restrictions of the default service provided by the enterprise.
       },
       {  
          "Id": "b40ac4a8-f5da-457d-88fe-7a895e1580ab",
+         "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
          "ExternalIdentifier": "5678",
          "Conditions": {  
             "Type": "Start",
             "ExactRateId": null,
             "BaseRateId": "e5b538b1-36e6-43a0-9f5c-103204c7f68e",
             "RateGroupId": null,
-            "SpaceCategoryId": null,
-            "SpaceType": "Room",
+            "ResourceCategoryId": null,
+            "ResourceCategoryType": "Room",
             "StartUtc": "2018-10-01T00:00:00Z",
             "EndUtc": "2018-10-31T00:00:00Z",
             "Days": [  
@@ -668,30 +689,31 @@ Returns all restrictions of the default service provided by the enterprise.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Restrictions` | array of [Restriction](services.md#restriction) | required | Restrictions of the default service. |
+| `Restrictions` | array of [Restriction](#restriction) | required | Restrictions of the default service. |
 
 #### Restriction
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the restriction. |
+| `ServiceId` | string | required | Unique identifier of the [Service](#service). |
 | `ExternalIdentifier` | string | optional | External identifier of the restriction. |
-| `Conditions` | string | required | [Conditions](services.md#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
-| `Exceptions` | string | optional | [Exceptions](services.md#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
+| `Conditions` | string | required | [Conditions](#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
+| `Exceptions` | string | optional | [Exceptions](#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
 
 #### Restriction Conditions
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Type` | string | required | [Restriction type](services.md#restriction-type). |
-| `ExactRateId` | string | optional | Unique identifier of the restricted [ExactRate](services.md#rate). |
-| `BaseRateId` | string | optional | Unique identifier of the restricted [BaseRate](services.md#rate). |
-| `RateGroupId` | string | optional | Unique identifier of the restricted [RateGroup](services.md#rate-group). |
-| `SpaceCategoryId` | string | optional | Unique identifier of the restricted [SpaceCategory](enterprises.md#space-category). |
-| `SpaceType` | string | optional | Name of the restricted [Space type](services.md#space-type). |
+| `Type` | string | required | [Restriction type](#restriction-type). |
+| `ExactRateId` | string | optional | Unique identifier of the restricted [Exact rate](#rate). |
+| `BaseRateId` | string | optional | Unique identifier of the restricted [Base rate](#rate). |
+| `RateGroupId` | string | optional | Unique identifier of the restricted [Rate group](#rate-group). |
+| `ResourceCategoryId` | string | optional | Unique identifier of the restricted [Resource category](enterprises.md#resource-category). |
+| `ResourceType` | string | optional | Name of the restricted [Resource type](#resource-type). |
 | `StartUtc` | string | optional | Start of the restricted interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | End of the restricted interval in UTC timezone in ISO 8601 format. |
-| `Days` | array of string [Day](services.md#day) | required | The restricted days of week. |
+| `Days` | array of string [Day](#day) | required | The restricted days of week. |
 
 #### Restriction Exceptions
 
@@ -732,6 +754,7 @@ Adds new restrictions with the specified conditions.
 {  
    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+   "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
    "Restrictions": [  
       {  
          "Identifier": "1234",
@@ -739,7 +762,7 @@ Adds new restrictions with the specified conditions.
          "Conditions": {  
             "Type": "Start",
             "ExactRateId": "7c7e89d6-69c0-4cce-9d42-35443f2193f3",
-            "SpaceCategoryId": "86336EAC-4168-46B1-A544-2A47251BF864",
+            "ResourceCategoryId": "86336EAC-4168-46B1-A544-2A47251BF864",
             "Days": [  
                "Friday",
                "Saturday",
@@ -777,15 +800,16 @@ Adds new restrictions with the specified conditions.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `Restrictions` | array of [Restriction parameters](services.md#restriction-parameters) | required | Parameters of restrictions. |
+| `ServiceId` | string | required | Unique identifier of the [Service](#service) restrictions will be added in. |
+| `Restrictions` | array of [Restriction parameters](#restriction-parameters) | required | Parameters of restrictions. |
 
 #### Restriction parameters
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Identifier` | string | optional | Identifier of the restriction within the transaction. |
 | `ExternalIdentifier` | string | optional | External identifier of the restriction. |
-| `Conditions` | string | required | [Conditions](services.md#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
-| `Exceptions` | string | optional | [Exceptions](services.md#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
+| `Conditions` | string | required | [Conditions](#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
+| `Exceptions` | string | optional | [Exceptions](#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
 
 ### Response
 
@@ -796,14 +820,15 @@ Adds new restrictions with the specified conditions.
          "Identifier": "1234",
          "Restriction": {
             "Id": "40c24757-c16e-4094-91d3-4ca952e488a1",
+            "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
             "ExternalIdentifier": "5678",
             "Conditions": {
                "Type": "Stay",
                "ExactRateId": "7c7e89d6-69c0-4cce-9d42-35443f2193f3",
                "BaseRateId": null,
                "RateGroupId": null,
-               "SpaceCategoryId": "86336EAC-4168-46B1-A544-2A47251BF864",
-               "SpaceType": null,
+               "ResourceCategoryId": "86336EAC-4168-46B1-A544-2A47251BF864",
+               "ResourceCategoryType": null,
                "StartUtc": "2018-10-09T00:00:00Z",
                "EndUtc": "2018-10-31T00:00:00Z",
                "Days": [
@@ -825,14 +850,15 @@ Adds new restrictions with the specified conditions.
          "Identifier": "1235",
          "Restriction": {
             "Id": "b40ac4a8-f5da-457d-88fe-7a895e1580ab",
+            "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
             "ExternalIdentifier": "5678",
             "Conditions": {
                "Type": "Start",
                "ExactRateId": null,
                "BaseRateId": "e5b538b1-36e6-43a0-9f5c-103204c7f68e",
                "RateGroupId": null,
-               "SpaceCategoryId": null,
-               "SpaceType": "Room",
+               "ResourceCategoryId": null,
+               "ResourceCategoryType": "Room",
                "StartUtc": "2018-10-01T00:00:00Z",
                "EndUtc": "2018-10-31T00:00:00Z",
                "Days": [
@@ -859,14 +885,14 @@ Adds new restrictions with the specified conditions.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Restrictions` | array of [Added restriction](services.md#added-restriction) | required | The added restrictions. |
+| `Restrictions` | array of [Added restriction](#added-restriction) | required | The added restrictions. |
 
 #### Added restriction
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Identifier` | string | optional | Identifier of the restriction within the transaction. |
-| `Restriction` | [Restriction](services.md#restriction) | required | The added restriction. |
+| `Restriction` | [Restriction](#restriction) | required | The added restriction. |
 
 ## Delete restrictions
 
@@ -893,7 +919,7 @@ Removes restrictions from the service.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `RestrictionIds` | array of string | required | Unique identifiers of the [Restriction](services.md#restriction)s. |
+| `RestrictionIds` | array of string | required | Unique identifiers of the [Restriction](#restriction)s. |
 
 ### Response
 
@@ -946,19 +972,19 @@ Creates a new order with the specified products and items. Only positive charges
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `CustomerId` | string | required | Identifier of the [Customer](customers.md#customer) to be charged. |
-| `ServiceId` | string | required | Identifier of the [Service](services.md#service) to be ordered. |
+| `ServiceId` | string | required | Identifier of the [Service](#service) to be ordered. |
 | `ConsumptionUtc` | string | optional | Date and time of the order consumption in UTC timezone in ISO 8601 format. If not specified, current date and time is used. |
 | `Notes` | string | optional | Additional notes of the order. |
-| `ProductOrders` | array of [Product order parameters](services.md#product-order-parameters) | optional | Parameters of the ordered products. |
-| `Items` | array of [Item parameters](services.md#item-parameters) | optional | Parameters of the ordered custom items. |
+| `ProductOrders` | array of [Product order parameters](#product-order-parameters) | optional | Parameters of the ordered products. |
+| `Items` | array of [Item parameters](#item-parameters) | optional | Parameters of the ordered custom items. |
 
 #### Product order parameters
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ProductId` | string | required | Unique identifier of the [Product](services.md#product) to be ordered. |
+| `ProductId` | string | required | Unique identifier of the [Product](#product) to be ordered. |
 | `Count` | number | optional | Count of products to be ordered, e.g. 10 in case of 10 beers. |
-| `UnitAmount` | [Amount](services.md#amount-parameters) | optional | Unit amount of the product that overrides the amount defined in Mews. |
+| `UnitAmount` | [Amount](#amount-parameters) | optional | Unit amount of the product that overrides the amount defined in Mews. |
 
 #### Item parameters
 
@@ -966,7 +992,7 @@ Creates a new order with the specified products and items. Only positive charges
 | --- | --- | --- | --- |
 | `Name` | string | required | Name of the item. |
 | `UnitCount` | number | required | Count of units to be ordered, e.g. 10 in case of 10 beers. |
-| `UnitAmount` | [Amount](services.md#amount-parameters) | required | Unit amount, e.g. amount for one beer \(note that total amount of the item is therefore `UnitAmount` times `UnitCount`\). |
+| `UnitAmount` | [Amount](#amount-parameters) | required | Unit amount, e.g. amount for one beer \(note that total amount of the item is therefore `UnitAmount` times `UnitCount`\). |
 | `AccountingCategoryId` | string | optional | Unique identifier of an [Accounting category](finance.md#accounting-category) to be assigned to the item. |
 
 #### Amount parameters
@@ -1023,7 +1049,7 @@ Returns all companionships based on customers, reservations or reservation group
 | `CustomerIds` | array of string | optional | Unique identifiers of [Customer](customers.md#customer)s. |
 | `ReservationIds` | array of string | optional | Unique identifiers of [Reservation](reservations.md#reservation)s. |
 | `ReservationGroupIds` | array of string | optional | Unique identifiers of [Reservation group](reservations.md#reservation-group)s. |
-| `Extent` | [Companionship extent](services.md#companionship-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the companionships, customers, reservations, and reservation groups should be also returned. |
+| `Extent` | [Companionship extent](#companionship-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the companionships, customers, reservations, and reservation groups should be also returned. |
 
 #### Companionship extent
 
@@ -1053,7 +1079,7 @@ Returns all companionships based on customers, reservations or reservation group
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Companionships` | array of [Companionship](services.md#companionship) | required | Companionships. |
+| `Companionships` | array of [Companionship](#companionship) | required | Companionships. |
 | `Customers` | array of [Customer](customers.md#customer) | optional | Customers that belong to the companionships. |
 | `Reservations` | array of [Reservation](reservations.md#reservation) | optional | The accompanied reservations. |
 | `ReservationGroups` | array of [Reservation group](reservations.md#reservation-group) | optional | The accompanied reservation groups. |
@@ -1062,7 +1088,7 @@ Returns all companionships based on customers, reservations or reservation group
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Id` | string | required | Unique identifier of [Companionship](services.md#Companionship). |
+| `Id` | string | required | Unique identifier of [Companionship](#Companionship). |
 | `CustomerId` | string | required | Unique identifier of [Customer](customers.md#customer). |
 | `ReservationId` | string | optional | Unique identifier of [Reservation](reservations.md#reservation). |
 | `ReservationGroupId` | string | required | Unique identifier of [Reservation group](reservations.md#reservation-group). |

--- a/operations/services.md
+++ b/operations/services.md
@@ -63,7 +63,7 @@ Returns all services offered by the enterprise.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Services` | array of [Service](#service) | required | Services offered by the enterprise. |
+| `Services` | array of [Service](services.md#service) | required | Services offered by the enterprise. |
 
 #### Service
 
@@ -74,8 +74,8 @@ Returns all services offered by the enterprise.
 | `Name` | string | required | Name of the service. |
 | `StartTime` | string | optional | Default start time of the service orders in ISO 8601 duration format. |
 | `EndTime` | string | optional | Default end time of the service orders in ISO 8601 duration format. |
-| `Promotions` | [Promotions](#promotions) | required | Promotions of the service. |
-| `Type` | string | [Service type](#service-type) | required | Type of the service. |
+| `Promotions` | [Promotions](services.md#promotions) | required | Promotions of the service. |
+| `Type` | string | [Service type](services.md#service-type) | required | Type of the service. |
 
 #### Promotions
 
@@ -116,7 +116,7 @@ Returns availability of a reservable service in the specified interval. Note tha
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ServiceId` | string | required | Unique identifier of the [Service](#service) whose availability should be returned. |
+| `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) whose availability should be returned. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
@@ -178,7 +178,7 @@ Returns all products offered together with the specified services.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ServiceIds` | array of string | required | Unique identifiers of the [Service](#service)s. |
+| `ServiceIds` | array of string | required | Unique identifiers of the [Service](services.md#service)s. |
 
 ### Response
 
@@ -226,23 +226,23 @@ Returns all products offered together with the specified services.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Products` | array of [Product](#product) | required | Products offered with the service. |
+| `Products` | array of [Product](services.md#product) | required | Products offered with the service. |
 
 #### Product
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the product. |
-| `ServiceId` | string | required | Unique identifier of the [Service](#service). |
+| `ServiceId` | string | required | Unique identifier of the [Service](services.md#service). |
 | `CategoryId` | string | optional | Unique identifier of the Product category. |
 | `IsActive` | boolean | required | Whether the product is still active. |
 | `Name` | string | required | Name of the product. |
 | `ShortName` | string | required | Short name of the product. |
 | `Description` | string | optional | Description of the product. |
-| `Charging` | string [Product charging](#product-charging) | required | Charging of the product. |
-| `Posting` | string [Product posting](#product-posting) | required | Posting of the product. |
-| `Promotions` | [Promotions](#promotions) | required | Promotions of the service. |
-| `Classifications` | [Product classifications](#product-classifications) | required | Classifications of the service. |
+| `Charging` | string [Product charging](services.md#product-charging) | required | Charging of the product. |
+| `Posting` | string [Product posting](services.md#product-posting) | required | Posting of the product. |
+| `Promotions` | [Promotions](services.md#promotions) | required | Promotions of the service. |
+| `Classifications` | [Product classifications](services.md#product-classifications) | required | Classifications of the service. |
 | `Price` | [Currency value](finance.md#currency-value) | required | Price of the product. |
 
 #### Product charging
@@ -315,7 +315,7 @@ Returns all business segments of the default service provided by the enterprise.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `BusinessSegments` | array of [Business segment](#business-segment) | required | Business segments of the default service. |
+| `BusinessSegments` | array of [Business segment](services.md#business-segment) | required | Business segments of the default service. |
 
 #### Business segment
 
@@ -355,7 +355,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceIds` | array of string | required | Unique identifiers of the [Service](#service)s from which the rates are requested. |
-| `Extent` | [Rate extent](#rate-extent) | required | Extent of data to be returned. |
+| `Extent` | [Rate extent](services.md#rate-extent) | required | Extent of data to be returned. |
 
 #### Rate extent
 
@@ -397,16 +397,16 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Rates` | array of [Rate](#rate) | required | Rates of the default service. |
-| `RateGroups` | array of [Rate group](#rate-group) | required | Rate groups of the default service. |
+| `Rates` | array of [Rate](services.md#rate) | required | Rates of the default service. |
+| `RateGroups` | array of [Rate group](services.md#rate-group) | required | Rate groups of the default service. |
 
 #### Rate
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Id` | string | required | Unique identifier of the rate. |
-| `GroupId` | string | required | Unique identifier of [Rate group](#rate-group) where the rate belongs. |
-| `BaseRateId` | string | required | Unique identifier of the base [Rate](#rate). |
+| `GroupId` | string | required | Unique identifier of [Rate group](services.md#rate-group) where the rate belongs. |
+| `BaseRateId` | string | required | Unique identifier of the base [Rate](services.md#rate). |
 | `ServiceId` | string | required | Unique identifier of the [Service](#service). |
 | `IsActive` | boolean | required | Whether the rate is still active. |
 | `IsPublic` | boolean | required | Whether the rate is publicly available. |
@@ -447,7 +447,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `RateId` | string | required | Unique identifier of the [Rate](#rate) whose prices should be returned. |
+| `RateId` | string | required | Unique identifier of the [Rate](services.md#rate) whose prices should be returned. |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
@@ -548,8 +548,8 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `RateId` | string | required | Unique identifier of the base [Rate](#rate) to update. |
-| `PriceUpdates` | array of [Price update](#price-update) | required | Price updates. |
+| `RateId` | string | required | Unique identifier of the base [Rate](services.md#rate) to update. |
+| `PriceUpdates` | array of [Price update](services.md#price-update) | required | Price updates. |
 
 #### Price update
 
@@ -610,7 +610,7 @@ Returns all restrictions of the default service provided by the enterprise.
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceIds` | array of string | required | Unique identifiers of the [Service](#service)s from which the restrictions are requested. |
 | `ResourceCategoryIds` | array of string | optional | Unique identifiers of [Resource categories](enterprises.md#resource-category). |
-| `RateIds` | array of string | optional | Unique identifiers of [Rate](#rate)s. |
+| `RateIds` | array of string | optional | Unique identifiers of [Rate](services.md#rate)s. |
 | `CollidingUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Restriction](#restriction) is active. Required if no other filter is provided. |
 | `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Restriction](#restriction) was created. |
 | `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional | Interval in which the [Restriction](#restriction) was updated. |
@@ -689,7 +689,7 @@ Returns all restrictions of the default service provided by the enterprise.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Restrictions` | array of [Restriction](#restriction) | required | Restrictions of the default service. |
+| `Restrictions` | array of [Restriction](services.md#restriction) | required | Restrictions of the default service. |
 
 #### Restriction
 
@@ -698,22 +698,22 @@ Returns all restrictions of the default service provided by the enterprise.
 | `Id` | string | required | Unique identifier of the restriction. |
 | `ServiceId` | string | required | Unique identifier of the [Service](#service). |
 | `ExternalIdentifier` | string | optional | External identifier of the restriction. |
-| `Conditions` | string | required | [Conditions](#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
-| `Exceptions` | string | optional | [Exceptions](#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
+| `Conditions` | string | required | [Conditions](services.md#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
+| `Exceptions` | string | optional | [Exceptions](services.md#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
 
 #### Restriction Conditions
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Type` | string | required | [Restriction type](#restriction-type). |
-| `ExactRateId` | string | optional | Unique identifier of the restricted [Exact rate](#rate). |
-| `BaseRateId` | string | optional | Unique identifier of the restricted [Base rate](#rate). |
-| `RateGroupId` | string | optional | Unique identifier of the restricted [Rate group](#rate-group). |
+| `Type` | string | required | [Restriction type](services.md#restriction-type). |
+| `ExactRateId` | string | optional | Unique identifier of the restricted [Exact rate](services.md#rate). |
+| `BaseRateId` | string | optional | Unique identifier of the restricted [Base rate](services.md#rate). |
+| `RateGroupId` | string | optional | Unique identifier of the restricted [Rate group](services.md#rate-group). |
 | `ResourceCategoryId` | string | optional | Unique identifier of the restricted [Resource category](enterprises.md#resource-category). |
 | `ResourceType` | string | optional | Name of the restricted [Resource type](#resource-type). |
 | `StartUtc` | string | optional | Start of the restricted interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | End of the restricted interval in UTC timezone in ISO 8601 format. |
-| `Days` | array of string [Day](#day) | required | The restricted days of week. |
+| `Days` | array of string [Day](services.md#day) | required | The restricted days of week. |
 
 #### Restriction Exceptions
 
@@ -801,15 +801,15 @@ Adds new restrictions with the specified conditions.
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceId` | string | required | Unique identifier of the [Service](#service) restrictions will be added in. |
-| `Restrictions` | array of [Restriction parameters](#restriction-parameters) | required | Parameters of restrictions. |
+| `Restrictions` | array of [Restriction parameters](services.md#restriction-parameters) | required | Parameters of restrictions. |
 
 #### Restriction parameters
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Identifier` | string | optional | Identifier of the restriction within the transaction. |
 | `ExternalIdentifier` | string | optional | External identifier of the restriction. |
-| `Conditions` | string | required | [Conditions](#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
-| `Exceptions` | string | optional | [Exceptions](#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
+| `Conditions` | string | required | [Conditions](services.md#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
+| `Exceptions` | string | optional | [Exceptions](services.md#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
 
 ### Response
 
@@ -885,14 +885,14 @@ Adds new restrictions with the specified conditions.
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Restrictions` | array of [Added restriction](#added-restriction) | required | The added restrictions. |
+| `Restrictions` | array of [Added restriction](services.md#added-restriction) | required | The added restrictions. |
 
 #### Added restriction
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
 | `Identifier` | string | optional | Identifier of the restriction within the transaction. |
-| `Restriction` | [Restriction](#restriction) | required | The added restriction. |
+| `Restriction` | [Restriction](services.md#restriction) | required | The added restriction. |
 
 ## Delete restrictions
 
@@ -919,7 +919,7 @@ Removes restrictions from the service.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `RestrictionIds` | array of string | required | Unique identifiers of the [Restriction](#restriction)s. |
+| `RestrictionIds` | array of string | required | Unique identifiers of the [Restriction](services.md#restriction)s. |
 
 ### Response
 
@@ -972,19 +972,19 @@ Creates a new order with the specified products and items. Only positive charges
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `CustomerId` | string | required | Identifier of the [Customer](customers.md#customer) to be charged. |
-| `ServiceId` | string | required | Identifier of the [Service](#service) to be ordered. |
+| `ServiceId` | string | required | Identifier of the [Service](services.md#service) to be ordered. |
 | `ConsumptionUtc` | string | optional | Date and time of the order consumption in UTC timezone in ISO 8601 format. If not specified, current date and time is used. |
 | `Notes` | string | optional | Additional notes of the order. |
-| `ProductOrders` | array of [Product order parameters](#product-order-parameters) | optional | Parameters of the ordered products. |
-| `Items` | array of [Item parameters](#item-parameters) | optional | Parameters of the ordered custom items. |
+| `ProductOrders` | array of [Product order parameters](services.md#product-order-parameters) | optional | Parameters of the ordered products. |
+| `Items` | array of [Item parameters](services.md#item-parameters) | optional | Parameters of the ordered custom items. |
 
 #### Product order parameters
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `ProductId` | string | required | Unique identifier of the [Product](#product) to be ordered. |
+| `ProductId` | string | required | Unique identifier of the [Product](services.md#product) to be ordered. |
 | `Count` | number | optional | Count of products to be ordered, e.g. 10 in case of 10 beers. |
-| `UnitAmount` | [Amount](#amount-parameters) | optional | Unit amount of the product that overrides the amount defined in Mews. |
+| `UnitAmount` | [Amount](services.md#amount-parameters) | optional | Unit amount of the product that overrides the amount defined in Mews. |
 
 #### Item parameters
 
@@ -992,7 +992,7 @@ Creates a new order with the specified products and items. Only positive charges
 | --- | --- | --- | --- |
 | `Name` | string | required | Name of the item. |
 | `UnitCount` | number | required | Count of units to be ordered, e.g. 10 in case of 10 beers. |
-| `UnitAmount` | [Amount](#amount-parameters) | required | Unit amount, e.g. amount for one beer \(note that total amount of the item is therefore `UnitAmount` times `UnitCount`\). |
+| `UnitAmount` | [Amount](services.md#amount-parameters) | required | Unit amount, e.g. amount for one beer \(note that total amount of the item is therefore `UnitAmount` times `UnitCount`\). |
 | `AccountingCategoryId` | string | optional | Unique identifier of an [Accounting category](finance.md#accounting-category) to be assigned to the item. |
 
 #### Amount parameters
@@ -1049,7 +1049,7 @@ Returns all companionships based on customers, reservations or reservation group
 | `CustomerIds` | array of string | optional | Unique identifiers of [Customer](customers.md#customer)s. |
 | `ReservationIds` | array of string | optional | Unique identifiers of [Reservation](reservations.md#reservation)s. |
 | `ReservationGroupIds` | array of string | optional | Unique identifiers of [Reservation group](reservations.md#reservation-group)s. |
-| `Extent` | [Companionship extent](#companionship-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the companionships, customers, reservations, and reservation groups should be also returned. |
+| `Extent` | [Companionship extent](services.md#companionship-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the companionships, customers, reservations, and reservation groups should be also returned. |
 
 #### Companionship extent
 
@@ -1079,7 +1079,7 @@ Returns all companionships based on customers, reservations or reservation group
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Companionships` | array of [Companionship](#companionship) | required | Companionships. |
+| `Companionships` | array of [Companionship](services.md#companionship) | required | Companionships. |
 | `Customers` | array of [Customer](customers.md#customer) | optional | Customers that belong to the companionships. |
 | `Reservations` | array of [Reservation](reservations.md#reservation) | optional | The accompanied reservations. |
 | `ReservationGroups` | array of [Reservation group](reservations.md#reservation-group) | optional | The accompanied reservation groups. |
@@ -1088,7 +1088,7 @@ Returns all companionships based on customers, reservations or reservation group
 
 | Property | Type |  | Description |
 | --- | --- | --- | --- |
-| `Id` | string | required | Unique identifier of [Companionship](#Companionship). |
+| `Id` | string | required | Unique identifier of [Companionship](services.md#Companionship). |
 | `CustomerId` | string | required | Unique identifier of [Customer](customers.md#customer). |
 | `ReservationId` | string | optional | Unique identifier of [Reservation](reservations.md#reservation). |
 | `ReservationGroupId` | string | required | Unique identifier of [Reservation group](reservations.md#reservation-group). |


### PR DESCRIPTION
#### Changelog notes 

```
A month ago we announced the [project Spacetime](https://developers.mews.com/project-spacetime/) whose main objective is to generalize the notion of services and spaces. And later, also the time units. We're pleased to announce that the first phase is now available in the Connector API. We're deprecating lot of things, we're generalizing spaces into resources, we're introducing the possibility to have multiple "visit" services, not just a single one etc. There are no breaking changes in the API, all of the previous endpoints and capabilities are still working and will be working until the end of the deprecation period. However we'd like to ask you to migrate as soon as possible, we're not able to roll out the new possibilities to our clients if you are not ready. If we did that, it would break the connection. Therefore we rely on you and your timely cooperation because we want to give this new opportunity to the hotels as soon as possible. We acknowledge it's a lot of changes, we're prepared to monitor the situation and help you with any questions or concerns, feel free to contact us at integrations@mews.com.

* All "space" fields and entities are now renamed to the "resource". 
* Added [Resource](operations/enterprises.md#resource) that is replacing the Space. It can have multiple categories through multiple services. Note that Resource does not need to be assigned to any category.
* Added [Resource category](operations/enterprises.md#resource-category) that is replacing the Space category.
* Added [Resource category image assignment](operations/enterprises.md#resource-category-image-assignment) that links an image to a category.
* Added [Resource category assignment](operations/enterprises.md#resource-category-assignment) that links a resource to a category. Note that resource can be assigned only to a single category within the same service.
* Added [Resource feature](operations/enterprises.md#resource-feature) that is replacing the Space feature and now is within the service context.
* Added [Resource feature assignment](operations/enterprises.md#resource-feature-assignment) that is replacing the Space feature assignment.
* Added [Resource block](operations/enterprises.md#resource-block) that is replacing the Space block. Note that a resource without any category can be assigned to a block.
* Added [Get all resources](operations/enterprises.md#get-all-resources) that is replacing Get all spaces.
* Added [Update resources](operations/enterprises.md#update-resources).
* Added [Get all resource blocks](operations/enterprises.md#get-all-resource-blocks) that is replacing Get all space blocks.
* Added [Add resource blocks](operations/enterprises.md#add-resource-block) that is replacing Add space block.
* Added [Delete resource blocks](operations/enterprises.md#delete-resource-blocks) that is replacing Delete space blocks.
* Extended [Get all reservations](operations/reservations.md#get-all-reservations) parameters with required `ServiceIds` and `AssignedResourceIds` that is replacing `SpaceIds`.
* Extended [Get all reservations](operations/reservations.md#get-all-reservations) response with `Resources`, `ResourceCategories` that is replacing `Spaces`, `SpaceCategories` and `ResourceCategoryAssignments`.
* Extended [Reservation extent](operations/reservations.md#reservation-extent) with `ResourceCategories`, `ResourceCategoryAssignments` and `Resources` that is replacing the `Spaces`.
* Extended [Reservation](operations/reservations.md#reservation) with `AssignedResourceId` and `AssignedResourceLocked` that is replacing `AssignedSpaceId` and `AssignedSpaceLocked`.
* Extended [Update reservation](operations/reservations.md#update-reservation) parameters with `AssignedResourceId` that is replacing Update reservation space.
* Extended [Search customers](operations/customers.md#search-customers) parameters with `ResourceId` that is replacing `SpaceId`.
* Extended [Get all business segments](operations/services.md#get-all-business-segments) parameters with required `ServiceIds`.
* Extended [Get all rates](operations/services.md#get-all-rates) parameters with required `ServiceIds`.
* Extended [Get all restrictions](operations/services.md#get-all-restrictions) parameters with required `ServiceIds` and `ResourceCategoryIds` that is replacing `SpaceCategoryIds`.
* Extended [Add restrictions](operations/services.md#get-all-rates) parameters with required `ServiceId`.
* Extended [Restriction](operations/services.md#restriction) with `ServiceId` and `ResourceCategoryId`, `ResourceCategoryType` that is replacing `SpaceCategoryId`, `SpaceType`.
* Extended [Restriction conditions](operations/services.md#restriction-conditions) with `ResourceCategoryId`, `ResourceCategoryType` that is replacing `SpaceCategoryId`, `SpaceType`,
* Extended [Business segment](operations/services.md#business-segment) with `ServiceId`.
* Extended [Rate](operations/services.md#rate) with `ServiceId`.
* Extended [Rate group](operations/services.md#rate-group) with `ServiceId`.
* Renamed `Space category availability` to [Resource category availability](operations/services.md#resource-category-availability).
* Renamed `Space category pricing` to [Resource category pricing](operations/services.md#resource-category-pricing).
* Renamed `Space category adjustment` to [Resource category adjustment](operations/services.md#resource-category-adjustment).
* Removed `Update space state` which is replaced by general Update resources.
* Removed `Update reservation requested category`. [Update reservation](operations/reservations.md#update-reservation) should be used instead.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
