### PR TITLE
Consumption date for charged once and per person

### DIFF
--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -1040,8 +1040,8 @@ Adds a new product order of the specified product to the reservation.
 | `ReservationId` | string | required | Unique identifier of the [Reservation](reservations.md#reservation). |
 | `ProductId` | string | required | Unique identifier of the [Product](services.md#product). |
 | `Count` | int | required | The amount of the products to be added. Note that if the product is charged e.g. per night, count 1 means a single product every night. Count 2 means two products every night. |
-| `StartUtc` | string | optional | Product start in UTC timezone in ISO 8601 format e.g. it is not possible to specify for products with charging `Once` and `PerPerson`.. |
-| `EndUtc` | string | optional | Product end in UTC timezone in ISO 8601 format e.g. it is not possible to specify for products with charging `Once` and `PerPerson`.. |
+| `StartUtc` | string | optional | Product start in UTC timezone in ISO 8601 format. For products with charging `Once` and `PerPerson` must be set to same value as `EndUtc`. |
+| `EndUtc` | string | optional | Product end in UTC timezone in ISO 8601 format. For products with charging `Once` and `PerPerson` must be set to same value as `StartUtc`. |
 | `UnitAmount` | [Amount](services.md#amount-parameters) | optional | Price of the product that overrides the price defined in Mews. |
 
 ### Response

--- a/operations/services.md
+++ b/operations/services.md
@@ -1178,8 +1178,8 @@ Creates a new order with the specified products and items. Only positive charges
 | `ProductId` | string | required | Unique identifier of the [Product](services.md#product) to be ordered. |
 | `Count` | number | optional | Count of products to be ordered, e.g. 10 in case of 10 beers. |
 | `UnitAmount` | [Amount](services.md#amount-parameters) | optional | Unit amount of the product that overrides the amount defined in Mews. |
-| `StartUtc` | string | optional | Product start in UTC timezone in ISO 8601 format. It is not possible to specify for products with charging `Once` and `PerPerson`. |
-| `EndUtc` | string | optional | Product end in UTC timezone in ISO 8601 format. It is not possible to specify for products with charging `Once` and `PerPerson` . |
+| `StartUtc` | string | optional | Product start in UTC timezone in ISO 8601 format. For products with charging `Once` and `PerPerson` must be set to same value as `EndUtc`. |
+| `EndUtc` | string | optional | Product end in UTC timezone in ISO 8601 format. For products with charging `Once` and `PerPerson` must be set to same value as `StartUtc`. |
 
 #### Item parameters
 


### PR DESCRIPTION
#### Changelog notes 

```
* Extended operations [Add reservations](operations/reservations.md#add-reservations), [Add reservation product](operations/reservations.md#add-reservation-product) and [Add order](operations/services.md#add-order) with possibility to specify consumption date for products charged `Once` and `Per Person`.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
