### PR TITLE
replace Gender property with Sex

### DIFF
--- a/operations/customers.md
+++ b/operations/customers.md
@@ -85,7 +85,7 @@ Returns all customers filtered by identifiers, emails, names and other filters.
             "CreatedUtc": "2016-01-01T00:00:00Z",
             "Email": null,
             "FirstName": "John",
-            "Gender": "Male",
+            "Sex": "Male",
             "Id": "35d4b117-4e60-44a3-9580-c582117eff98",
             "IdentityCard": null,
             "LanguageCode": null,
@@ -133,7 +133,7 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 | `LastName` | string | required | Last name of the customer. |
 | `SecondLastName` | string | optional | Second last name of the customer. |
 | `Title` | string [Title](customers.md#title) | optional | Title prefix of the customer. |
-| `Gender` | string [Gender](customers.md#gender) | optional | Gender of the customer. |
+| `Sex` | string [Sex](customers.md#Sex) | optional | Sex of the customer. |
 | `NationalityCode` | string | optional | ISO 3166-1 code of the [Country](configuration.md#country). |
 | `LanguageCode` | string | optional | Language and culture code of the customers preferred language. E.g. `en-US` or `fr-FR`. |
 | `BirthDate` | string | optional | Date of birth in ISO 8601 format. |
@@ -159,7 +159,7 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 * `Miss`
 * `Misses`
 
-#### Gender
+#### Sex
 
 * `Male`
 * `Female`
@@ -247,7 +247,7 @@ Searches for customers that are active at the moment in the enterprise \(e.g. co
                 "CreatedUtc": "2016-01-01T00:00:00Z",
                 "Email": null,
                 "FirstName": "John",
-                "Gender": "Male",
+                "Sex": "Male",
                 "Id": "35d4b117-4e60-44a3-9580-c582117eff98",
                 "IdentityCard": null,
                 "LanguageCode": null,
@@ -373,7 +373,7 @@ Adds a new customer to the system and returns details of the added customer. If 
     "LastName": "Doe",
     "SecondLastName": "the Second",
     "Title": "Mister",
-    "Gender": "Male",
+    "Sex": "Male",
     "NationalityCode": "US",
     "BirthDate": "2000-01-01",
     "BirthPlace": "Prague, Czech Republic",
@@ -412,7 +412,7 @@ Adds a new customer to the system and returns details of the added customer. If 
 | `LastName` | string | required | Last name of the customer. |
 | `SecondLastName` | string | optional | Second last name of the customer. |
 | `Title` | string [Title](customers.md#title) | optional | Title prefix of the customer. |
-| `Gender` | string [Gender](customers.md#gender) | optional | Gender of the customer. |
+| `Sex` | string [Sex](customers.md#Sex) | optional | Sex of the customer. |
 | `NationalityCode` | string | optional | ISO 3166-1 code of the [Country](configuration.md#country). |
 | `BirthDate` | string | optional | Date of birth in ISO 8601 format. |
 | `BirthPlace` | string | optional | Place of birth. |
@@ -465,7 +465,7 @@ Updates personal information of a customer. Note that if any of the fields is le
     "LastName": "Smith",
     "SecondLastName": "the Second",
     "Title": "Mister",
-    "Gender": "Male",
+    "Sex": "Male",
     "NationalityCode": "US",
     "BirthDate": "2000-01-01",
     "BirthPlace": "Prague, Czech Republic",
@@ -498,7 +498,7 @@ Updates personal information of a customer. Note that if any of the fields is le
 | `LastName` | string | optional | New last name. |
 | `SecondLastName` | string | optional | New second last name. |
 | `Title` | string [Title](customers.md#title) | optional | New title. |
-| `Gender` | string [Gender](customers.md#gender) | optional | Gender of the customer. |
+| `Sex` | string [Sex](customers.md#Sex) | optional | Sex of the customer. |
 | `BirthDate` | string | optional | New birth date in ISO 8601 format. |
 | `BithPlace` | string | optional | New birth place. |
 | `NationalityCode` | string | optional | ISO 3166-1 code of the [Country](configuration.md#country). |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -102,7 +102,7 @@ Returns all reservations specified by any identifier, customer or other filter. 
             "CreatedUtc": "2016-01-01T00:00:00Z",
             "Email": null,
             "FirstName": "John",
-            "Gender": null,
+            "Sex": null,
             "Id": "35d4b117-4e60-44a3-9580-c582117eff98",
             "IdentityCard": null,
             "LanguageCode": null,


### PR DESCRIPTION
#### Changelog notes 

```
* Replaced `Gender` property with `Sex` for operations [Add customer](operations/customers.md#add-customer), [Update customer](operations/customers.md#update-customer), [Get all customers](operations/customers.md#get-all-customer), [Search customers](operations/customers.md#search-customers) and [Get all reservations](operations/reservations.md#get-all-reservations) and all other usages.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
