### PR TITLE
fix typo in tax rate hyperlink in orders/add

### DIFF
--- a/operations/services.md
+++ b/operations/services.md
@@ -1246,7 +1246,7 @@ Creates a new order with the specified products and items. Only positive charges
 | `GrossValue` | decimal | optional | Amount including tax. Required for [Gross enviroments](configuration.md#pricing). |
 | `NetValue` | decimal | optional | Amount excluding tax. Required for [Net enviroments](configuration.md#pricing). |
 | `Currency` | string | required | ISO-4217 code of the [Currency](configuration.md#currency). |
-| `TaxCodes` | array of string [Tax Codes](configuration.md#tax-rate) | required | Tax codes to be applied to the item. (Note, you can only define one tax when sending `GrossValue`. For multiple taxes, use `NetValue`)|
+| `TaxCodes` | array of string [Tax rate](configuration.md#tax-rate) Codes | required | Tax codes to be applied to the item. (Note, you can only define one tax when sending `GrossValue`. For multiple taxes, use `NetValue`)|
 
 ### Response
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -1246,7 +1246,7 @@ Creates a new order with the specified products and items. Only positive charges
 | `GrossValue` | decimal | optional | Amount including tax. Required for [Gross enviroments](configuration.md#pricing). |
 | `NetValue` | decimal | optional | Amount excluding tax. Required for [Net enviroments](configuration.md#pricing). |
 | `Currency` | string | required | ISO-4217 code of the [Currency](configuration.md#currency). |
-| `TaxCodes` | array of string [Tax Codes](configuration.md#tax-rates) | required | Tax codes to be applied to the item. (Note, you can only define one tax when sending `GrossValue`. For multiple taxes, use `NetValue`)|
+| `TaxCodes` | array of string [Tax Codes](configuration.md#tax-rate) | required | Tax codes to be applied to the item. (Note, you can only define one tax when sending `GrossValue`. For multiple taxes, use `NetValue`)|
 
 ### Response
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -1246,7 +1246,7 @@ Creates a new order with the specified products and items. Only positive charges
 | `GrossValue` | decimal | optional | Amount including tax. Required for [Gross enviroments](configuration.md#pricing). |
 | `NetValue` | decimal | optional | Amount excluding tax. Required for [Net enviroments](configuration.md#pricing). |
 | `Currency` | string | required | ISO-4217 code of the [Currency](configuration.md#currency). |
-| `TaxCodes` | array of string [Tax rate](configuration.md#tax-rate) Codes | required | Tax codes to be applied to the item. (Note, you can only define one tax when sending `GrossValue`. For multiple taxes, use `NetValue`)|
+| `TaxCodes` | array of string | required | Codes of [Tax rate](configuration.md#tax-rate)s to be applied to the item. (Note, you can only define one tax when sending `GrossValue`. For multiple taxes, use `NetValue`)|
 
 ### Response
 


### PR DESCRIPTION
#### Changelog notes 

```
* Added/Extended operations....
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
