### PR TITLE
update Add Credit Card Payment endpoint description

### DIFF
--- a/operations/finance.md
+++ b/operations/finance.md
@@ -1390,7 +1390,9 @@ Returns all preauthorizations of specified customers.
 
 ## Add credit card payment
 
-Adds a new credit card payment to a bill of the specified customer. Note that the payment is added to open bill of the customer, either to the specified one or the default one. So the bill has to be later settled in Mews. So e.g. payment terminal integration should use this operation to post payments taken through the terminal.
+Adds a new credit card payment to a bill of the specified customer. Note that the payment is added to open bill of the customer, either to the specified one or the default one. This operation only serves to record a credit card payment that has already been taken outside of Mews or Mews' payment terminal, and does not actually charge the customer's credit card. 
+
+The bill can then be closed manually by a Mews user, or automatically via API with the [Close bill](finance.md#close-bill) operation. 
 
 ### Request
 


### PR DESCRIPTION
The old description was wrong. It was suggesting that integration partners use this endpoint to record a payment taken through a terminal - which is confusing now that Mews has its own Terminal solution for which payment items are automatically generated via the Add Terminal Payment operation.

#### Changelog notes 

```
* Added/Extended operations....
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
