### PR TITLE
platform vs api address naming

### DIFF
--- a/guidelines/requests.md
+++ b/guidelines/requests.md
@@ -3,11 +3,11 @@
 The API accepts only `HTTP POST` requests with `Content-Type` set to `application/json` and JSON content depending on the operation to be performed. All operations follow this address pattern:
 
 ```text
-[ApiAddress]/api/connector/v1/[Resource]/[Operation]
+[PlatformAddress]/api/connector/v1/[Resource]/[Operation]
 ```
 
-* **ApiAddress** - Base address of the MEWS API, depends on environment \(testing, staging, production\).
-* **PlatformAddress** - Address of the MEWS web application, depends on environment \(testing, staging, production\).
+* **PlatformAddress** - Base address of the MEWS API, depends on environment \(testing, staging, production\).
+* **MewsWebApplicationAddress** - Address of the MEWS web application, depends on environment \(testing, staging, production\).
 * **Resource** - Logical group of operations, in most cases identifies target of the operations.
 * **Operation** - Name of the operation to be performed.
 


### PR DESCRIPTION
Everywhere else in the documentation, platform address refers to the api.mews-demo or mews.li address for sending API requests, and MewsWebApplicationAddress for the URL used to log into Mews PMS (app.mews-demo or mews.li). 

This was the last place where it was different
![image](https://user-images.githubusercontent.com/57252634/119639591-0bb78080-be18-11eb-93f8-ac8eb93c9122.png)


rest of the gitboook

![image](https://user-images.githubusercontent.com/57252634/119639176-a5326280-be17-11eb-9ee4-4143d3c42676.png)


![image](https://user-images.githubusercontent.com/57252634/119639434-e591e080-be17-11eb-8c45-9a6800d3b096.png)


#### Changelog notes 

```
* Added/Extended operations....
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
