### PR TITLE
Add filtering on customers/getAll for deleted customer

### DIFF
--- a/operations/customers.md
+++ b/operations/customers.md
@@ -60,7 +60,7 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 | `LoyaltyCodes` | array of string | optional, max 1000 items | Loyalty codes of the [Customer](customers.md#customer)s. |
 | `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was created. |
 | `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was updated. |
-| `DeletedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was deleted, operational only when `ActivityState` - `Deleted` is supplied |
+| `DeletedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was deleted. `ActivityStates` value `Deleted` should be provided with this filter to get expected results. |
 | `ActivityStates` | array of string [Activity state](services.md#activity-state) | optional | Whether return only active, only deleted or both records. |
 | `Extent` | [Customer extent](customers.md#customer-extent) | required | Extent of data to be returned. |
 
@@ -600,4 +600,3 @@ Attaches the specified file to the customer profile.
 ```javascript
 {}
 ```
-

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -60,15 +60,9 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 | `LoyaltyCodes` | array of string | optional, max 1000 items | Loyalty codes of the [Customer](customers.md#customer)s. |
 | `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was created. |
 | `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was updated. |
-| `DeletedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was deleted. |
-| `ActivityStates` | array of string [Activity state](#activity-state) | optional | Whether return only active, only deleted or both records. |
+| `DeletedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was deleted, operational only when `ActivityState` - `Deleted` is supplied |
+| `ActivityStates` | array of string [Activity state](services.md#activity-state) | optional | Whether return only active, only deleted or both records. |
 | `Extent` | [Customer extent](customers.md#customer-extent) | required | Extent of data to be returned. |
-
-#### Activity state
-
-* `Active` - Active records.
-* `Deleted`- Deleted records.
-* `All`- Active and Deleted records.
 
 #### Customer extent
 

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -36,7 +36,10 @@ Returns all customers filtered by identifiers, emails, names and other filters.
     "UpdatedUtc": {
         "StartUtc": "2019-12-10T00:00:00Z",
         "EndUtc": "2019-12-17T00:00:00Z"
-    }
+    },
+    "ActivityStates": [
+        "Active"
+    ],
     "Extent" : {
         "Customers": "true",
         "Documents": "true",
@@ -57,7 +60,15 @@ Returns all customers filtered by identifiers, emails, names and other filters.
 | `LoyaltyCodes` | array of string | optional, max 1000 items | Loyalty codes of the [Customer](customers.md#customer)s. |
 | `CreatedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was created. |
 | `UpdatedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was updated. |
+| `DeletedUtc` | [Time interval](enterprises.md#time-interval) | optional, max length 3 months | Interval in which [Customer](customers.md#customer) was deleted. |
+| `ActivityStates` | array of string [Activity state](#activity-state) | optional | Whether return only active, only deleted or both records. |
 | `Extent` | [Customer extent](customers.md#customer-extent) | required | Extent of data to be returned. |
+
+#### Activity state
+
+* `Active` - Active records.
+* `Deleted`- Deleted records.
+* `All`- Active and Deleted records.
 
 #### Customer extent
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -2012,7 +2012,7 @@ Returns all rate vouchers filtered by [Service](#service), voucher code or vouch
 
 * `Active` - active records (the validity might be restricted by another parameter i.e. interval).
 * `Deleted`- deleted records.
-* `All`- both all and deleted records.
+* `All`- both active and deleted records.
 
 ### Response
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -2012,6 +2012,7 @@ Returns all rate vouchers filtered by [Service](#service), voucher code or vouch
 
 * `Active` - active records (the validity might be restricted by another parameter i.e. interval).
 * `Deleted`- deleted records.
+* `All`- both all and deleted records.
 
 ### Response
 


### PR DESCRIPTION
#### Changelog notes 

```
* Added [Get Deleted Customers](operations/customers.md#get-all-customers) filtering with `DeletedUtc`.
* Filtering by `DeletedUtc` is only enabled when [Activity States](operations/customers.md#activity-state) field is provided as `Deleted` or `All`.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
