### PR TITLE
Update reservations.md

### DIFF
--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -44,8 +44,8 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `TimeFilter` | string [Reservation time filter](#reservation-time-filter) | optional | Time filter of the interval. If not specified, reservations `Colliding` with the interval are returned. |
-| `StartUtc` | string | required, max length 3 months | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required, max length 3 months | End of the interval in UTC timezone in ISO 8601 format. |
+| `StartUtc` | string | optional, max length 3 months | Start of the interval in UTC timezone in ISO 8601 format. Required when used in conjunction with the `TimeFilter` or `States` search parameter.|
+| `EndUtc` | string | optional, max length 3 months | End of the interval in UTC timezone in ISO 8601 format. Required when used in conjunction with the `TimeFilter` or `States` search parameter.|
 | `ServiceIds` | array of string | required, max 1000 items | Unique identifiers of the [Service](services.md#service)s from which the reservations are requested. |
 | `ReservationIds` | array of string | optional, max 1000 items | Unique identifiers of the requested [Reservation](reservations.md#reservation)s. |
 | `GroupIds` | array of string | optional, max 1000 items | Unique identifiers of the requested [Reservation group](reservations.md#reservation-group)s. |


### PR DESCRIPTION
#### Changelog notes 
Question from integration partner:
> While testing Get all reservations I was able to get reservations by ReservationIds without providing StartUtc and EndUtc parameters - both of which are marked as required in the documentation and there is nothing in there that would suggest that they are not required in case of providing the Ids - is this some bug that will be fixed or is this expected behavior and can we create our integration assuming this will work?

update intended to clarify when it is required and when it is not. Mimicking description in other parameters.

![image](https://user-images.githubusercontent.com/57252634/135445651-c0f3eb4c-8b83-4520-81d8-ebdb9d02c267.png)

```
* Added/Extended operations....
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
