### PR TITLE
Rates endpoint - TimeUnit interval

### DIFF
--- a/operations/services.md
+++ b/operations/services.md
@@ -56,7 +56,7 @@ Returns all services offered by the enterprise.
                     "EndOffset": "P0M0DT12H0M0S",
                     "OccupancyStartOffset": "P0M0DT15H0M0S",
                     "OccupancyEndOffset": "P0M0DT12H0M0S",
-                    "TimeUnit": "Day"
+                    "TimeUnitPeriod": "Day"
                 }
             }
         }
@@ -97,7 +97,7 @@ Returns all services offered by the enterprise.
 | `EndOffset` | string | required | Offset from the end of the time unit defining the default end of the service orders in ISO 8601 duration format. |
 | `OccupancyStartOffset` | string | required | Offset from the start of the time unit defining the occupancy start of the service in ISO 8601 duration format that is considered regarding the availability and reporting. |
 | `OccupancyEndOffset` | string | required | Offset from the end of the time unit defining the occupancy end of the service in ISO 8601 duration format that is considered regarding the availability and reporting. |
-| `TimeUnit` | [Time unit period](#time-unit-period) | required | Time unit period of the service. |
+| `TimeUnitPeriod` | [Time unit period](#time-unit-period) | required | Time unit period of the service. |
 
 #### Time unit
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -116,7 +116,7 @@ Negative or zero end offsets of the daily time unit define the daily service as 
 ![](../.gitbook/assets/timeunits-connector-day.png)
 
 #### Time unit interval length restrictions
-Interval length is allowed for up to 100 time units, but no more than 2 years.
+Interval length created between FirstTimeUnit StartUtc and LastTimeUnit StartUtc is allowed for up to 100 time units, but no more than 2 years.
 
 #### Time unit period
 
@@ -1106,8 +1106,8 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `RateId` | string | required | Unique identifier of the [Rate](services.md#rate) whose prices should be returned. |
-| `FirstTimeUnit` | [TimeUnit](#time-unit) | required, [max length](#time-unit-interval-length-restrictions) | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](#time-unit) | required, [max length](#time-unit-interval-length-restrictions) | Last TimeUnit of the interval. |
+| `FirstTimeUnit` | [TimeUnit](#time-unit) | required, Time unit interval [max length](#time-unit-interval-length-restrictions) applies. | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](#time-unit) | required, Time unit interval [max length](#time-unit-interval-length-restrictions) applies. | Last TimeUnit of the interval. |
 
 ### Response
 
@@ -1222,8 +1222,8 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 | Property | Type | Contract | Description |
 | --- | --- | --- | --- |
 | `CategoryId` | string | optional | Unique identifier of the [Resource category](enterprises.md#resource-category) whose prices to update. If not specified, base price is updated. |
-| `FirstTimeUnit` | [TimeUnit](#time-unit) | required, [max length](#time-unit-interval-length-restrictions) | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](#time-unit) | required, [max length](#time-unit-interval-length-restrictions) | Last TimeUnit of the interval. |
+| `FirstTimeUnit` | [TimeUnit](#time-unit) | required, Time unit interval [max length](#time-unit-interval-length-restrictions) applies. | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](#time-unit) | required, Time unit interval [max length](#time-unit-interval-length-restrictions) applies. | Last TimeUnit of the interval. |
 | `Value` | number | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
 
 ### Response

--- a/operations/services.md
+++ b/operations/services.md
@@ -1156,7 +1156,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | --- | --- | --- | --- |
 | `Currency` | string | required | ISO-4217 code of the [Currency](configuration.md#currency). |
 | `DatesUtc` | array of string | required | Covered dates in UTC timezone in ISO 8601 format. |
-| `TimeUnits` | array of [TimeUnit](#time-unit) | required | Covered time units in UTC timezone |
+| `TimeUnits` | array of [TimeUnit](#time-unit) | required | Covered time units in UTC timezone. |
 | `BasePrices` | array of number | required | Base prices of the rate in the covered dates. |
 | `CategoryPrices` | array of [Resource category pricing](#resource-category-pricing) | required | Resource category prices. |
 | `CategoryAdjustments` | array of [Resource category adjustment](#resource-category-adjustment) | required | Resource category adjustments. |

--- a/operations/services.md
+++ b/operations/services.md
@@ -99,8 +99,10 @@ Returns all services offered by the enterprise.
 | `OccupancyEndOffset` | string | required | Offset from the end of the time unit defining the occupancy end of the service in ISO 8601 duration format that is considered regarding the availability and reporting. |
 | `TimeUnit` | [Time unit period](#time-unit-period) | required | Time unit period of the service. |
 
+
+#### Time unit start and end
 Time units represent a fixed, finite time interval: a minute, a day, a month, etc. A Time unit defines the operable periods for a bookable service.
-We think of the daily time unit as the physical time unit that starts at midnight and ends at midnight the following day. The monthly time unit is time unit that starts at mightnight of the first day of the month and ends at midnight of the first day of the following month.
+We think of the daily time unit as the physical time unit that starts at midnight and ends at midnight the following day. A monthly time unit is a time unit that starts at midnight on the first day of the month and ends at midnight on the first day of the following month.
 
 
 Start offsets are anchored to the start of the time unit and end offsets are anchored to the end of the time unit.
@@ -112,6 +114,9 @@ Positive end offsets of the daily time unit define the nightly service as depict
 
 Negative or zero end offsets of the daily time unit define the daily service as depicted on the picture below.
 ![](../.gitbook/assets/timeunits-connector-day.png)
+
+#### Time unit interval length restrictions
+Interval length is allowed for up to 100 time units, but no more than 2 years.
 
 #### Time unit period
 
@@ -1074,7 +1079,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 
 ## Get rate pricing
 
-Returns prices of a rate in the specified interval. Note that response contains prices for all dates that the specified interval intersects. So e.g. interval `1st Jan 13:00 - 1st Jan 14:00` will result in one price for `1st Jan`. Interval `1st Jan 23:00 - 2nd Jan 01:00` will result in two prices for `1st Jan` and `2nd Jan`. Interval length is allowed for up to 100 time units, but no more than 2 years.
+Returns prices of a rate in the specified interval. Note that response contains prices for all dates that the specified interval intersects. So e.g. interval `1st Jan 00:00 - 1st Jan 00:00` will result in one price for `1st Jan`. Interval `1st Jan 00:00 - 2nd Jan 00:00` will result in two prices for `1st Jan` and `2nd Jan`. Other time part of interval than [time unit start](#time-unit-start-and-end) is not supported. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
 
 ### Request
 
@@ -1101,8 +1106,8 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `RateId` | string | required | Unique identifier of the [Rate](services.md#rate) whose prices should be returned. |
-| `FirstTimeUnit` | [TimeUnit](#time-unit) | required | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](#time-unit) | required | Last TimeUnit of the interval. |
+| `FirstTimeUnit` | [TimeUnit](#time-unit) | required, [max length](#time-unit-interval-length-restrictions) | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](#time-unit) | required, [max length](#time-unit-interval-length-restrictions) | Last TimeUnit of the interval. |
 
 ### Response
 
@@ -1168,7 +1173,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 
 ## Update rate price
 
-Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Resource category](enterprises.md#resource-category), otherwise updates the base price for all resource categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`, future updates are allowed for up to 100 time units, but no more than 2 years.
+Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Resource category](enterprises.md#resource-category), otherwise updates the base price for all resource categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
 
 ### Request
 
@@ -1217,8 +1222,8 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 | Property | Type | Contract | Description |
 | --- | --- | --- | --- |
 | `CategoryId` | string | optional | Unique identifier of the [Resource category](enterprises.md#resource-category) whose prices to update. If not specified, base price is updated. |
-| `FirstTimeUnit` | [TimeUnit](#time-unit) | required | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](#time-unit) | required | Last TimeUnit of the interval. |
+| `FirstTimeUnit` | [TimeUnit](#time-unit) | required, [max length](#time-unit-interval-length-restrictions) | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](#time-unit) | required, [max length](#time-unit-interval-length-restrictions) | Last TimeUnit of the interval. |
 | `Value` | number | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
 
 ### Response

--- a/operations/services.md
+++ b/operations/services.md
@@ -1077,7 +1077,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 
 ## Get rate pricing
 
-Returns prices of a rate in the specified interval. Note that response contains prices for all time units that the specified interval intersects. So e.g. interval `1st Jan 00:00 - 1st Jan 00:00` will result in one price for `1st Jan`. Interval `1st Jan 00:00 - 2nd Jan 00:00` will result in two prices for `1st Jan` and `2nd Jan`. Other time part of interval than [time unit start](#time-unit-start-and-end) is not supported. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
+Returns prices of a rate in the specified interval. Note that response contains prices for all time units that the specified interval intersects. So e.g. interval `1st Jan 00:00 - 1st Jan 00:00` will result in one price for `1st Jan`. Interval `1st Jan 00:00 - 2nd Jan 00:00` will result in two prices for `1st Jan` and `2nd Jan`. Other time part of interval than [time unit start](#time-unit) is not supported. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
 
 ### Request
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -1101,8 +1101,8 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `RateId` | string | required | Unique identifier of the [Rate](services.md#rate) whose prices should be returned. |
-| `FirstTimeUnit` | [TimeUnit](services.md#time-unit) | required | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](services.md#time-unit) | required | Last TimeUnit of the interval. |
+| `FirstTimeUnit` | [TimeUnit](#time-unit) | required | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](#time-unit) | required | Last TimeUnit of the interval. |
 
 ### Response
 
@@ -1217,8 +1217,8 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 | Property | Type | Contract | Description |
 | --- | --- | --- | --- |
 | `CategoryId` | string | optional | Unique identifier of the [Resource category](enterprises.md#resource-category) whose prices to update. If not specified, base price is updated. |
-| `FirstTimeUnit` | [TimeUnit](services.md#time-unit) | required | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](services.md#time-unit) | required | Last TimeUnit of the interval. |
+| `FirstTimeUnit` | [TimeUnit](#time-unit) | required | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](#time-unit) | required | Last TimeUnit of the interval. |
 | `Value` | number | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
 
 ### Response

--- a/operations/services.md
+++ b/operations/services.md
@@ -97,10 +97,11 @@ Returns all services offered by the enterprise.
 | `EndOffset` | string | required | Offset from the end of the time unit defining the default end of the service orders in ISO 8601 duration format. |
 | `OccupancyStartOffset` | string | required | Offset from the start of the time unit defining the occupancy start of the service in ISO 8601 duration format that is considered regarding the availability and reporting. |
 | `OccupancyEndOffset` | string | required | Offset from the end of the time unit defining the occupancy end of the service in ISO 8601 duration format that is considered regarding the availability and reporting. |
-| `TimeUnit` | [Time unit](#time-unit) | required | Time unit of the service. |
+| `TimeUnit` | [Time unit period](#time-unit-period) | required | Time unit period of the service. |
 
-Time units represent a fixed, finite time interval: a minute, a day, a month, etc. A Time unit defines the operable periods for a bookable service. We currently only support the Day unit.
-We think of the daily time unit as the physical time unit that starts at midnight and ends at midnight the following day.
+Time units represent a fixed, finite time interval: a minute, a day, a month, etc. A Time unit defines the operable periods for a bookable service.
+We think of the daily time unit as the physical time unit that starts at midnight and ends at midnight the following day. The monthly time unit is time unit that starts at mightnight of the first day of the month and ends at midnight of the first day of the following month.
+
 
 Start offsets are anchored to the start of the time unit and end offsets are anchored to the end of the time unit.
 `StartOffset` and `EndOffset` define the default start and end of the service (so, the service orders).
@@ -112,10 +113,17 @@ Positive end offsets of the daily time unit define the nightly service as depict
 Negative or zero end offsets of the daily time unit define the daily service as depicted on the picture below.
 ![](../.gitbook/assets/timeunits-connector-day.png)
 
-#### Time unit
+#### Time unit period
 
 * `Day`
+* `Month`
 * ...
+
+#### Time unit
+
+| Property | Type | Contract | Description |
+| --- | --- | --- | --- |
+| `StartUtc` | string | required | Base start of the TimeUnit in UTC timezone in ISO 8601 format. |
 
 #### Additional service data
 
@@ -1093,16 +1101,8 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `RateId` | string | required | Unique identifier of the [Rate](services.md#rate) whose prices should be returned. |
-| `FirstTimeUnit` | [TimeUnit](services.md#rates-get-price-timeunit) | required | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](services.md#rates-get-price-timeunit) | required | Last TimeUnit of the interval. |
-
-<h4 id="rates-get-price-timeunit">
-TimeUnit
-</h4>
-
-| Property | Type | Contract | Description |
-| --- | --- | --- | --- |
-| `StartUtc` | string | required | Base start of the TimeUnit in UTC timezone in ISO 8601 format. |
+| `FirstTimeUnit` | [TimeUnit](services.md#time-unit) | required | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](services.md#time-unit) | required | Last TimeUnit of the interval. |
 
 ### Response
 
@@ -1217,17 +1217,9 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 | Property | Type | Contract | Description |
 | --- | --- | --- | --- |
 | `CategoryId` | string | optional | Unique identifier of the [Resource category](enterprises.md#resource-category) whose prices to update. If not specified, base price is updated. |
-| `FirstTimeUnit` | [TimeUnit](services.md#rates-update-price-timeunit) | required | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](services.md#rates-update-price-timeunit) | required | Last TimeUnit of the interval. |
+| `FirstTimeUnit` | [TimeUnit](services.md#time-unit) | required | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](services.md#time-unit) | required | Last TimeUnit of the interval. |
 | `Value` | number | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
-
-<h4 id="rates-update-price-timeunit">
-TimeUnit
-</h4>
-
-| Property | Type | Contract | Description |
-| --- | --- | --- | --- |
-| `StartUtc` | string | required | Base start of the TimeUnit in UTC timezone in ISO 8601 format. |
 
 ### Response
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -114,13 +114,9 @@ Positive end offsets of the daily time unit define the nightly service as depict
 Negative or zero end offsets of the daily time unit define the daily service as depicted on the picture below.
 ![](../.gitbook/assets/timeunits-connector-day.png)
 
-| Property | Type | Contract | Description |
-| --- | --- | --- | --- |
-| `StartUtc` | string | required | Base start of the TimeUnit in UTC timezone in ISO 8601 format. |
-
 #### Time unit interval length restrictions
 
-Interval length created between FirstTimeUnit StartUtc and LastTimeUnit StartUtc is allowed for up to 100 time units, but no more than 2 years.
+Interval length created between FirstTimeUnitStartUtc and LastTimeUnitStartUtc is allowed for up to 100 time units, but no more than 2 years.
 
 #### Time unit period
 
@@ -1077,7 +1073,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 
 ## Get rate pricing
 
-Returns prices of a rate in the specified interval. Note that response contains prices for all time units that the specified interval intersects. So e.g. interval `1st Jan 00:00 - 1st Jan 00:00` will result in one price for `1st Jan`. Interval `1st Jan 00:00 - 2nd Jan 00:00` will result in two prices for `1st Jan` and `2nd Jan`. Other time part of interval than [time unit start](#time-unit) is not supported. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
+Returns prices of a rate in the specified interval. Note that response contains prices for all time units that the specified interval intersects. So e.g. interval `1st Jan 00:00 - 1st Jan 00:00` will result in one price for `1st Jan`. Interval `1st Jan 00:00 - 2nd Jan 00:00` will result in two prices for `1st Jan` and `2nd Jan`. Other time part of interval than [time unit start](#time-unit) is not supported. [Time unit interval length restrictions](#time-unit-interval-length-restrictions) applies.
 
 ### Request
 
@@ -1089,12 +1085,8 @@ Returns prices of a rate in the specified interval. Note that response contains 
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
     "RateId": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
-    "FirstTimeUnit": {
-        "StartUtc": "2022-01-01T23:00:00.000Z"
-    },
-    "LastTimeUnit": {
-        "StartUtc": "2022-01-03T23:00:00.000Z"
-    }
+    "FirstTimeUnitStartUtc": "2022-01-01T23:00:00.000Z",
+    "LastTimeUnitStartUtc": "2022-01-03T23:00:00.000Z"
 }
 ```
 
@@ -1104,8 +1096,8 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `RateId` | string | required | Unique identifier of the [Rate](services.md#rate) whose prices should be returned. |
-| `FirstTimeUnit` | [TimeUnit](#time-unit) | required, Time unit interval [max length](#time-unit-interval-length-restrictions) applies. | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](#time-unit) | required, Time unit interval [max length](#time-unit-interval-length-restrictions) applies. | Last TimeUnit of the interval. |
+| `FirstTimeUnitStartUtc` | string | required, [Time unit interval length restrictions](#time-unit-interval-length-restrictions) applies. | Start of the time unit interval in UTC timezone in ISO 8601 format. |
+| `LastTimeUnitStartUtc` | string | required, [Time unit interval length restrictions](#time-unit-interval-length-restrictions) applies. | End of the time unit interval in UTC timezone in ISO 8601 format. |
 
 ### Response
 
@@ -1133,21 +1125,10 @@ Returns prices of a rate in the specified interval. Note that response contains 
             "Prices": [ 20, 20, 20 ]
         }
     ],
-    "DatesUtc": [
-        "2022-01-01T23:00:00Z",
-        "2022-01-02T23:00:00Z",
+    "TimeUnitStartsUtc": [
+        "2022-01-01T23:00:00Z"
+        "2022-01-02T23:00:00Z"
         "2022-01-03T23:00:00Z"
-    ],
-    "TimeUnits": [
-        {
-            "StartUtc": "2022-01-01T23:00:00Z"
-        },
-        {
-            "StartUtc": "2022-01-02T23:00:00Z"
-        },
-        {
-            "StartUtc": "2022-01-03T23:00:00Z"
-        }
     ]
 }
 ```
@@ -1155,8 +1136,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | Property | Type | Contract | Description |
 | --- | --- | --- | --- |
 | `Currency` | string | required | ISO-4217 code of the [Currency](configuration.md#currency). |
-| `DatesUtc` | array of string | required | Covered dates in UTC timezone in ISO 8601 format. |
-| `TimeUnits` | array of [TimeUnit](#time-unit) | required | Covered time units in UTC timezone. |
+| `TimeUnitStartsUtc` | array of string | required | Covered time units starts in UTC timezone. |
 | `BasePrices` | array of number | required | Base prices of the rate in the covered dates. |
 | `CategoryPrices` | array of [Resource category pricing](#resource-category-pricing) | required | Resource category prices. |
 | `CategoryAdjustments` | array of [Resource category adjustment](#resource-category-adjustment) | required | Resource category adjustments. |
@@ -1183,7 +1163,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 
 ## Update rate price
 
-Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Resource category](enterprises.md#resource-category), otherwise updates the base price for all resource categories. Note that prices are defined per time unit (i.e. daily), so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all time units that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
+Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Resource category](enterprises.md#resource-category), otherwise updates the base price for all resource categories. Note that prices are defined per time unit (i.e. daily), so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all time units that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`. [Time unit interval length restrictions](#time-unit-interval-length-restrictions) applies.
 
 ### Request
 
@@ -1197,22 +1177,14 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
     "RateId": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
     "PriceUpdates": [
         {
-            "FirstTimeUnit": {
-                "StartUtc": "2016-09-01T00:00:00Z"
-            },
-            "LastTimeUnit": {
-                "StartUtc": "2016-09-02T00:00:00Z"
-            },
+            "FirstTimeUnitStartUtc": "2022-01-01T23:00:00.000Z",
+            "LastTimeUnitStartUtc": "2022-01-03T23:00:00.000Z",
             "Value": 111
         },
         {
             "CategoryId": "e3aa3117-dff0-46b7-b49a-2c0391e70ff9",
-            "FirstTimeUnit": {
-                "StartUtc": "2016-09-04T00:00:00Z"
-            }
-            "LastTimeUnit": {
-                "StartUtc": "2016-09-05T00:00:00Z"
-            },
+            "FirstTimeUnitStartUtc": "2022-01-04T23:00:00.000Z",
+            "LastTimeUnitStartUtc": "2022-01-05T23:00:00.000Z",
             "Value": 222
         }
     ]
@@ -1232,8 +1204,8 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 | Property | Type | Contract | Description |
 | --- | --- | --- | --- |
 | `CategoryId` | string | optional | Unique identifier of the [Resource category](enterprises.md#resource-category) whose prices to update. If not specified, base price is updated. |
-| `FirstTimeUnit` | [TimeUnit](#time-unit) | required, Time unit interval [max length](#time-unit-interval-length-restrictions) applies. | First TimeUnit of the interval. |
-| `LastTimeUnit` | [TimeUnit](#time-unit) | required, Time unit interval [max length](#time-unit-interval-length-restrictions) applies. | Last TimeUnit of the interval. |
+| `FirstTimeUnitStartUtc` | string | required, [Time unit interval length restrictions](#time-unit-interval-length-restrictions) applies. | Start of the time unit interval in UTC timezone in ISO 8601 format. |
+| `LastTimeUnitStartUtc` | string | required, [Time unit interval length restrictions](#time-unit-interval-length-restrictions) applies. | End of the time unit interval in UTC timezone in ISO 8601 format. |
 | `Value` | number | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
 
 ### Response

--- a/operations/services.md
+++ b/operations/services.md
@@ -1136,7 +1136,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | Property | Type | Contract | Description |
 | --- | --- | --- | --- |
 | `Currency` | string | required | ISO-4217 code of the [Currency](configuration.md#currency). |
-| `TimeUnitStartsUtc` | array of string | required | Covered time units starts in UTC timezone. |
+| `TimeUnitStartsUtc` | array of string | required | Covered time unit starts in the UTC timezone in ISO 8601 format. |
 | `BasePrices` | array of number | required | Base prices of the rate in the covered dates. |
 | `CategoryPrices` | array of [Resource category pricing](#resource-category-pricing) | required | Resource category prices. |
 | `CategoryAdjustments` | array of [Resource category adjustment](#resource-category-adjustment) | required | Resource category adjustments. |

--- a/operations/services.md
+++ b/operations/services.md
@@ -99,11 +99,10 @@ Returns all services offered by the enterprise.
 | `OccupancyEndOffset` | string | required | Offset from the end of the time unit defining the occupancy end of the service in ISO 8601 duration format that is considered regarding the availability and reporting. |
 | `TimeUnit` | [Time unit period](#time-unit-period) | required | Time unit period of the service. |
 
+#### Time unit
 
-#### Time unit start and end
 Time units represent a fixed, finite time interval: a minute, a day, a month, etc. A Time unit defines the operable periods for a bookable service.
 We think of the daily time unit as the physical time unit that starts at midnight and ends at midnight the following day. A monthly time unit is a time unit that starts at midnight on the first day of the month and ends at midnight on the first day of the following month.
-
 
 Start offsets are anchored to the start of the time unit and end offsets are anchored to the end of the time unit.
 `StartOffset` and `EndOffset` define the default start and end of the service (so, the service orders).
@@ -115,7 +114,12 @@ Positive end offsets of the daily time unit define the nightly service as depict
 Negative or zero end offsets of the daily time unit define the daily service as depicted on the picture below.
 ![](../.gitbook/assets/timeunits-connector-day.png)
 
+| Property | Type | Contract | Description |
+| --- | --- | --- | --- |
+| `StartUtc` | string | required | Base start of the TimeUnit in UTC timezone in ISO 8601 format. |
+
 #### Time unit interval length restrictions
+
 Interval length created between FirstTimeUnit StartUtc and LastTimeUnit StartUtc is allowed for up to 100 time units, but no more than 2 years.
 
 #### Time unit period
@@ -123,12 +127,6 @@ Interval length created between FirstTimeUnit StartUtc and LastTimeUnit StartUtc
 * `Day`
 * `Month`
 * ...
-
-#### Time unit
-
-| Property | Type | Contract | Description |
-| --- | --- | --- | --- |
-| `StartUtc` | string | required | Base start of the TimeUnit in UTC timezone in ISO 8601 format. |
 
 #### Additional service data
 
@@ -1092,10 +1090,10 @@ Returns prices of a rate in the specified interval. Note that response contains 
     "Client": "Sample Client 1.0.0",
     "RateId": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
     "FirstTimeUnit": {
-        "StartUtc": "2017-01-01T00:00:00.000Z"
+        "StartUtc": "2022-01-01T23:00:00.000Z"
     },
     "LastTimeUnit": {
-        "StartUtc": "2017-01-03T00:00:00.000Z"
+        "StartUtc": "2022-01-03T23:00:00.000Z"
     }
 }
 ```
@@ -1136,9 +1134,20 @@ Returns prices of a rate in the specified interval. Note that response contains 
         }
     ],
     "DatesUtc": [
-        "2016-12-31T23:00:00Z",
-        "2017-01-01T23:00:00Z",
-        "2017-01-02T23:00:00Z"
+        "2022-01-01T23:00:00Z",
+        "2022-01-02T23:00:00Z",
+        "2022-01-03T23:00:00Z"
+    ],
+    "TimeUnits": [
+        {
+            "StartUtc": "2022-01-01T23:00:00Z"
+        },
+        {
+            "StartUtc": "2022-01-02T23:00:00Z"
+        },
+        {
+            "StartUtc": "2022-01-03T23:00:00Z"
+        }
     ]
 }
 ```
@@ -1147,6 +1156,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | --- | --- | --- | --- |
 | `Currency` | string | required | ISO-4217 code of the [Currency](configuration.md#currency). |
 | `DatesUtc` | array of string | required | Covered dates in UTC timezone in ISO 8601 format. |
+| `TimeUnits` | array of [TimeUnit](#time-unit) | required | Covered time units in UTC timezone |
 | `BasePrices` | array of number | required | Base prices of the rate in the covered dates. |
 | `CategoryPrices` | array of [Resource category pricing](#resource-category-pricing) | required | Resource category prices. |
 | `CategoryAdjustments` | array of [Resource category adjustment](#resource-category-adjustment) | required | Resource category adjustments. |

--- a/operations/services.md
+++ b/operations/services.md
@@ -1079,7 +1079,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 
 ## Get rate pricing
 
-Returns prices of a rate in the specified interval. Note that response contains prices for all dates that the specified interval intersects. So e.g. interval `1st Jan 00:00 - 1st Jan 00:00` will result in one price for `1st Jan`. Interval `1st Jan 00:00 - 2nd Jan 00:00` will result in two prices for `1st Jan` and `2nd Jan`. Other time part of interval than [time unit start](#time-unit-start-and-end) is not supported. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
+Returns prices of a rate in the specified interval. Note that response contains prices for all time units that the specified interval intersects. So e.g. interval `1st Jan 00:00 - 1st Jan 00:00` will result in one price for `1st Jan`. Interval `1st Jan 00:00 - 2nd Jan 00:00` will result in two prices for `1st Jan` and `2nd Jan`. Other time part of interval than [time unit start](#time-unit-start-and-end) is not supported. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
 
 ### Request
 
@@ -1173,7 +1173,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 
 ## Update rate price
 
-Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Resource category](enterprises.md#resource-category), otherwise updates the base price for all resource categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
+Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Resource category](enterprises.md#resource-category), otherwise updates the base price for all resource categories. Note that prices are defined per time unit (i.e. daily), so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all time units that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`. Time unit max length [restrictions](#time-unit-interval-length-restrictions) applies.
 
 ### Request
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -1066,7 +1066,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 
 ## Get rate pricing
 
-Returns prices of a rate in the specified interval. Note that response contains prices for all dates that the specified interval intersects. So e.g. interval `1st Jan 13:00 - 1st Jan 14:00` will result in one price for `1st Jan`. Interval `1st Jan 23:00 - 2nd Jan 01:00` will result in two prices for `1st Jan` and `2nd Jan`.
+Returns prices of a rate in the specified interval. Note that response contains prices for all dates that the specified interval intersects. So e.g. interval `1st Jan 13:00 - 1st Jan 14:00` will result in one price for `1st Jan`. Interval `1st Jan 23:00 - 2nd Jan 01:00` will result in two prices for `1st Jan` and `2nd Jan`. Interval length is allowed for up to 100 time units, but no more than 2 years.
 
 ### Request
 
@@ -1078,8 +1078,12 @@ Returns prices of a rate in the specified interval. Note that response contains 
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
     "RateId": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
-    "StartUtc":"2017-01-01T00:00:00.000Z",
-    "EndUtc":"2017-01-03T00:00:00.000Z"
+    "FirstTimeUnit": {
+        "StartUtc": "2017-01-01T00:00:00.000Z"
+    },
+    "LastTimeUnit": {
+        "StartUtc": "2017-01-03T00:00:00.000Z"
+    }
 }
 ```
 
@@ -1089,8 +1093,16 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `RateId` | string | required | Unique identifier of the [Rate](services.md#rate) whose prices should be returned. |
-| `StartUtc` | string | required, max length 3 months | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required, max length 3 months | End of the interval in UTC timezone in ISO 8601 format. |
+| `FirstTimeUnit` | [TimeUnit](services.md#rates-get-price-timeunit) | required | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](services.md#rates-get-price-timeunit) | required | Last TimeUnit of the interval. |
+
+<h4 id="rates-get-price-timeunit">
+TimeUnit
+</h4>
+
+| Property | Type | Contract | Description |
+| --- | --- | --- | --- |
+| `StartUtc` | string | required | Base start of the TimeUnit in UTC timezone in ISO 8601 format. |
 
 ### Response
 
@@ -1156,7 +1168,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 
 ## Update rate price
 
-Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Resource category](enterprises.md#resource-category), otherwise updates the base price for all resource categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`, future updates are allowed for up to 5 years.
+Updates price of a rate in the specified intervals. If the `CategoryId` is specified, updates price of the corresponding [Resource category](enterprises.md#resource-category), otherwise updates the base price for all resource categories. Note that prices are defined daily, so when the server receives the UTC interval, it first converts it to enterprise timezone and updates the price on all dates that the interval intersects. Only root rates can be updated (the rates that have no base rate, that have `BaseRateId` set to `null`). It's not allowed to update past prices outside of `EditableHistoryInterval`, future updates are allowed for up to 100 time units, but no more than 2 years.
 
 ### Request
 
@@ -1170,14 +1182,22 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
     "RateId": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
     "PriceUpdates": [
         {
-            "StartUtc": "2016-09-01T00:00:00Z",
-            "EndUtc": "2016-09-02T00:00:00Z",
+            "FirstTimeUnit": {
+                "StartUtc": "2016-09-01T00:00:00Z"
+            },
+            "LastTimeUnit": {
+                "StartUtc": "2016-09-02T00:00:00Z"
+            },
             "Value": 111
         },
         {
             "CategoryId": "e3aa3117-dff0-46b7-b49a-2c0391e70ff9",
-            "StartUtc": "2016-09-04T00:00:00Z",
-            "EndUtc": "2016-09-05T00:00:00Z",
+            "FirstTimeUnit": {
+                "StartUtc": "2016-09-04T00:00:00Z"
+            }
+            "LastTimeUnit": {
+                "StartUtc": "2016-09-05T00:00:00Z"
+            },
             "Value": 222
         }
     ]
@@ -1197,9 +1217,17 @@ Updates price of a rate in the specified intervals. If the `CategoryId` is speci
 | Property | Type | Contract | Description |
 | --- | --- | --- | --- |
 | `CategoryId` | string | optional | Unique identifier of the [Resource category](enterprises.md#resource-category) whose prices to update. If not specified, base price is updated. |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
+| `FirstTimeUnit` | [TimeUnit](services.md#rates-update-price-timeunit) | required | First TimeUnit of the interval. |
+| `LastTimeUnit` | [TimeUnit](services.md#rates-update-price-timeunit) | required | Last TimeUnit of the interval. |
 | `Value` | number | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
+
+<h4 id="rates-update-price-timeunit">
+TimeUnit
+</h4>
+
+| Property | Type | Contract | Description |
+| --- | --- | --- | --- |
+| `StartUtc` | string | required | Base start of the TimeUnit in UTC timezone in ISO 8601 format. |
 
 ### Response
 


### PR DESCRIPTION
#### Changelog notes 

```
* Extended [Time unit period](operations/services.md#time-unit-period) with Month.
* Added [Time unit](operations/services.md#time-unit).
* Extended [Get rate pricing](operations/services.md#get-rate-pricing) with FirstTimeUnitStartUtc, LastTimeUnitStartUtc and info about max interval length.
* Extended [Get rate pricing](operations/services.md#get-rate-pricing) return value with TimeUnitStartsUtc
* Removed DatesUtc from [Get rate pricing](operations/services.md#get-rate-pricing) return value
* Extended [Update rate price](operations/services.md#update-rate-price) with FirstTimeUnitStartUtc, LastTimeUnitStartUtc and info about max interval length.
* Removed TimeUnit from [Bookable service data](operations/services.md#bookable-service-data)
* Added TimeUnitPeriod to [Bookable service data](operations/services.md#bookable-service-data)
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
