### PR TITLE
Add OrderItems to ReservationsExtent

### DIFF
--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -74,7 +74,9 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | :-- | :-- | :-- | :-- |
 | `BusinessSegments` | bool | optional | Whether the response should contain business segmentation. |
 | `Customers` | bool | optional | Whether the response should contain customers of the reservations. |
-| `Items` | bool | optional | Whether the response should contain reservation items. |
+| `CustomersAddresses` | bool | optional | Whether the response should contain customer adresses. |
+| `CustomerIdentityDocuments` | bool | optional | Whether the response should contain customer identity documents. |
+| `OrderItems` | bool | optional | Whether the response should contain reservation items. |
 | `Products` | bool | optional | Whether the response should contain products orderable with the reservations. |
 | `Rates` | bool | optional | Whether the response should contain rates and rate groups. |
 | `Reservations` | bool | optional | Whether the response should contain reservations. |
@@ -85,6 +87,7 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `ResourceCategoryAssignments` | bool | optional | Whether the response should contain assignments of the resources to categories. |
 | `Notes` | bool | optional | Whether the response should contain notes. |
 | `QrCodeData` | bool | optional | Whether the response should contain QR code data. |
+| `Companies` | bool | optional | Whether the response should contain companies. |
 | `AccountingStates` | array of string [Accounting item state](accountingitems.md#accounting-item-state) | optional | States the items should be in. If not specified, items in `Open` or `Closed` states are returned. |
 
 ### Response

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -74,8 +74,6 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | :-- | :-- | :-- | :-- |
 | `BusinessSegments` | bool | optional | Whether the response should contain business segmentation. |
 | `Customers` | bool | optional | Whether the response should contain customers of the reservations. |
-| `CustomersAddresses` | bool | optional | Whether the response should contain customer adresses. |
-| `CustomerIdentityDocuments` | bool | optional | Whether the response should contain customer identity documents. |
 | `OrderItems` | bool | optional | Whether the response should contain reservation items. |
 | `Products` | bool | optional | Whether the response should contain products orderable with the reservations. |
 | `Rates` | bool | optional | Whether the response should contain rates and rate groups. |


### PR DESCRIPTION
#### Changelog notes 

```
## 25th April 2022 11:00 UTC

* Extended operations [Get all reservations](../operations/reservations.md#get-all-reservations) with `OrderItems` in `ReservationExtent` to prevent double serialization of Items.
```

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
