### PR TITLE
Added limitation to message and message-threads

### DIFF
--- a/operations/messages.md
+++ b/operations/messages.md
@@ -19,6 +19,10 @@ Get all messages belonging to the specified [Message threads](messagethreads.md#
     "CreatedUtc": {
         "StartUtc": "2022-03-03T00:00:00Z",
         "EndUtc": "2022-03-14T00:00:00Z"
+    },
+    "Limitation":{
+        "Cursor": "e7f26210-10e7-462e-9da8-ae8300be8ab7",
+        "Count": 10
     }
 }
 ```
@@ -30,6 +34,7 @@ Get all messages belonging to the specified [Message threads](messagethreads.md#
 | `Client` | string | required | Name and version of the client application. |
 | `MessageThreadIds` | array of string | required, max 1000 items | Unique identifiers of [Message threads](messagethreads.md#message-thread) from where to return messages. |
 | `CreatedUtc` | [Time interval](messagethreads.md#time-interval) | optional, max length 1 months | Interval in which the [Message](#message) was created. |
+| `Limitation` | [Limitation](messagethreads.md#limitation) | required | Limitation applied to the fetched messages. |
 
 ### Response
 
@@ -45,13 +50,15 @@ Get all messages belonging to the specified [Message threads](messagethreads.md#
             },
             "CreatedUtc": "2022-03-09T13:19:46Z"
         }
-    ]
+    ],
+    "Cursor": "8d02142f-31cf-4115-90bf-ae5200c7a1ba"
 }
 ```
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Messages` | array of [Messages](#message) | required | The filtered messages. |
+| `Cursor` | string | required | Index of the last message Id. Should be used in [Limitation](messagethreads.md#limitation) to fetch older messages in the follow-up request. |
 
 #### Message
 

--- a/operations/messages.md
+++ b/operations/messages.md
@@ -34,7 +34,7 @@ Get all messages belonging to the specified [Message threads](messagethreads.md#
 | `Client` | string | required | Name and version of the client application. |
 | `MessageThreadIds` | array of string | required, max 1000 items | Unique identifiers of [Message threads](messagethreads.md#message-thread) from where to return messages. |
 | `CreatedUtc` | [Time interval](messagethreads.md#time-interval) | optional, max length 1 months | Interval in which the [Message](#message) was created. |
-| `Limitation` | [Limitation](messagethreads.md#limitation) | required | Limitation applied to the fetched messages. |
+| `Limitation` | [Limitation](messagethreads.md#limitation) | required | Limitation on the quantity of message data returned (using cursor pagination). |
 
 ### Response
 

--- a/operations/messages.md
+++ b/operations/messages.md
@@ -2,7 +2,7 @@
 
 ## Get all messages
 
-Get all messages belonging to the specified [Message threads](messagethreads.md#message-thread). Messages can only be returned for message threads you have created.
+Get all messages belonging to the specified [Message threads](messagethreads.md#message-thread). Messages can only be returned for message threads you have created. Note this operation uses the `Limitation` property to implement a form of data pagination and thus limit the quantity of items returned.
 
 ### Request
 
@@ -58,7 +58,7 @@ Get all messages belonging to the specified [Message threads](messagethreads.md#
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Messages` | array of [Messages](#message) | required | The filtered messages. |
-| `Cursor` | string | optional | Index of the last message Id. Should be used in [Limitation](messagethreads.md#limitation) to fetch older messages in the follow-up request. |
+| `Cursor` | string | optional | Unique identifier of the last and hence oldest message returned. This can be used in [Limitation](messagethreads.md#limitation) in a subsequent request to fetch the next batch of older messages. |
 
 #### Message
 

--- a/operations/messages.md
+++ b/operations/messages.md
@@ -58,7 +58,7 @@ Get all messages belonging to the specified [Message threads](messagethreads.md#
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Messages` | array of [Messages](#message) | required | The filtered messages. |
-| `Cursor` | string | required | Index of the last message Id. Should be used in [Limitation](messagethreads.md#limitation) to fetch older messages in the follow-up request. |
+| `Cursor` | string | optional | Index of the last message Id. Should be used in [Limitation](messagethreads.md#limitation) to fetch older messages in the follow-up request. |
 
 #### Message
 

--- a/operations/messagethreads.md
+++ b/operations/messagethreads.md
@@ -32,7 +32,7 @@ Get all message threads that you have created, filtered by time interval and/or 
 | `MessageThreadIds` | array of string | optional, max 1000 items | Unique identifiers of [Message threads](#message-thread). Required if no other filter is provided. |
 | `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was created. Required if no other filter is provided. |
 | `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was updated. Required if no other filter is provided. |
-| `Limitation` | [Limitation](#limitation) | required | Limitation applied to the fetched message threads. |
+| `Limitation` | [Limitation](#limitation) | required | Limitation on the quantity of message data returned (using cursor pagination). |
 
 #### Time interval
 

--- a/operations/messagethreads.md
+++ b/operations/messagethreads.md
@@ -2,7 +2,7 @@
 
 ## Get all message threads
 
-Get all message threads that you have created, filtered by time interval and/or specific message thread IDs.
+Get all message threads that you have created, filtered by time interval and/or specific message thread IDs. Note this operation uses the `Limitation` property to implement a form of data pagination and thus limit the quantity of items returned.
 
 ### Request
 
@@ -32,7 +32,7 @@ Get all message threads that you have created, filtered by time interval and/or 
 | `MessageThreadIds` | array of string | optional, max 1000 items | Unique identifiers of [Message threads](#message-thread). Required if no other filter is provided. |
 | `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was created. Required if no other filter is provided. |
 | `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was updated. Required if no other filter is provided. |
-| `Limitation` | [Limitation](#limitation) | required | Limitation on the quantity of message data returned (using cursor pagination). |
+| `Limitation` | [Limitation](#limitation) | required | Limitation on the quantity of message thread data returned (using cursor pagination). |
 
 #### Time interval
 
@@ -45,8 +45,13 @@ Get all message threads that you have created, filtered by time interval and/or 
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Cursor` | string | optional | Id of the item prior to which the returned items are going to be skipped. |
-| `Count` | number | required, max count 1000 | Number of items returned by the endpoint. |
+| `Cursor` | string | optional | Unique identifier of the item one newer in time order than the items to be returned. If Cursor is not specified, i.e. null, then the latest or most recent items will be returned. Note that the response message will include the identifier of the oldest item in the response, which can then be used in subsequent calls - see Limitation example below. |
+| `Count` | number | required | Count of items to be returned, minimum 1, maximum 1000. |
+
+> **Limitation example:**
+> A request with Cursor set to null and Count set to 10 will return the latest or most recent 10 items, and the value of Cursor in the response will reference the oldest of those 10 items returned.
+> Let's say the value of Cursor returned is "12345", then if a subsequent request is made with Cursor set to "12345" and Count set to 10, then the next oldest 10 items will be returned.
+> This process can be repeated as required to fetch historical data.
 
 ### Response
 
@@ -68,7 +73,7 @@ Get all message threads that you have created, filtered by time interval and/or 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `MessageThreads` | array of [Message threads](#message-thread) | required | The filtered message threads. |
-| `Cursor` | string | optional | Index of the last message thread Id. Should be used in [Limitation](#limitation) to fetch older message threads in the follow-up request. |
+| `Cursor` | string | optional | Unique identifier of the last and hence oldest message thread returned. This can be used in [Limitation](#limitation) in a subsequent request to fetch the next batch of older message threads. |
 
 #### Message thread
 

--- a/operations/messagethreads.md
+++ b/operations/messagethreads.md
@@ -16,6 +16,10 @@ Get all message threads that you have created, filtered by time interval and/or 
     "CreatedUtc":{
         "StartUtc": "2022-03-03T00:00:00Z",
         "EndUtc": "2022-03-14T00:00:00Z"
+    },
+    "Limitation":{
+        "Cursor": "e7f26210-10e7-462e-9da8-ae8300be8ab7",
+        "Count": 10
     }
 }
 ```
@@ -28,6 +32,7 @@ Get all message threads that you have created, filtered by time interval and/or 
 | `MessageThreadIds` | array of string | optional, max 1000 items | Unique identifiers of [Message threads](#message-thread). Required if no other filter is provided. |
 | `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was created. Required if no other filter is provided. |
 | `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was updated. Required if no other filter is provided. |
+| `Limitation` | [Limitation](#limitation) | required | Limitation applied to the fetched message threads. |
 
 #### Time interval
 
@@ -35,6 +40,13 @@ Get all message threads that you have created, filtered by time interval and/or 
 | :-- | :-- | :-- | :-- |
 | `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
+
+#### Limitation
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Cursor` | string | optional | Id of the item prior to which the returned items are going to be skipped. |
+| `Count` | number | required, max count 1000 | Number of items returned by the endpoint. |
 
 ### Response
 
@@ -48,13 +60,15 @@ Get all message threads that you have created, filtered by time interval and/or 
             "CreatedUtc": "2022-03-07T16:09:45Z",
             "UpdatedUtc": "2022-03-07T16:09:45Z"
         }
-    ]
+    ],
+    "Cursor": "7f9325f6-ef44-4911-89a8-ae51010a5aa4"
 }
 ```
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `MessageThreads` | array of [Message threads](#message-thread) | required | The filtered message threads. |
+| `Cursor` | string | required | Index of the last message thread Id. Should be used in [Limitation](#limitation) to fetch older message threads in the follow-up request. |
 
 #### Message thread
 

--- a/operations/messagethreads.md
+++ b/operations/messagethreads.md
@@ -68,7 +68,7 @@ Get all message threads that you have created, filtered by time interval and/or 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `MessageThreads` | array of [Message threads](#message-thread) | required | The filtered message threads. |
-| `Cursor` | string | required | Index of the last message thread Id. Should be used in [Limitation](#limitation) to fetch older message threads in the follow-up request. |
+| `Cursor` | string | optional | Index of the last message thread Id. Should be used in [Limitation](#limitation) to fetch older message threads in the follow-up request. |
 
 #### Message thread
 


### PR DESCRIPTION
#### Changelog notes 

```
## 2nd May 2022 11:00 UTC

* Extended operations [Get all messages](../operations/messages.md#get-all-messages) with `Limitation` to provide a pagination functionality
* Extended operations [Get all message threads](../operations/messagethreads.md#get-all-message-threads) with `Limitation` to provide a pagination functionality
```

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
