### PR TITLE
Made restriction Days optional.

### DIFF
--- a/operations/restrictions.md
+++ b/operations/restrictions.md
@@ -156,7 +156,7 @@ Returns all restrictions of the default service provided by the enterprise.
 | `ResourceCategoryType` | string | optional | Name of the restricted [Resource category type](resources.md#resource-category-type). |
 | `StartUtc` | string | optional | Start of the restricted interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | End of the restricted interval in UTC timezone in ISO 8601 format. |
-| `Days` | array of string [Day](#day) | optional | The restricted days of week. Will be automatically set to all values when not provided. |
+| `Days` | array of string [Day](#day) | optional | The restricted days of week. Will be automatically set to all values when not provided or service has time unit longer than a day.
 
 #### Restriction Exceptions
 

--- a/operations/restrictions.md
+++ b/operations/restrictions.md
@@ -156,7 +156,7 @@ Returns all restrictions of the default service provided by the enterprise.
 | `ResourceCategoryType` | string | optional | Name of the restricted [Resource category type](resources.md#resource-category-type). |
 | `StartUtc` | string | optional | Start of the restricted interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | End of the restricted interval in UTC timezone in ISO 8601 format. |
-| `Days` | array of string [Day](#day) | optional | The restricted days of week. When not provided for services with daily time unit will be automatically set to all values. For services with time unit longer than day will be ignored. |
+| `Days` | array of string [Day](#day) | optional | The restricted days of week. Will be automatically set to all values when not provided. |
 
 #### Restriction Exceptions
 

--- a/operations/restrictions.md
+++ b/operations/restrictions.md
@@ -156,7 +156,7 @@ Returns all restrictions of the default service provided by the enterprise.
 | `ResourceCategoryType` | string | optional | Name of the restricted [Resource category type](resources.md#resource-category-type). |
 | `StartUtc` | string | optional | Start of the restricted interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | End of the restricted interval in UTC timezone in ISO 8601 format. |
-| `Days` | array of string [Day](#day) | required | The restricted days of week. |
+| `Days` | array of string [Day](#day) | optional | The restricted days of week. When not provided for services with daily time unit will be automatically set to all values. For services with time unit longer than day will be ignored. |
 
 #### Restriction Exceptions
 
@@ -166,8 +166,8 @@ Returns all restrictions of the default service provided by the enterprise.
 | `MaxAdvance` | string | optional | The maximum time before the reservation starts, you can reserve in ISO 8601 duration format. |
 | `MinLength` | string | optional | Minimal reservation length in ISO 8601 duration format. |
 | `MaxLength` | string | optional | Maximal reservation length in ISO 8601 duration format. |
-| `MinPrice` | [Currency value](accountingitems.md#currency-value)| optional | Value of the minimum night price. |
-| `MaxPrice` | [Currency value](accountingitems.md#currency-value)| optional | Value of the maximum night price. |
+| `MinPrice` | [Currency value](accountingitems.md#currency-value)| optional | Value of the minimum price per time unit. |
+| `MaxPrice` | [Currency value](accountingitems.md#currency-value)| optional | Value of the maximum price per time unit. |
 
 #### Day
 
@@ -181,7 +181,7 @@ Returns all restrictions of the default service provided by the enterprise.
 
 #### Restriction type
 
-* `Stay` - guests can't stay overnight within specified dates.
+* `Stay` - guests can't stay within specified dates.
 * `Start`- guests can't check in within specified dates.
 * `End` - guests can't check out within specified dates.
 

--- a/operations/restrictions.md
+++ b/operations/restrictions.md
@@ -156,7 +156,7 @@ Returns all restrictions of the default service provided by the enterprise.
 | `ResourceCategoryType` | string | optional | Name of the restricted [Resource category type](resources.md#resource-category-type). |
 | `StartUtc` | string | optional | Start of the restricted interval in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | optional | End of the restricted interval in UTC timezone in ISO 8601 format. |
-| `Days` | array of string [Day](#day) | optional | The restricted days of week. Will be automatically set to all values when not provided or service has time unit longer than a day.
+| `Days` | array of string [Day](#day) | optional | The restricted days of week. Will automatically be set to all values when not provided or when the service uses a time unit longer than a day.
 
 #### Restriction Exceptions
 


### PR DESCRIPTION
#### Changelog notes 

```
* Updated `Days` field of [Restriction conditions](../operations/restrictions.md#restriction-conditions) to optional.
```

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
