### PR TITLE
added new restricted operation 'Add payment command'

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 14th February 2023
+## 20th February 2023
 
 * Added new restricted operation [Add payment command](../operations/commands.md#add-payment-command).
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 14th February 2023
+
+* Added new restricted operation [Add payment command](../operations/commands.md#add-payment-command).
+
 ## 1st February 2023
 
 * Some changes to documentation structure to improve readability and navigability; documentation only, no functional changes to the API

--- a/operations/README.md
+++ b/operations/README.md
@@ -45,6 +45,7 @@ This section describes all operations supported by the API, organised here by th
 | [Get all commands by ids](commands.md#get-all-commands-by-ids) | Returns all commands by their identifiers |
 | [Add printer command](commands.md#add-printer-command) | Adds a new printer command representing printing of the specified document on a printer |
 | [Add key cutter command](commands.md#add-key-cutter-command) | Adds a new key cutter command representing cutting of a key for the specified reservation |
+| [Add payment command](commands.md#add-payment-command) | **Restricted!** Adds a new Mews Payment Terminal command |
 | [Update command](commands.md#update-command) | Updates state of a command |
 
 ## Enterprises

--- a/operations/commands.md
+++ b/operations/commands.md
@@ -299,6 +299,7 @@ The operation instructs a specified terminal device to take a payment from a spe
 
 * `Payment`
 * `Preauthorization`
+...
 
 ### Response
 

--- a/operations/commands.md
+++ b/operations/commands.md
@@ -255,6 +255,63 @@ Adds a new key cutter command representing cutting of a key for the specified re
 | :-- | :-- | :-- | :-- |
 | `CommandId` | string | required | Unique identifier of the created [Command](#command). |
 
+## Add payment command
+
+> ### Restricted!
+> This operation is part of a custom workflow for Mews partners such as POS systems to access Mews Payment Terminals.
+> See [Mews Payment Terminals](../use-cases/mews-terminals.md).
+
+Adds a new Mews Payment Terminal command for taking a customer payment.
+The operation instructs a specified terminal device to take a payment from a specified customer for a specified amount.
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/commands/addPaymentTerminal`
+
+```javascript
+{
+    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+    "AccessToken": "7059D2C25BF64EA681ACAB3A00B859CC-D91BFF2B1E3047A3E0DEC1D57BE1382",
+    "Client": "MyPOS 1.0",
+    "Type": "Payment",
+    "TerminalId": "be35b39e-ad7e-460a-8de9-4c7581e016a2",
+    "CustomerId": "35d4b117-4e60-44a3-9580-c582117eff98",
+    "BillId": null,
+    "Amount": {
+        "Currency": "EUR",
+        "Value": 230.00
+   }
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ClientToken` | string | required | Token authenticating the client application. |
+| `AccessToken` | string | required | Token authenticating access to the enterprise integration. |
+| `Client` | string | required | Name and version of the client application. |
+| `Type` | string [Payment type](#payment-type) | required | The type of payment, e.g. "preauthorization". |
+| `TerminalId` | string | required | Unique identifier of the payment terminal. |
+| `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
+| `BillId` | string | optional | Unique identifier of the [Bill](bills.md#bill). |
+| `Amount` | [Currency value](accountingitems.md#currency-value) | required | Amount of the payment. |
+
+#### Payment type
+
+* `Payment`
+* `Preauthorization`
+
+### Response
+
+```javascript
+{
+  "CommandId": "2391a3df-1c61-4131-b6f8-c85b4234adcb"
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `CommandId` | string | required | Unique identifier of the created [Command](#command). |
+
 ## Update command
 
 Updates state of a command.


### PR DESCRIPTION
#### Summary

* Ref. YT kanban-4667 "Document: Add payment terminal command"
* Added new operation 'Add payment command'
* This needs verification from the Connectivity Team! In particular, the definition of Amount is NOT consistent with Amount used in the Mews Payment Terminals use case (PR #394)

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
