### PR TITLE
important re-working of Datetime documentation and restrictions page

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 23rd March 2023
+
+* Re-wrote the [Datetimes](../guidelines/serialization.md#datetimes) section to better explain how date-times are used in the API.
+* Updated descriptions for `startUtc` and `endUtc` in [Restriction Conditions](../operations/restrictions.md#restriction-conditions) and [Restriction set data](../operations/restrictions.md#restriction-set-data).
+* Other minor improvements to documentation in the [Restrictions](../operations/restrictions.md) page.
+
 ## 17th March 2023
 
 * Added operation [Set restrictions](../operations/restrictions.md#set-restrictions).

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 23rd March 2023
+## 27th March 2023
 
 * Re-wrote the [Datetimes](../guidelines/serialization.md#datetimes) section to better explain how date-times are used in the API.
 * Updated descriptions for `startUtc` and `endUtc` in [Restriction Conditions](../operations/restrictions.md#restriction-conditions) and [Restriction set data](../operations/restrictions.md#restriction-set-data).

--- a/guidelines/serialization.md
+++ b/guidelines/serialization.md
@@ -2,21 +2,35 @@
 
 ## Datetimes
 
-Some operations of the API accept datetimes in their parameters or return them in their results. The datetimes are represented as `string`s following the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) formatting rules. Moreover, they should always be in [UTC](https://en.wikipedia.org/wiki/ISO_8601#UTC) so that it is clear which instant they represent and there is no room for confusion. Putting this all together means that the expected format of datetimes is `YYYY-MM-DDThh:mm:ssZ`. This format is also used in return values.
+Some operations of the API accept datetimes in their parameters or return them in their results. Datetime is represented as a `string`, following the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) formatting rules. Moreover, it should always be in [UTC](https://en.wikipedia.org/wiki/ISO_8601#UTC) so that it is clear which instant it represents and there is no room for confusion. This means the standard format for datetime used throughout the API is `YYYY-MM-DDThh:mm:ssZ`.
 
-As an example, consider an operation that takes datetime interval in its parameters. And let's say we want to fully cover 1st and 2nd of January 2017 in an enterprise that is located in timezone UTC+2. Then the interval in the local time is:
+> ### Example 1
+> A date and time of 7:12am on March 22nd 2023 local time in Chicago (UTC-5), would be represented as:
+> * `2023-03-22T12:12:00Z`
 
-* Start `2021-01-01T00:00:00+02:00`
-* End `2021-01-03T00:00:00+02:00`
+Where only a date is needed, this is also usually represented with standard datetime, but in this case the time component is set to zero, i.e. `00:00:00`.
+Note however that when adjusted from local time to UTC, the time may become non-zero.
 
-In order to pass this interval to the API, it has to be converted to UTC:
+> ### Example 2
+> A date-only of March 22nd 2023 local time in Chicago (UTC-5), would be represented as:
+> * `2023-03-22T05:00:00Z`
 
-* StartUtc `2020-12-31T22:00:00Z`
-* EndUtc `2021-01-02T22:00:00Z`
+Note that adjusting from local time to UTC can also shift the date.
+
+> ### Example 3
+> A date-only of March 22nd 2023 local time in Beijing (UTC+8), would be represented as:
+> * `2023-03-21T16:00:00Z`
+
+The API frequently uses time intervals, i.e. periods of time defined by a start datetime and an end datetime, as usual expressed in UTC. These time intervals are inclusive, meaning that the interval includes the start and end as part of the interval. For example, an interval with start of January 1st and end of January 5th includes the 1st, 2nd, 3rd, 4th and 5th. The datetimes used to define a time interval follow all the normal rules for datetimes, as described above.
+
+> ### Example 4
+> A date-only time interval of March 20th to March 23rd 2023 (including the 20th, 21st, 22nd and 23rd) local time in Beijing (UTC+8), would be represented as:
+> * StartUtc `2023-03-19T16:00:00Z`
+> * EndUtc `2023-03-22T16:00:00Z`
 
 ## Durations
 
-Some operations of the API accept durations in their parameters or return them in their results. The durations are represented as `string`s following the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) formatting rules.
+Some operations of the API accept durations in their parameters or return them in their results. Duration is represented as a `string`, following the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) formatting rules.
 
 As an example, consider minimum and maximum length of the reservation:
 

--- a/operations/restrictions.md
+++ b/operations/restrictions.md
@@ -44,9 +44,9 @@ Returns all restrictions of the default service provided by the enterprise.
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceIds` | array of string | required, max 1000 items | Unique identifiers of the [Services](services.md#service) from which the restrictions are requested. |
 | `ResourceCategoryIds` | array of string | optional, max 1000 items | Unique identifiers of [Resource categories](resources.md#resource-category). |
-| `RateIds` | array of string | optional, max 1000 items | Unique identifiers of [Rates](rates.md#rate). Returns all restrictions that affect given rates (i.e. ones without any [Conditions](#restriction-conditions), ones assigned directly to specified rates, ones assigned to [Rate group](rates.md#rate-group) of specified rates, or ones inherited from base rates).  |
-| `BaseRateIds` | array of string | optional, max 1000 items | Unique identifiers of [Rates](rates.md#rate). Returns only those restrictions which have matching `BaseRateId` set in [Conditions](#restriction-conditions). |
-| `ExactRateIds` | array of string | optional, max 1000 items | Unique identifiers of [Rates](rates.md#rate). Returns only those restrictions which have matching `ExactRateId` set in [Conditions](#restriction-conditions). |
+| `RateIds` | array of string | optional, max 1000 items | Unique identifiers of [Rates](rates.md#rate). Returns all restrictions that affect the given rates, i.e. ones without any [Restriction Conditions](#restriction-conditions), ones assigned directly to specified rates, ones assigned to [Rate groups](rates.md#rate-group) of specified rates, or ones inherited from base rates. |
+| `BaseRateIds` | array of string | optional, max 1000 items | Unique identifiers of [Rates](rates.md#rate). Returns only those restrictions which have matching `BaseRateId` set in [Restriction Conditions](#restriction-conditions). |
+| `ExactRateIds` | array of string | optional, max 1000 items | Unique identifiers of [Rates](rates.md#rate). Returns only those restrictions which have matching `ExactRateId` set in [Restriction Conditions](#restriction-conditions). |
 | `CollidingUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Restriction](#restriction) is active. Required if no other filter is provided. |
 | `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Restriction](#restriction) was created. |
 | `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Restriction](#restriction) was updated. |
@@ -141,8 +141,8 @@ Returns all restrictions of the default service provided by the enterprise.
 | `Id` | string | required | Unique identifier of the restriction. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service). |
 | `ExternalIdentifier` | string | optional | External identifier of the restriction. |
-| `Conditions` | string | required | [Conditions](#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
-| `Exceptions` | string | optional | [Exceptions](#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
+| `Conditions` | [Restriction Conditions](#restriction-conditions) | required | The conditions or rules that must be met by a reservation for the restriction to apply. |
+| `Exceptions` | [Restriction Exceptions](#restriction-exceptions) | optional | The rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
 
 #### Restriction Conditions
 
@@ -154,8 +154,8 @@ Returns all restrictions of the default service provided by the enterprise.
 | `RateGroupId` | string | optional | Unique identifier of the restricted [Rate group](rates.md#rate-group). |
 | `ResourceCategoryId` | string | optional | Unique identifier of the restricted [Resource category](resources.md#resource-category). |
 | `ResourceCategoryType` | string | optional | Name of the restricted [Resource category type](resources.md#resource-category-type). |
-| `StartUtc` | string | optional | Start of the restricted interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | optional | End of the restricted interval in UTC timezone in ISO 8601 format. |
+| `StartUtc` | string | optional | Start date of the restriction time interval, specified in ISO 8601 format and adjusted to UTC - see [Datetimes](../guidelines/serialization.md#datetimes) for important information on format and implementation. |
+| `EndUtc` | string | optional | End date of the restriction time interval, specified in ISO 8601 format and adjusted to UTC - see [Datetimes](../guidelines/serialization.md#datetimes) for important information on format and implementation. |
 | `Days` | array of string [Day](#day) | optional | The restricted days of week. Will automatically be set to all values when not provided or when the service uses a time unit longer than a day.
 
 #### Restriction Exceptions
@@ -187,7 +187,7 @@ Returns all restrictions of the default service provided by the enterprise.
 
 ## Add restrictions
 
-Adds new restrictions with the specified conditions.
+Adds new restrictions with the specified conditions. Note care is needed to specify `StartUtc` and `EndUtc` in the correct format - see [Datetimes](../guidelines/serialization.md#datetimes).
 
 > **Important:** If consecutive restrictions are sent with the exact same conditions and exceptions, no attempt at merging them into a single restriction is made. This means that there can be a large number of restrictions per service, leading to sub-optimal performance. A quota limit of 150000 has been introduced for this reason. To mitigate the issue, the preferred way to add restrictions is new operation [Set restrictions](#set-restrictions). The new operation is currently marked as 'Restricted' and subject to change as part of beta testing, but in time we expect that to replace [Add restrictions](#add-restrictions).
 
@@ -253,8 +253,8 @@ Adds new restrictions with the specified conditions.
 | :-- | :-- | :-- | :-- |
 | `Identifier` | string | optional | Identifier of the restriction within the transaction. |
 | `ExternalIdentifier` | string | optional | External identifier of the restriction. |
-| `Conditions` | string | required | [Conditions](#restriction-conditions) are rules that must be met by a reservation for the restriction to apply. |
-| `Exceptions` | string | optional | [Exceptions](#restriction-exceptions) are rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
+| `Conditions` | [Restriction Conditions](#restriction-conditions) | required | The conditions or rules that must be met by a reservation for the restriction to apply. |
+| `Exceptions` | [Restriction Exceptions](#restriction-exceptions) | optional | The rules that prevent the restriction from applying to a reservation, even when all conditions have been met. |
 
 ### Response
 
@@ -378,6 +378,7 @@ Removes restrictions from the service.
 > This operation is currently in beta-test and as such it is subject to change. Use of this operation must be enabled per enterprise. Please contact the Technical Partner Support team in order to enable it.
 
 Adds new restrictions with the specified conditions. For improved efficiency, multiple similar restrictions will be merged into a single restriction - see [Merging algorithm](#merging-algorithm). A quota of 150000 restrictions per service applies, although it is unlikely to be exceeded because of the [Merging algorithm](#merging-algorithm).
+Note care is needed to specify `StartUtc` and `EndUtc` in the correct format - see [Datetimes](../guidelines/serialization.md#datetimes). The validation of these properties is stronger in this operation than for [Add restrictions](#add-restrictions).
 
 ### Merging algorithm
 
@@ -391,10 +392,6 @@ This reduces the overall number of restrictions and improves system performance.
    1) If the new interval overlaps the old interval, the old restriction will be spliced before and after the new interval. Restrictions matching the old restriction are then added at the appropriate interval along with the new restriction.
    2) If the new interval does _not_ overlap the old interval, the new restriction is added as usual.
 
-### Time interval
-
-Note the `StartUtc` and `EndUtc` properties must be set to the midnight of the given date when converted to the enterprise's local datetime. This is different from the [Add restrictions](#add-restrictions) operation since it allows the setting of different times. Restrictions are applied for all the dates within the interval, including the `EndUtc` date.
-
 ### Request
 
 `[PlatformAddress]/api/connector/v1/restrictions/set`
@@ -404,11 +401,11 @@ Note the `StartUtc` and `EndUtc` properties must be set to the midnight of the g
    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
    "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
-   "Restrictions": [  
+   "Data": [  
       {  
-         "Identifier": "1234",
-         "ExternalIdentifier": "5678",
          "Type": "Start",
+         "StartUtc": "2023-02-15T00:00:00Z",
+         "EndUtc": "2023-02-22T00:00:00Z",
          "ExactRateId": "7c7e89d6-69c0-4cce-9d42-35443f2193f3",
          "ResourceCategoryId": "86336EAC-4168-46B1-A544-2A47251BF864",
          "Days": {
@@ -424,9 +421,9 @@ Note the `StartUtc` and `EndUtc` properties must be set to the midnight of the g
          "MaxLength": "P0M7DT0H0M0S",
       },
       {  
-         "Identifier": "1235",
-         "ExternalIdentifier": "5678",
          "Type": "Start",
+         "StartUtc": "2023-02-23T00:00:00Z",
+         "EndUtc": "2023-03-03T00:00:00Z",
          "BaseRateId": "e5b538b1-36e6-43a0-9f5c-103204c7f68e",
          "Days": {
             "Monday": false,
@@ -450,21 +447,19 @@ Note the `StartUtc` and `EndUtc` properties must be set to the midnight of the g
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) restrictions will be set in. |
-| `Data` | array of [RestrictionSetData](#restriction-set-data) | required | Parameters of restrictions. |
+| `Data` | array of [Restriction set data](#restriction-set-data) | required | Parameters of restrictions. |
 
 #### Restriction set data
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Identifier` | string | optional | Identifier of the restriction within the transaction. |
-| `ExternalIdentifier` | string | optional | External identifier of the restriction. |
 | `Type` | string | required | [Restriction type](#restriction-type). |
 | `ExactRateId` | string | optional | Unique identifier of the restricted exact [Rate](rates.md#rate). |
 | `BaseRateId` | string | optional | Unique identifier of the restricted base [Rate](rates.md#rate). |
 | `RateGroupId` | string | optional | Unique identifier of the restricted [Rate group](rates.md#rate-group). |
 | `ResourceCategoryId` | string | optional | Unique identifier of the restricted [Resource category](resources.md#resource-category). |
 | `ResourceCategoryType` | string | optional | Name of the restricted [Resource category type](resources.md#resource-category-type). |
-| `StartUtc` | string | optional | Start date of the restricted interval in UTC timezone in ISO 8601 format. The time must be the midnight of the day when converted to enterprise's local time. |
-| `EndUtc` | string | optional | End of the restricted interval in UTC timezone in ISO 8601 format. The time must be the midnight of the day when converted to enterprise's local time. Restriction's `EndUtc` is inclusive meaning the restriction will apply on the date of `EndUtc`. |
+| `StartUtc` | string | optional | Start date of the restriction time interval, specified in ISO 8601 format and adjusted to UTC - see [Datetimes](../guidelines/serialization.md#datetimes) for important information on format and implementation. |
+| `EndUtc` | string | optional | End date of the restriction time interval, specified in ISO 8601 format and adjusted to UTC - see [Datetimes](../guidelines/serialization.md#datetimes) for important information on format and implementation. |
 | `Days` | [DaysParameters](#days-parameters) | required | The restricted days of week. |
 | `MinAdvance` | string | optional | The minimum time before the reservation starts, you can reserve in ISO 8601 duration format. |
 | `MaxAdvance` | string | optional | The maximum time before the reservation starts, you can reserve in ISO 8601 duration format. |


### PR DESCRIPTION
#### Summary

Important changes to address errors from misuse of restrictions endpoints:

* Re-wrote **Datetime** section in **Serialization** page to better explain date-time formats and how they should be used, including examples
* Numerous small updates to the **Restrictions** page to clarify use of `StartUtc` and `EndUtc` and correct minor issues

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
