### PR TITLE
Set type to int instead of string

### DIFF
--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -811,7 +811,7 @@ Updates information about the specified reservations. Note that if any of the fi
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Index` | number | required | Index of the unit. Indexing starts with `0`. E.g the first night of the reservation has index 0. |
+| `Index` | integer | required | Index of the unit. Indexing starts with `0`. E.g the first night of the reservation has index 0. |
 | `Amount` | [Amount parameters](orders.md#amount-parameters) | required | Amount of the unit. |
 
 #### Person counts update value

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -811,7 +811,7 @@ Updates information about the specified reservations. Note that if any of the fi
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Index` | string | required | Index of the unit. Indexing starts with `0`. E.g the first night of the reservation has index 0. |
+| `Index` | number | required | Index of the unit. Indexing starts with `0`. E.g the first night of the reservation has index 0. |
 | `Amount` | [Amount parameters](orders.md#amount-parameters) | required | Amount of the unit. |
 
 #### Person counts update value


### PR DESCRIPTION
Type used for the request is int not string

#### Summary

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
