### PR TITLE
added new Common objects page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,6 +29,7 @@
   * [Payment automation](use-cases/payment-automation/README.md)
     * [Using tokenized credit cards](use-cases/payment-automation/using-tokenized-credit-cards.md)
 * [API Operations](operations/README.md)
+  * [Common objects](operations/_objects.md)
   * [Accounting categories](operations/accountingcategories.md)
   * [Accounting items](operations/accountingitems.md)
   * [Accounts](operations/accounts.md)

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 31st March 2023
+
+* Added new page for [common object definitions](../operations/_objects.md) used throughout the API
+
 ## 27th March 2023
 
 * Updated [loyalty programs](../operations/loyaltyprograms.md) and [loyalty memberships](../operations/loyaltymemberships.md) operations as restricted.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 31st March 2023
+## 6th April 2023
 
 * Added new page for [common object definitions](../operations/_objects.md) used throughout the API
 

--- a/operations/_objects.md
+++ b/operations/_objects.md
@@ -63,3 +63,18 @@ These are JSON object definitions shared by operations across the API.
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Value` | integer | optional | Value which is to be updated. |
+
+### Dictionary
+
+Dictionary is a collection of key-value pairs.
+
+```javascript
+{
+    "TaxIdentifier": "CZ8810310963",
+    "CityOfRegistration": "Prague"
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| ?Key? | string | optional | Some value corresponding to the ?Key? unique identifier. Cannot be null. |

--- a/operations/_objects.md
+++ b/operations/_objects.md
@@ -1,0 +1,65 @@
+# Common objects
+
+These are JSON object definitions shared by operations across the API.
+
+### Time interval
+
+```javascript
+{
+    "StartUtc": "2020-01-05T00:00:00Z",
+    "EndUtc": "2020-01-10T00:00:00Z"
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format \(see [Datetimes](../guidelines/serialization.md#datetimes)\). |
+| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format \(see [Datetimes](../guidelines/serialization.md#datetimes)\). |
+
+### String update value
+
+```javascript
+{
+    "Value": "182a56ee-037d-4da5-b6f8-ada8006e7d5c"
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Value` | string | optional | Value which is to be updated. |
+
+### Bool update value
+
+```javascript
+{
+    "Value": false
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Value` | boolean | optional | Value which is to be updated. |
+
+### Number update value
+
+```javascript
+{
+    "Value": 6
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Value` | number | optional | Value which is to be updated. |
+
+### Integer update value
+
+```javascript
+{
+    "Value": 5
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Value` | integer | optional | Value which is to be updated. |

--- a/operations/accountingitems.md
+++ b/operations/accountingitems.md
@@ -45,21 +45,14 @@ Returns all accounting items of the enterprise that were consumed \(posted\) or 
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ConsumedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the accounting item was consumed. Required if no other filter is provided. |
-| `ClosedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the accounting item was closed. Required if no other filter is provided. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the accounting item was updated. Required if no other filter is provided. |
+| `ConsumedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the accounting item was consumed. Required if no other filter is provided. |
+| `ClosedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the accounting item was closed. Required if no other filter is provided. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the accounting item was updated. Required if no other filter is provided. |
 | `ItemIds` | array of string | optional, max 1000 items | Unique identifiers of the Accounting items. Required if no other filter is provided. |
 | `RebatedItemIds` | array of string | optional, max 1000 items | Unique identifiers of the Accounting items we are finding rebates for. Required if no other filter is provided. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](currencies.md#currency) the item costs should be converted to. |
 | `Extent` | [Accounting item extent](#accounting-item-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the accounting items, credit card transactions should be also returned. |
 | `States` | array of string [Accounting item state](#accounting-item-state) | optional | States the accounting items should be in. If not specified, accounting items in `Open` or `Closed` states are returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 #### Accounting item extent
 
@@ -389,14 +382,8 @@ Updates specified accounting items. Allows to change to which account or bill th
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `AccountingItemId` | string | required | Unique identifier of the [Accounting item](#accounting-item). |
-| `AccountId` | [String update value](#string-update-value) | optional | Unique identifier of the account (for example [Customer](customers.md#customer)) the item is assigned to \(or `null` if the assigned account should not be updated\). If defined, valid account identifier must be provided. |
-| `BillId` | [String update value](#string-update-value) | required | Unique identifier of the [Bill](bills.md#bill) the items is assigned to. It's possible to assign item to bill belonging to another account, in that case both `AccountId` and `BillId` must be provided.
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
+| `AccountId` | [String update value](_objects.md#string-update-value) | optional | Unique identifier of the account (for example [Customer](customers.md#customer)) the item is assigned to \(or `null` if the assigned account should not be updated\). If defined, valid account identifier must be provided. |
+| `BillId` | [String update value](_objects.md#string-update-value) | required | Unique identifier of the [Bill](bills.md#bill) the items is assigned to. It's possible to assign item to bill belonging to another account, in that case both `AccountId` and `BillId` must be provided.
 
 ### Response
 

--- a/operations/addresses.md
+++ b/operations/addresses.md
@@ -34,15 +34,8 @@ Returns all addresses associated with the specified accounts within the enterpri
 | `Client` | string | required | Name and version of the client application. |
 | `AccountIds` | array of string | optional, max 1000 items | Unique identifiers of [Companies](companies.md#company) or [Customers](customers.md#customer) within the enterprise. Required if no other filter is provided. |
 | `AddressIds` | array of string | optional, max 1000 items | Unique identifiers of [Addresses](#account-address) within the enterprise. Use this property if you want to fetch specific addresses. Required if no other filter is provided. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Address](#account-address) last update date and time. Required if no other filter is provided. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of [Address](#account-address) last update date and time. Required if no other filter is provided. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of Account address returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 ### Response
 
@@ -210,18 +203,12 @@ Updates one or more existing addresses in the system, assigned to specified acco
 | :-- | :-- | :-- | :-- |
 | `AddressId` | string | required | Unique identifier of the address. |
 | `AccountId` | string | required | Unique identifier of a [Company](companies.md#company) or a [Customer](customers.md#customer) within the enterprise. |
-| `Line1` | [String update value](#string-update-value) | optional | First line of the address. |
-| `Line2` | [String update value](#string-update-value) | optional | Second line of the address. |
-| `City` | [String update value](#string-update-value) | optional | The city. |
-| `PostalCode` | [String update value](#string-update-value) | optional | Postal code. |
-| `CountryCode` | [String update value](#string-update-value) | optional | ISO 3166-1 code of the [Country](countries.md#country). |
-| `CountrySubdivisionCode` | [String update value](#string-update-value) | optional | ISO 3166-2 code of the administrative division, e.g. `DE-BW`. |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
+| `Line1` | [String update value](_objects.md#string-update-value) | optional | First line of the address. |
+| `Line2` | [String update value](_objects.md#string-update-value) | optional | Second line of the address. |
+| `City` | [String update value](_objects.md#string-update-value) | optional | The city. |
+| `PostalCode` | [String update value](_objects.md#string-update-value) | optional | Postal code. |
+| `CountryCode` | [String update value](_objects.md#string-update-value) | optional | ISO 3166-1 code of the [Country](countries.md#country). |
+| `CountrySubdivisionCode` | [String update value](_objects.md#string-update-value) | optional | ISO 3166-2 code of the administrative division, e.g. `DE-BW`. |
 
 ### Response
 

--- a/operations/availabilityadjustments.md
+++ b/operations/availabilityadjustments.md
@@ -34,15 +34,8 @@ Returns all availability adjustments.  Note that this operation uses [Pagination
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `AvailabilityAdjustmentIds` | string | optional, max 1000 items | Unique identifiers of the requested [Availability adjustments](#availability-adjustment). |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Availability adjustments](#availability-adjustment) were updated. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Availability adjustments](#availability-adjustment) were updated. |
 | `ActivityStates` | array of string [Activity state](#activity-state) | optional| Whether to return only active, only deleted or both records. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 ### Response
 

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -62,21 +62,14 @@ Returns all availability blocks filtered by services, unique identifiers and oth
 | `Client` | string | required | Name and version of the client application. |
 | `AvailabilityBlockIds` | string | optional, max 1000 items | Unique identifiers of the requested [Availability blocks](#availability-block). |
 | `ServiceIds` | string | optional, max 1000 items | Unique identifiers of the [Services](services.md#service) to which [Availability blocks](#availability-block) are assigned. |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Availability blocks](#availability-block) were created. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Availability blocks](#availability-block) were updated. |
-| `CollidingUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Availability blocks](#availability-block) are active. |
-| `ReleasedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Availability blocks](#availability-block) are released. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Availability blocks](#availability-block) were created. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Availability blocks](#availability-block) were updated. |
+| `CollidingUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Availability blocks](#availability-block) are active. |
+| `ReleasedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Availability blocks](#availability-block) are released. |
 | `States` | array of string [Availability block state](#availability-block-state) | optional | States the availability blocks should be in. |
 | `ExternalIdentifiers` | string | optional, max 1000 items | Identifiers of [Availability block](#availability-block)s from external systems. |
 | `ActivityStates` | array of string [Activity state](vouchers.md#activity-state) | required | Whether return only active, only deleted or both records. |
 | `Extent` | [Availability block extent](#availability-block-extent) | required | Extent of data to be returned. E.g. it is possible to specify that related service orders (for example [Reservations](reservations.md#reservation)) are returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 #### Availability block state
 
@@ -329,17 +322,11 @@ Updates information about the specified [Availability block](#availability-block
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `AvailabilityBlockId` | string | required | Unique identifier of the [Availability block](#availability-block). |
-| `Name` | [String update value](#string-update-value) | optional | The name of the block \(or `null` if the name should not be updated\). |
-| `FirstTimeUnitStartUtc` | [String update value](#string-update-value) | required | Start of the time interval, expressed as the timestamp for the start of the first [time unit](services.md#time-unit), in UTC timezone ISO 8601 format \(or `null` if the start time should not be updated\). |
-| `LastTimeUnitStartUtc` | [String update value](#string-update-value) | required | End of the time interval, expressed as the timestamp for the start of the last [time unit](services.md#time-unit), in UTC timezone ISO 8601 format \(or `null` if the end time should not be updated\). |
-| `ReleasedUtc` | [String update value](#string-update-value) | required | The moment when the block and its availability is released \(or `null` if the released time should not be updated\). |
-| `ExternalIdentifier` | [String update value](#string-update-value) | optional, max 255 characters | Identifier of the block from external system \(or `null` if the identifier should not be updated\). |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| --- | --- | --- | --- |
-| `Value` | string | optional | Value which is to be updated. |
+| `Name` | [String update value](_objects.md#string-update-value) | optional | The name of the block \(or `null` if the name should not be updated\). |
+| `FirstTimeUnitStartUtc` | [String update value](_objects.md#string-update-value) | required | Start of the time interval, expressed as the timestamp for the start of the first [time unit](services.md#time-unit), in UTC timezone ISO 8601 format \(or `null` if the start time should not be updated\). |
+| `LastTimeUnitStartUtc` | [String update value](_objects.md#string-update-value) | required | End of the time interval, expressed as the timestamp for the start of the last [time unit](services.md#time-unit), in UTC timezone ISO 8601 format \(or `null` if the end time should not be updated\). |
+| `ReleasedUtc` | [String update value](_objects.md#string-update-value) | required | The moment when the block and its availability is released \(or `null` if the released time should not be updated\). |
+| `ExternalIdentifier` | [String update value](_objects.md#string-update-value) | optional, max 255 characters | Identifier of the block from external system \(or `null` if the identifier should not be updated\). |
 
 ### Response
 

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -116,7 +116,7 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
                     },
                     "LegalIdentifiers": {
                         "TaxIdentifier": "CZ8810310963",
-                    "CityOfRegistration": "Prague",
+                        "CityOfRegistration": "Prague",
                     },
                     "BillingCode": "Billing code value",
                     "LastName": "Doe",
@@ -226,7 +226,7 @@ A bill is either a `Receipt` which means that it has been fully paid, or `Invoic
 | :-- | :-- | :-- | :-- |
 | `Id` | string  | required | ID of the [Customer](customers.md#customer) to whom the bill was assigned. |
 | `Address` | [Bill address](#bill-address) | optional | Address of the customer. |
-| `LegalIdentifiers` | [Dictionary](#dictionary) | optional | The set of [LegalIdentifiers](#legal-identifiers) for the customer. |
+| `LegalIdentifiers` | [Dictionary](_objects.md#dictionary) | optional | The set of [LegalIdentifiers](#legal-identifiers) for the customer. |
 | `BillingCode` | string  | optional | A unique code for Mews to list on invoices it sends to the customer. |
 | `LastName` | string  | required | Last name of the customer. |
 | `FirstName` | string  | optional | First name of the customer. |
@@ -239,7 +239,7 @@ A bill is either a `Receipt` which means that it has been fully paid, or `Invoic
 | :-- | :-- | :-- | :-- |
 | `Id` | string  | required | ID of the [Company](companies.md#company). |
 | `Address` | [Bill address](#bill-address) | optional | Address of the company. |
-| `LegalIdentifiers` | [Dictionary](#dictionary) | optional | The set of [LegalIdentifiers](#legal-identifiers) for the company. |
+| `LegalIdentifiers` | [Dictionary](_objects.md#dictionary) | optional | The set of [LegalIdentifiers](#legal-identifiers) for the company. |
 | `BillingCode` | string  | optional | A unique code for Mews to list on invoices it sends to the company. |
 | `Name` | string  | required | Name of the company. |
 | `FiscalIdentifier` | string  | optional | Fiscal identifier of the company. |
@@ -267,17 +267,9 @@ A bill is either a `Receipt` which means that it has been fully paid, or `Invoic
 | `SubdivisionCode` | string  | optional | ISO 3166-2 code of the administrative division. |
 | `CountryCode` | string  | optional | ISO 3166-1 code of the country. |
 
-### Dictionary
-
-Dictionary is a collection of key-value pairs.
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| ?Key? | string | optional | Some value corresponding to the ?Key? unique identifier. Cannot be null. |
-
 ### Legal Identifiers
 
-`LegalIdentifiers` is a [Dictionary](#dictionary), where the key is the type of legal identifier and the value is the corresponding value of that identifier. Keys are as follows:
+`LegalIdentifiers` is a [Dictionary](_objects.md#dictionary), where the key is the type of legal identifier and the value is the corresponding value of that identifier. Keys are as follows:
 
 * `TaxIdentifier`
 * `Siret`

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -116,7 +116,7 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
                     },
                     "LegalIdentifiers": {
                         "TaxIdentifier": "CZ8810310963",
-                        "CityOfRegistration": "Prague",
+                        "CityOfRegistration": "Prague"
                     },
                     "BillingCode": "Billing code value",
                     "LastName": "Doe",

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -52,20 +52,13 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
 | `BillIds` | array of string | optional, max 1000 items | Unique identifiers of the [Bills](#bill). Required if no other filter is provided. |
 | `CustomerIds` | array of string | optional, max 1000 items | Unique identifiers of the [Customers](customers.md#customer). |
 | `State` | string | optional | [Bill state](#bill-state) the bills should be in. If not specified `Open` and `Closed` bills are returned. |
-| `ClosedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Bill](#bill) was closed. |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Bill](#bill) was created. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Bill](#bill) was updated. |
-| `DueUtc` | [Time interval](#time-interval) | optional , max length 3 months| Interval in which the [Bill](#bill) is due to be paid. |
-| `PaidUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Bill](#bill) was paid. |
+| `ClosedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Bill](#bill) was closed. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Bill](#bill) was created. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Bill](#bill) was updated. |
+| `DueUtc` | [Time interval](_objects.md#time-interval) | optional , max length 3 months| Interval in which the [Bill](#bill) is due to be paid. |
+| `PaidUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Bill](#bill) was paid. |
 | `Extent` | [Bill extent](#bill-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the bills, payments and revenue items should be also returned. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of bill data returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 #### Bill state
 
@@ -455,32 +448,20 @@ Closes a bill so no further modification to it is possible.
 | `BillCounterId` | string | optional | Unique identifier of the [Counter](counters.md#counter) to be used for closing. Default one is used when no value is provided. |
 | `FiscalMachineId` | string | optional | Unique identifier of the [Fiscal Machine](devices.md#device) to be used for closing. Default one is used when no value is provided. |
 | `Options` | [Bill options parameters](#bill-options-parameters) | optional  | Options of the bill. If not provided both `DisplayCustomer` and `DisplayTaxation` are set by default. |
-| `TaxedDate` | [String update value](#string-update-value) | optional | Date of consumption for tax purposes. Can be used only with [Bill type](#bill-type) `Invoice`. |
-| `DueDate` | [String update value](#string-update-value) | optional | Deadline when [Bill](#bill) is due to be paid. Can be used only with [Bill type](#bill-type) `Invoice`. |
-| `VariableSymbol` | [String update value](#string-update-value) | optional | Optional unique identifier of requested payment. Can be used only with [Bill type](#bill-type) `Invoice`. |
-| `TaxIdentifier` | [String update value](#string-update-value) | optional | Tax identifier of account to be put on a bill. |
-| `PurchaseOrderNumber` | [String update value](#string-update-value) | optional | Unique number of the purchase order from the buyer. |
-| `Notes` | [String update value](#string-update-value) | optional | Notes to be attached to bill. |
+| `TaxedDate` | [String update value](_objects.md#string-update-value) | optional | Date of consumption for tax purposes. Can be used only with [Bill type](#bill-type) `Invoice`. |
+| `DueDate` | [String update value](_objects.md#string-update-value) | optional | Deadline when [Bill](#bill) is due to be paid. Can be used only with [Bill type](#bill-type) `Invoice`. |
+| `VariableSymbol` | [String update value](_objects.md#string-update-value) | optional | Optional unique identifier of requested payment. Can be used only with [Bill type](#bill-type) `Invoice`. |
+| `TaxIdentifier` | [String update value](_objects.md#string-update-value) | optional | Tax identifier of account to be put on a bill. |
+| `PurchaseOrderNumber` | [String update value](_objects.md#string-update-value) | optional | Unique number of the purchase order from the buyer. |
+| `Notes` | [String update value](_objects.md#string-update-value) | optional | Notes to be attached to bill. |
 | `Address` | [Address parameters](customers.md#address-parameters) | optional | Address of the account to be displayed on bill. Overrides the default one taken from account profile. |
 
 #### Bill options parameters
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `DisplayCustomer` | [Bool update value](#bool-update-value) | required | Display customer information on a bill. |
-| `DisplayTaxation` | [Bool update value](#bool-update-value) | required | Display taxation detail on a bill. |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
-
-#### Bool update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | bool | optional | Value which is to be updated. |
+| `DisplayCustomer` | [Bool update value](_objects.md#bool-update-value) | required | Display customer information on a bill. |
+| `DisplayTaxation` | [Bool update value](_objects.md#bool-update-value) | required | Display taxation detail on a bill. |
 
 ### Response
 

--- a/operations/cashiertransactions.md
+++ b/operations/cashiertransactions.md
@@ -25,14 +25,7 @@ Returns all cashier transactions created within the specified interval.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `CreatedUtc` | [Time interval](#time-interval) | required, max length 3 months | Interval in which the [Cashier transaction](#cashier-transaction) was created. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | required, max length 3 months | Interval in which the [Cashier transaction](#cashier-transaction) was created. |
 
 ### Response
 

--- a/operations/companies.md
+++ b/operations/companies.md
@@ -46,17 +46,10 @@ Returns all company profiles of the enterprise, possibly filtered by identifiers
 | `Client` | string | required | Name and version of the client application. |
 | `Ids` | array of string | optional, max 1000 items | Unique identifiers of [Companies](#company). |
 | `Names` | array of string | optional, max 1000 items | Names of [Companies](#company). |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Company](#company) creation date and time. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Company](#company) last update date and time. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of [Company](#company) creation date and time. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of [Company](#company) last update date and time. |
 | `ExternalIdentifiers` | array of string | optional, max 1000 items | Portfolio-level company identifiers, used for portfolio management; called Company Key in Mews Operations. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of customers returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 ### Response
 
@@ -351,50 +344,38 @@ Updates information of the company.
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `CompanyId` | string | required | Unique identifier of the [Company](#company). |
-| `Name` | [String update value](#string-update-value) | optional | Name of the company \(or `null` if the name should not be updated\). |
+| `Name` | [String update value](_objects.md#string-update-value) | optional | Name of the company \(or `null` if the name should not be updated\). |
 | `Options` | [Options update value](#company-options-update-value) | optional | Options of the company. |
-| `MotherCompanyId` | [String update value](#string-update-value) | optional | Unique identifier of the mother company \(or `null` if the mother company should not be updated\). |
-| `Identifier` | [String update value](#string-update-value) | optional | Identifier of the company, e.g. legal identifier \(or `null` if the identifier should not be updated\). |
-| `TaxIdentifier` | [String update value](#string-update-value) | optional | Tax identification number of the company \(or `null` if the tax identifier should not be updated\). |
-| `AdditionalTaxIdentifier` | [String update value](#string-update-value) | optional | Additional tax identifer of the company \(or `null` if the additional tax identifier should not be updated\). |
-| `BillingCode` | [String update value](#string-update-value) | optional | Billing code of the company \(or `null` if the billing code should not be updated\). |
-| `AccountingCode` | [String update value](#string-update-value) | optional | Accounting code of the company \(or `null` if the acounting code should not be updated\). |
-| `InvoiceDueInterval` | [String update value](#string-update-value) | optional | The maximum time, when the invoice has to be be paid in ISO 8601 duration format. |
-| `ContactPerson` | [String update value](#string-update-value) | optional | Contact person of the company. |
-| `Contact` | [String update value](#string-update-value) | optional | Other contact details, such as telephone, email or similar. |
-| `Notes` | [String update value](#string-update-value) | optional | Notes of the company. |
-| `Iata` | [String update value](#string-update-value) | optional | Iata of the company. |
-| `Department` | [String update value](#string-update-value) | optional | The internal segmentation of a company, e.g. sales department. |
-| `DunsNumber` | [String update value](#string-update-value) | optional | The Dun & Bradstreet unique 9-digit DUNS number. |
+| `MotherCompanyId` | [String update value](_objects.md#string-update-value) | optional | Unique identifier of the mother company \(or `null` if the mother company should not be updated\). |
+| `Identifier` | [String update value](_objects.md#string-update-value) | optional | Identifier of the company, e.g. legal identifier \(or `null` if the identifier should not be updated\). |
+| `TaxIdentifier` | [String update value](_objects.md#string-update-value) | optional | Tax identification number of the company \(or `null` if the tax identifier should not be updated\). |
+| `AdditionalTaxIdentifier` | [String update value](_objects.md#string-update-value) | optional | Additional tax identifer of the company \(or `null` if the additional tax identifier should not be updated\). |
+| `BillingCode` | [String update value](_objects.md#string-update-value) | optional | Billing code of the company \(or `null` if the billing code should not be updated\). |
+| `AccountingCode` | [String update value](_objects.md#string-update-value) | optional | Accounting code of the company \(or `null` if the acounting code should not be updated\). |
+| `InvoiceDueInterval` | [String update value](_objects.md#string-update-value) | optional | The maximum time, when the invoice has to be be paid in ISO 8601 duration format. |
+| `ContactPerson` | [String update value](_objects.md#string-update-value) | optional | Contact person of the company. |
+| `Contact` | [String update value](_objects.md#string-update-value) | optional | Other contact details, such as telephone, email or similar. |
+| `Notes` | [String update value](_objects.md#string-update-value) | optional | Notes of the company. |
+| `Iata` | [String update value](_objects.md#string-update-value) | optional | Iata of the company. |
+| `Department` | [String update value](_objects.md#string-update-value) | optional | The internal segmentation of a company, e.g. sales department. |
+| `DunsNumber` | [String update value](_objects.md#string-update-value) | optional | The Dun & Bradstreet unique 9-digit DUNS number. |
 | `CreditRating` | [Credit rating update value](#credit-rating-update-value) | optional | Credit rating to define creditworthiness of the company. |
-| `ExternalIdentifier` | string | [String update value](#string-update-value) | optional | Portfolio-level company identifier, chosen by the user for the purposes of portfolio management; called Company Key in Mews Operations. |
-| `ReferenceIdentifier` |  [String update value](#string-update-value)  | optional | External system identifier - custom identifier used by an external system such as an external database. |
-| `WebsiteUrl` |  [String update value](#string-update-value)  | optional | The website url of the company. |
+| `ExternalIdentifier` | string | [String update value](_objects.md#string-update-value) | optional | Portfolio-level company identifier, chosen by the user for the purposes of portfolio management; called Company Key in Mews Operations. |
+| `ReferenceIdentifier` |  [String update value](_objects.md#string-update-value)  | optional | External system identifier - custom identifier used by an external system such as an external database. |
+| `WebsiteUrl` |  [String update value](_objects.md#string-update-value)  | optional | The website url of the company. |
 
 #### Company options update value
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Invoiceable` | [Bool update value](#bool-update-value) | optional | Whether the company is invoiceable or not. |
-| `AddFeesToInvoices` | [Bool update value](#bool-update-value) | optional | Whether the company has an additional fee applied for invoicing or not. |
+| `Invoiceable` | [Bool update value](_objects.md#bool-update-value) | optional | Whether the company is invoiceable or not. |
+| `AddFeesToInvoices` | [Bool update value](_objects.md#bool-update-value) | optional | Whether the company has an additional fee applied for invoicing or not. |
 
 #### Credit rating update value
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Basic` | [string update value](#string-update-value) with possible values of [Credit rating basic](#credit-rating-basic)| optional | The level of creditworthiness of the company. |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
-
-#### Bool update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | bool | optional | Value which is to be updated. |
+| `Basic` | [string update value](_objects.md#string-update-value) with possible values of [Credit rating basic](#credit-rating-basic)| optional | The level of creditworthiness of the company. |
 
 ### Response
 

--- a/operations/companionships.md
+++ b/operations/companionships.md
@@ -37,7 +37,7 @@ Returns all companionships based on customers, reservations or reservation group
 | `CustomerIds` | array of string | optional, max 1000 items | Unique identifiers of [Customers](customers.md#customer). |
 | `ReservationIds` | array of string | optional, max 1000 items | Unique identifiers of [Reservations](reservations.md#reservation). |
 | `ReservationGroupIds` | array of string | optional, max 1000 items | Unique identifiers of [Reservation groups](reservations.md#reservation-group). |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Companionship](#companionship) was updated. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Companionship](#companionship) was updated. |
 | `Extent` | [Companionship extent](#companionship-extent) | required | Extent of data to be returned. E.g. it is possible to specify that together with the companionships, customers, reservations, and reservation groups should be also returned. |
 
 #### Companionship extent

--- a/operations/companycontracts.md
+++ b/operations/companycontracts.md
@@ -237,43 +237,25 @@ Updates one or more company contracts.
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `TravelAgencyContractId` | string | required | Unique identifier of the Travel agency contract. |
-| `CommissionIncluded` | [Bool update value](#bool-update-value) | optional | Whether commission of the travel agency is included in the rate. |
-| `Commission` | [Number update value](#number-update-value) | optional | Commission of the travel agency. |
-| `ChannelManagerAbsoluteAdjustment` | [Number update value](#number-update-value) | optional | Flat fee added to (or subtracted from) the reservation price when coming from Channel Managers. |
-| `ChannelManagerRelativeAdjustment` | [Number update value](#number-update-value) | optional | Percentage of the reservation price added to (or subtracted from) price when coming from Channel Managers. |
+| `CommissionIncluded` | [Bool update value](_objects.md#bool-update-value) | optional | Whether commission of the travel agency is included in the rate. |
+| `Commission` | [Number update value](_objects.md#number-update-value) | optional | Commission of the travel agency. |
+| `ChannelManagerAbsoluteAdjustment` | [Number update value](_objects.md#number-update-value) | optional | Flat fee added to (or subtracted from) the reservation price when coming from Channel Managers. |
+| `ChannelManagerRelativeAdjustment` | [Number update value](_objects.md#number-update-value) | optional | Percentage of the reservation price added to (or subtracted from) price when coming from Channel Managers. |
 | `Options` | [Travel agency contract update options](#travel-agency-contract-update-options) | optional | Options of the travel agency contract. |
-| `AccountingCode` | [String update value](#string-update-value) | optional | Accounting code of the travel agency contract. |
-| `InvoiceDueInterval` | [String update value](#string-update-value) | optional | The maximum time, when the invoice has to be be paid in ISO 8601 duration format. |
-| `ChannelManagerBusinessSegmentId` | [String update value](#string-update-value) | optional | Unique identifier of the [Business segment](businesssegments.md#business-segment) used for incoming reservations originating from Channel Managers, for this particular contract. |
-| `ContactPerson` | [String update value](#string-update-value) | optional | Contact person of the travel agency. |
-| `ContactEmail` | [String update value](#string-update-value) | optional | Contact email of the travel agency. |
-| `AdditionalContactInfo` | [String update value](#string-update-value) | optional | Additional contact info of the travel agency. |
-| `Notes` | [String update value](#string-update-value) | optional | Additional notes of the travel agency contract. |
+| `AccountingCode` | [String update value](_objects.md#string-update-value) | optional | Accounting code of the travel agency contract. |
+| `InvoiceDueInterval` | [String update value](_objects.md#string-update-value) | optional | The maximum time, when the invoice has to be be paid in ISO 8601 duration format. |
+| `ChannelManagerBusinessSegmentId` | [String update value](_objects.md#string-update-value) | optional | Unique identifier of the [Business segment](businesssegments.md#business-segment) used for incoming reservations originating from Channel Managers, for this particular contract. |
+| `ContactPerson` | [String update value](_objects.md#string-update-value) | optional | Contact person of the travel agency. |
+| `ContactEmail` | [String update value](_objects.md#string-update-value) | optional | Contact email of the travel agency. |
+| `AdditionalContactInfo` | [String update value](_objects.md#string-update-value) | optional | Additional contact info of the travel agency. |
+| `Notes` | [String update value](_objects.md#string-update-value) | optional | Additional notes of the travel agency contract. |
 
 #### Travel agency contract update options
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `IncludeCancellationFeeInCommissionEstimate` | [Bool update value](#bool-update-value) | required | Cancellation fee will be considered when calculating the travel agency commission estimate. |
-| `SkipAutomaticSettlement` | [Bool update value](#bool-update-value) | required | Reservations from travel agencies will not be automatically charged. |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
-
-#### Number update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | number | optional | Value which is to be updated. |
-
-#### Bool update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | bool | optional | Value which is to be updated. |
+| `IncludeCancellationFeeInCommissionEstimate` | [Bool update value](_objects.md#bool-update-value) | required | Cancellation fee will be considered when calculating the travel agency commission estimate. |
+| `SkipAutomaticSettlement` | [Bool update value](_objects.md#bool-update-value) | required | Reservations from travel agencies will not be automatically charged. |
 
 ### Response
 

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -62,19 +62,12 @@ Returns all customers filtered by identifiers, emails, names and other filters. 
 | `FirstNames` | array of string | optional, max 1000 items | First names of the [Customers](#customer). |
 | `LastNames` | array of string | optional, max 1000 items | Last names of the [Customers](#customer). |
 | `LoyaltyCodes` | array of string | optional, max 1000 items | Loyalty codes of the [Customers](#customer). |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which [Customer](#customer) was created. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which [Customer](#customer) was updated. |
-| `DeletedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which [Customer](#customer) was deleted. `ActivityStates` value `Deleted` should be provided with this filter to get expected results. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which [Customer](#customer) was created. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which [Customer](#customer) was updated. |
+| `DeletedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which [Customer](#customer) was deleted. `ActivityStates` value `Deleted` should be provided with this filter to get expected results. |
 | `ActivityStates` | array of string [Activity state](vouchers.md#activity-state) | optional | Whether return only active, only deleted or both records. |
 | `Extent` | [Customer extent](#customer-extent) | required | Extent of data to be returned. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of customers returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 #### Customer extent
 
@@ -576,14 +569,8 @@ Updates personal information of a customer. Note that if any of the fields is le
 | `Address` | [Address parameters](#address-parameters)  | optional | New address details. |
 | `Classifications` | array of [Customer classification](#customer-classification) | optional | New classifications of the customer. |
 | `Options` | array of [Customer option](#customer-option) | optional | Options of the customer. |
-| `ItalianDestinationCode` | [String update value](#string-update-value) | optional | New Italian destination code of customer. |
-| `ItalianFiscalCode` | [String update value](#string-update-value) | optional | New Italian fiscal code of customer. |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
+| `ItalianDestinationCode` | [String update value](_objects.md#string-update-value) | optional | New Italian destination code of customer. |
+| `ItalianFiscalCode` | [String update value](_objects.md#string-update-value) | optional | New Italian fiscal code of customer. |
 
 ### Response
 

--- a/operations/loyaltymemberships.md
+++ b/operations/loyaltymemberships.md
@@ -55,17 +55,10 @@ Note this operation uses [Pagination](../guidelines/pagination.md).
 | `LoyaltyMembershipIds` | array of string | optional, max 1000 items | Unique identifiers of [Loyalty memberships](#loyalty-membership). |
 | `LoyaltyProgramIds` | array of string | optional, max 1000 items | Unique identifiers of [Loyalty programs](loyaltyprograms.md#loyalty-program). |
 | `AccountIds` | array of string | optional, max 1000 items | Unique identifiers of accounts (for example [Customers](customers.md#customer) or [Companies](companies.md#company)) the membership is associated with. |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Loyalty membership](#loyalty-membership) creation date and time. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Loyalty membership](#loyalty-membership) last update date and time. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of [Loyalty membership](#loyalty-membership) creation date and time. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of [Loyalty membership](#loyalty-membership) last update date and time. |
 | `ActivityStates` | array of string [Activity state](#activity-state) | required | Whether return only active, only deleted or both records. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 #### Activity state
 
@@ -237,31 +230,12 @@ Updates information about the specified loyalty memberships.
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `LoyaltyMembershipId` | string | required | Unique identifier of the loyalty membership. |
-| `LoyaltyProgramId` | [String update value](#string-update-value) | optional | Unique identifier of the loyalty program \(or `null` if the program should not be updated\). |
-| `IsPrimary` | [Bool update value](#bool-update-value) | optional | Boolean value defining the primary loyalty membership for the account. \(or `null` if the value should not be updated\).  |
-| `Points` | [Integer update value](#integer-update-value) | optional | The loyalty points the account has in the loyalty membership \(or `null` if the points should not be updated\). |
-| `Code` | [String update value](#string-update-value) | optional | Code of the loyalty membership. \(or `null` if the code should not be updated\). |
-| `ExpirationDate` | [String update value](#string-update-value) | optional | Expiration date of the loyalty membership in UTC timezone in ISO 8601 format \(or `null` if the date should not be updated\). |
-| `Url` | [String update value](#string-update-value) | optional | Url of the loyalty membership \(or `null` if the url should not be updated\). |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| --- | --- | --- | --- |
-| `Value` | string | optional | Value which is to be updated. |
-
-#### Bool update value
-
-| Property | Type | Contract | Description |
-| --- | --- | --- | --- |
-| `Value` | bool | optional | Value which is to be updated. |
-
-#### Integer update value
-
-| Property | Type | Contract | Description |
-| --- | --- | --- | --- |
-| `Value` | integer | optional | Value which is to be updated. |
-
+| `LoyaltyProgramId` | [String update value](_objects.md#string-update-value) | optional | Unique identifier of the loyalty program \(or `null` if the program should not be updated\). |
+| `IsPrimary` | [Bool update value](_objects.md#bool-update-value) | optional | Boolean value defining the primary loyalty membership for the account. \(or `null` if the value should not be updated\).  |
+| `Points` | [Integer update value](_objects.md#integer-update-value) | optional | The loyalty points the account has in the loyalty membership \(or `null` if the points should not be updated\). |
+| `Code` | [String update value](_objects.md#string-update-value) | optional | Code of the loyalty membership. \(or `null` if the code should not be updated\). |
+| `ExpirationDate` | [String update value](_objects.md#string-update-value) | optional | Expiration date of the loyalty membership in UTC timezone in ISO 8601 format \(or `null` if the date should not be updated\). |
+| `Url` | [String update value](_objects.md#string-update-value) | optional | Url of the loyalty membership \(or `null` if the url should not be updated\). |
 
 ### Response
 

--- a/operations/loyaltyprograms.md
+++ b/operations/loyaltyprograms.md
@@ -45,17 +45,10 @@ Note this operation uses [Pagination](../guidelines/pagination.md).
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `LoyaltyProgramIds` | array of string | optional, max 1000 items | Unique identifiers of [Loyalty programs](#loyalty-program). |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Loyalty program](#loyalty-program) creation date and time. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Loyalty program](#loyalty-program) last update date and time. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of [Loyalty program](#loyalty-program) creation date and time. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of [Loyalty program](#loyalty-program) last update date and time. |
 | `ActivityStates` | array of string [Activity state](vouchers.md#activity-state) | required | Whether return only active, only deleted or both records. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 ### Response
 
@@ -186,13 +179,7 @@ Updates information about the specified loyalty programs.
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `LoyaltyProgramId` | string | required | Unique identifier of the loyalty program. |
-| `Name` | [String update value](#string-update-value) | optional | Name of the loyalty program \(or `null` if the name should not be updated\). |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| --- | --- | --- | --- |
-| `Value` | string | optional | Value which is to be updated. |
+| `Name` | [String update value](_objects.md#string-update-value) | optional | Name of the loyalty program \(or `null` if the name should not be updated\). |
 
 ### Response
 

--- a/operations/messages.md
+++ b/operations/messages.md
@@ -33,7 +33,7 @@ Get all messages belonging to the specified [Message threads](messagethreads.md#
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `MessageThreadIds` | array of string | required, max 1000 items | Unique identifiers of [Message threads](messagethreads.md#message-thread) from where to return messages. |
-| `CreatedUtc` | [Time interval](messagethreads.md#time-interval) | optional, max length 1 months | Interval in which the [Message](#message) was created. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 1 months | Interval in which the [Message](#message) was created. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of message data returned (using cursor pagination). |
 
 ### Response

--- a/operations/messagethreads.md
+++ b/operations/messagethreads.md
@@ -30,16 +30,9 @@ Get all message threads that you have created, filtered by time interval and/or 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `MessageThreadIds` | array of string | optional, max 1000 items | Unique identifiers of [Message threads](#message-thread). Required if no other filter is provided. |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was created. Required if no other filter is provided. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was updated. Required if no other filter is provided. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was created. Required if no other filter is provided. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Message thread](#message-thread) was updated. Required if no other filter is provided. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of message thread data returned (using cursor pagination). |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 ### Response
 

--- a/operations/outletitems.md
+++ b/operations/outletitems.md
@@ -38,18 +38,11 @@ Returns all outlet items of the enterprise that were consumed \(posted\) or will
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `ConsumedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Outlet item](#outlet-item) was consumed. Required if no other filter is provided. |
-| `ClosedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Outlet bill](#outlet-bill) was closed. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Outlet bill](#outlet-bill) was updated. |
+| `ConsumedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Outlet item](#outlet-item) was consumed. Required if no other filter is provided. |
+| `ClosedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Outlet bill](#outlet-bill) was closed. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Outlet bill](#outlet-bill) was updated. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](currencies.md#currency) the item costs should be converted to. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of outlet items returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 ### Response
 

--- a/operations/rates.md
+++ b/operations/rates.md
@@ -38,7 +38,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 | `Client` | string | required | Name and version of the client application. |
 | `ServiceIds` | array of string | required, max 1000 items | Unique identifiers of the [Services](services.md#service) from which the rates are requested. |
 | `RateIds` | array of [Rates](#rate) | optional, max 1000 items | Unique identifiers of the requested [Rates](rates.md#rate). |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Rates](rates.md#rates) were updated. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Rates](rates.md#rates) were updated. |
 | `Extent` | [Rate extent](#rate-extent) | required | Extent of data to be returned. |
 
 #### Rate extent
@@ -48,13 +48,6 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 | `Rates` | bool | optional | Whether the response should contain rates. |
 | `RateGroups` | bool | optional | Whether the response should contain rate groups. |
 | `AvailabilityBlockAssignments` | bool | optional | Whether the response should contain availability block assignments. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 ### Response
 

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -766,40 +766,22 @@ Updates information about the specified reservations. Note that if any of the fi
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `ReservationId` | string | required | Unique identifier of the [Reservation](#reservation). |
-| `StartUtc` | [String update value](#string-update-value) | optional | Reservation start in UTC timezone in ISO 8601 format. \(or `null` if the start time should not be updated). |
-| `EndUtc` | [String update value](#string-update-value) | optional | Reservation end in UTC timezone in ISO 8601 format. \(or `null` if the end time should not be updated). |
-| `AssignedResourceId` | [String update value](#string-update-value) | optional | Identifier of the assigned [Resource](resources.md#resource). |
-| `AssignedResourceLocked` | [Bool update value](#bool-update-value) | optional | Whether the reservation should be locked to the assigned [Resource](resources.md#resource). Unlocking and assigning reservation to new [Resource](resources.md#resource) can be done in one call. |
-| `ChannelNumber` | [String update value](#string-update-value) | optional | Number of the reservation within the Channel (i.e. OTA, GDS, CRS, etc) in case the reservation group originates there (e.g. Booking.com confirmation number) \(or `null` if the channel number should not be updated). |
-| `RequestedCategoryId` | [String update value](#string-update-value) | optional | Identifier of the requested [Resource category](resources.md#resource-category) \(or `null` if resource category should not be updated). |
-| `TravelAgencyId` | [String update value](#string-update-value) | optional | Identifier of the [Company](companies.md#company) that mediated the reservation \(or `null` if travel agency should not be updated). |
-| `CompanyId` | [String update value](#string-update-value) | optional | Identifier of the [Company](companies.md#company) on behalf of which the reservation was made \(or `null` if company should not be updated). |
-| `BusinessSegmentId` | [String update value](#string-update-value) | optional | Identifier of the reservation [Business segment](businesssegments.md#business-segment) \(or `null` if the business segment should not be updated).|
-| `Purpose` | [String update value](#string-update-value) | optional | [Purpose](#reservation-purpose) of the reservation \(or `null` if the purpose should not be updated).|
-| `RateId` | [String update value](#string-update-value) | optional | Identifier of the reservation [Rate](rates.md#rate) \(or `null` if the rate should not be updated). |
-| `BookerId` | [String update value](#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the booker should not be updated). |
+| `StartUtc` | [String update value](_objects.md#string-update-value) | optional | Reservation start in UTC timezone in ISO 8601 format. \(or `null` if the start time should not be updated). |
+| `EndUtc` | [String update value](_objects.md#string-update-value) | optional | Reservation end in UTC timezone in ISO 8601 format. \(or `null` if the end time should not be updated). |
+| `AssignedResourceId` | [String update value](_objects.md#string-update-value) | optional | Identifier of the assigned [Resource](resources.md#resource). |
+| `AssignedResourceLocked` | [Bool update value](_objects.md#bool-update-value) | optional | Whether the reservation should be locked to the assigned [Resource](resources.md#resource). Unlocking and assigning reservation to new [Resource](resources.md#resource) can be done in one call. |
+| `ChannelNumber` | [String update value](_objects.md#string-update-value) | optional | Number of the reservation within the Channel (i.e. OTA, GDS, CRS, etc) in case the reservation group originates there (e.g. Booking.com confirmation number) \(or `null` if the channel number should not be updated). |
+| `RequestedCategoryId` | [String update value](_objects.md#string-update-value) | optional | Identifier of the requested [Resource category](resources.md#resource-category) \(or `null` if resource category should not be updated). |
+| `TravelAgencyId` | [String update value](_objects.md#string-update-value) | optional | Identifier of the [Company](companies.md#company) that mediated the reservation \(or `null` if travel agency should not be updated). |
+| `CompanyId` | [String update value](_objects.md#string-update-value) | optional | Identifier of the [Company](companies.md#company) on behalf of which the reservation was made \(or `null` if company should not be updated). |
+| `BusinessSegmentId` | [String update value](_objects.md#string-update-value) | optional | Identifier of the reservation [Business segment](businesssegments.md#business-segment) \(or `null` if the business segment should not be updated).|
+| `Purpose` | [String update value](_objects.md#string-update-value) | optional | [Purpose](#reservation-purpose) of the reservation \(or `null` if the purpose should not be updated).|
+| `RateId` | [String update value](_objects.md#string-update-value) | optional | Identifier of the reservation [Rate](rates.md#rate) \(or `null` if the rate should not be updated). |
+| `BookerId` | [String update value](_objects.md#string-update-value) | optional | Identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. \(or `null` if the booker should not be updated). |
 | `TimeUnitPrices` | [Time unit amount update value](#time-unit-amount-update-value) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. \(or `null` if the unit amounts should not be updated). |
 | `PersonCounts` | array of [Person counts update value](#person-counts-update-value) | optional | Number of people per age category the reservation is for. Is supplied the person counts will be replaced. \(or `null` if the person counts should not be updated). |
-| `CreditCardId` | [String update value](#string-update-value) | optional | Identifier of [Credit card](creditcards.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation.  \(or `null` if the credit card should not be updated). |
-| `AvailabilityBlockId` | [String update value](#string-update-value) | optional | Unique identifier of the [Availability block](availabilityblocks.md#availability-block) the reservation is assigned to. |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
-
-#### Number update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | number | optional | Value which is to be updated. |
-
-#### Bool update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | bool | optional | Value which is to be updated. |
+| `CreditCardId` | [String update value](_objects.md#string-update-value) | optional | Identifier of [Credit card](creditcards.md#credit-card) belonging to [Customer](customers.md#customer) who owns the reservation.  \(or `null` if the credit card should not be updated). |
+| `AvailabilityBlockId` | [String update value](_objects.md#string-update-value) | optional | Unique identifier of the [Availability block](availabilityblocks.md#availability-block) the reservation is assigned to. |
 
 #### Time unit amount update value
 

--- a/operations/resourceaccesstokens.md
+++ b/operations/resourceaccesstokens.md
@@ -40,16 +40,9 @@ Returns all resource access tokens based on resource access token identifiers, r
 | `Client` | string | required | Name and version of the client application. |
 | `ResourceAccessTokenIds` | array of string | optional, max 1000 items | Unique identifiers of [Resource access tokens](#resource-access-token). Required if no other filter is provided. |
 | `ServiceOrderIds` | array of string | optional, max 1000 items | Unique identifiers of service orders (for example [Reservation](reservations.md#reservation)). Required if no other filter is provided. |
-| `CollidingUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Resource access token](#resource-access-token) is valid. Required if no other filter is provided. |
+| `CollidingUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Resource access token](#resource-access-token) is valid. Required if no other filter is provided. |
 | `ActivityStates` | array of string [Activity state](vouchers.md#activity-state) | required | Whether return only active, only deleted or both records. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of tokens returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 ### Response
 
@@ -173,16 +166,10 @@ Adds new resource access tokens with the specified data.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Bed` | [Bool update value](#bool-update-value) | optional | Specify whether [Resource access token](#resource-access-token) grants permission to access bed. |
-| `Room` | [Bool update value](#bool-update-value) | optional | Specify whether [Resource access token](#resource-access-token) grants permission to access room. |
-| `Floor` | [Bool update value](#bool-update-value) | optional | Specify whether [Resource access token](#resource-access-token) grants permission to access floor. |
-| `Building` | [Bool update value](#bool-update-value) | optional | Specify whether [Resource access token](#resource-access-token) grants permission to access building. |
-
-#### Bool update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | bool | optional | Value which is to be updated. |
+| `Bed` | [Bool update value](_objects.md#bool-update-value) | optional | Specify whether [Resource access token](#resource-access-token) grants permission to access bed. |
+| `Room` | [Bool update value](_objects.md#bool-update-value) | optional | Specify whether [Resource access token](#resource-access-token) grants permission to access room. |
+| `Floor` | [Bool update value](_objects.md#bool-update-value) | optional | Specify whether [Resource access token](#resource-access-token) grants permission to access floor. |
+| `Building` | [Bool update value](_objects.md#bool-update-value) | optional | Specify whether [Resource access token](#resource-access-token) grants permission to access building. |
 
 ### Response
 
@@ -256,16 +243,10 @@ Updates the [Resource access token](#resource-access-token) validity interval an
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `ResourceAccessTokenId` | [String update value](#string-update-value) | required | Unique identifier of [Resource access token](#resource-access-token). |
-| `ValidityStartUtc` | [String update value](#string-update-value) | optional | Marks the start of interval in which the resource access token can be used. |
-| `ValidityEndUtc` | [String update value](#string-update-value) | optional | Marks the end of interval in which the resource access token can be used. |
+| `ResourceAccessTokenId` | [String update value](_objects.md#string-update-value) | required | Unique identifier of [Resource access token](#resource-access-token). |
+| `ValidityStartUtc` | [String update value](_objects.md#string-update-value) | optional | Marks the start of interval in which the resource access token can be used. |
+| `ValidityEndUtc` | [String update value](_objects.md#string-update-value) | optional | Marks the end of interval in which the resource access token can be used. |
 | `Permissions` | [Resource access token permission parameter](#resource-access-token-permission-parameter) | optional | Specify permissions of [Resource access token](#resource-access-token). |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
 
 ### Response
 

--- a/operations/resourceblocks.md
+++ b/operations/resourceblocks.md
@@ -44,17 +44,10 @@ Returns all resource blocks \(out of order blocks or internal use blocks\).
 | `Client` | string | required | Name and version of the client application. |
 | `ResourceBlockIds` | array of string | optional, max 1000 items | Unique identifiers of the requested [Resource blocks](#resource-block). |
 | `AssignedResourceIds` | array of string | optional, max 1000 items | Unique identifiers of the requested Assigned [Resources](resources.md#resource). |
-| `CollidingUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Resource block](#resource-block) is active. |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Resource block](#resource-block) was created. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Resource block](#resource-block) was updated. |
+| `CollidingUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Resource block](#resource-block) is active. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Resource block](#resource-block) was created. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Resource block](#resource-block) was updated. |
 | `Extent` | [Resource block extent](#resource-block-extent) | required | Extent of data to be returned. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
 
 #### Resource block extent
 

--- a/operations/resources.md
+++ b/operations/resources.md
@@ -361,11 +361,11 @@ Updates details of the resources.
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `ResourceId` | string | required | Unique identifier of the [Resource](#resource) which is updated. |
-| `Name` | [String update value](#string-update-value) | optional | New name of the resource \(e.g. room number\). |
-| `ParentResourceId` | [String update value](#string-update-value) | optional | Identifier of the new parent [Resource](#resource). |
+| `Name` | [String update value](_objects.md#string-update-value) | optional | New name of the resource \(e.g. room number\). |
+| `ParentResourceId` | [String update value](_objects.md#string-update-value) | optional | Identifier of the new parent [Resource](#resource). |
 | `Data` | [Resource data update](#resource-data-update) | optional | New additional data of the resource. |
-| `State` | [String update value](#string-update-value) | optional | New [Resource state](#resource-state) except `OutOfOrder`. |
-| `StateReason` | [String update value](#string-update-value) | optional | New reason for the state of the resource. |
+| `State` | [String update value](_objects.md#string-update-value) | optional | New [Resource state](#resource-state) except `OutOfOrder`. |
+| `StateReason` | [String update value](_objects.md#string-update-value) | optional | New reason for the state of the resource. |
 
 #### Resource data update
 
@@ -378,14 +378,8 @@ Updates details of the resources.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `FloorNumber` | [String update value](#string-update-value) | required | New number of the floor the space is on. |
-| `LocationNotes` | [String update value](#string-update-value) | optional | New location notes for the space. |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
+| `FloorNumber` | [String update value](_objects.md#string-update-value) | required | New number of the floor the space is on. |
+| `LocationNotes` | [String update value](_objects.md#string-update-value) | optional | New location notes for the space. |
 
 ### Response
 

--- a/operations/restrictions.md
+++ b/operations/restrictions.md
@@ -47,16 +47,9 @@ Returns all restrictions of the default service provided by the enterprise.
 | `RateIds` | array of string | optional, max 1000 items | Unique identifiers of [Rates](rates.md#rate). Returns all restrictions that affect the given rates, i.e. ones without any [Restriction Conditions](#restriction-conditions), ones assigned directly to specified rates, ones assigned to [Rate groups](rates.md#rate-group) of specified rates, or ones inherited from base rates. |
 | `BaseRateIds` | array of string | optional, max 1000 items | Unique identifiers of [Rates](rates.md#rate). Returns only those restrictions which have matching `BaseRateId` set in [Restriction Conditions](#restriction-conditions). |
 | `ExactRateIds` | array of string | optional, max 1000 items | Unique identifiers of [Rates](rates.md#rate). Returns only those restrictions which have matching `ExactRateId` set in [Restriction Conditions](#restriction-conditions). |
-| `CollidingUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Restriction](#restriction) is active. Required if no other filter is provided. |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Restriction](#restriction) was created. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Restriction](#restriction) was updated. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
+| `CollidingUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Restriction](#restriction) is active. Required if no other filter is provided. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Restriction](#restriction) was created. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Restriction](#restriction) was updated. |
 
 ### Response
 

--- a/operations/routingrules.md
+++ b/operations/routingrules.md
@@ -273,18 +273,12 @@ Updates routing rules.
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `RoutingRuleId` | string | required | Unique identifier of the routing rule. |
-| `CompanyId` | [String update value](#string-update-value) | optional | Unique identifier of the [Company](companies.md#company) \(or `null` should it not be updated\). |
-| `CompanyRelation` | [String update value](#string-update-value)| optional | [Company relation](routingrules.md#company-relation) to the routing rule \(or `null` should it not be updated\). |
-| `ServiceId` | [String update value](#string-update-value) | required | Unique identifier of the [Service](services.md#service) routing rule is assigned to \(or `null` should it not be updated\). |
-| `Applicability` | [String update value](#string-update-value) | required | [Applicability](routingrules.md#applicability) that determines if routing rule apply to all future reservations with this company or travel agency attached or only future reservations that are prepaid in online travel agency (OTA) \(or `null` should it not be updated\). |
-| `RouteType` | [String update value](#string-update-value) | required | What should be routed [Route type](routingrules.md#route-type) \(or `null` should it not be updated\). |
+| `CompanyId` | [String update value](_objects.md#string-update-value) | optional | Unique identifier of the [Company](companies.md#company) \(or `null` should it not be updated\). |
+| `CompanyRelation` | [String update value](_objects.md#string-update-value)| optional | [Company relation](routingrules.md#company-relation) to the routing rule \(or `null` should it not be updated\). |
+| `ServiceId` | [String update value](_objects.md#string-update-value) | required | Unique identifier of the [Service](services.md#service) routing rule is assigned to \(or `null` should it not be updated\). |
+| `Applicability` | [String update value](_objects.md#string-update-value) | required | [Applicability](routingrules.md#applicability) that determines if routing rule apply to all future reservations with this company or travel agency attached or only future reservations that are prepaid in online travel agency (OTA) \(or `null` should it not be updated\). |
+| `RouteType` | [String update value](_objects.md#string-update-value) | required | What should be routed [Route type](routingrules.md#route-type) \(or `null` should it not be updated\). |
 | `SelectedStayItems` | [Selected stay items update parameters](routingrules.md#selected-stay-items-update-parameters) | optional | To which stay items routing rule applies to. Required only if RouteType value is SelectedStayItems. |
-
-#### String update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | string | optional | Value which is to be updated. |
 
 #### String array update value
 
@@ -292,18 +286,12 @@ Updates routing rules.
 | :-- | :-- | :-- | :-- |
 | `Value` | array of string | optional | Value which is to be updated. |
 
-#### Bool update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | bool | optional | Value which is to be updated. |
-
 #### Selected stay items update parameters
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Nights` | [Bool update value](#bool-update-value) | optional | Whether routing rule applies to nights \(or `null` should it not be updated\). |
-| `CityTax` | [Bool update value](#bool-update-value) | optional | Whether routing rule applies to city tax \(or `null` should it not be updated\). |
+| `Nights` | [Bool update value](_objects.md#bool-update-value) | optional | Whether routing rule applies to nights \(or `null` should it not be updated\). |
+| `CityTax` | [Bool update value](_objects.md#bool-update-value) | optional | Whether routing rule applies to city tax \(or `null` should it not be updated\). |
 | `ProductCategoryIds` | [String array update value](#string-array-update-value) | optional | Product categories to which the routing rule applies \(or `null` should it not be updated\). |
 
 ### Response

--- a/operations/services.md
+++ b/operations/services.md
@@ -268,13 +268,7 @@ Updates the number of available resources in [Resource category](resources.md#re
 | `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last [time unit](services.md#time-unit), in UTC timezone ISO 8601 format. The maximum size of time interval is 100 time units or 2 years, whichever is the shorter amount of time. |
 | `AvailabilityBlockId` | string | optional | Unique identifier of the [Availability block](availabilityblocks.md#availability-block) whose availability to update. |
 | `ResourceCategoryId` | string | required | Unique identifier of the [Resource category](resources.md#resource-category) whose availability to update. |
-| `UnitCountAdjustment` | [Number update value](#number-update-value) | required | Adjustment value to be applied on the interval, can be both positive and negative (relative adjustment, not an absolute number). If specified without `Value` parameter, removes all adjustments within the interval. |
-
-#### Number update value
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Value` | number | optional | Value which is to be updated. |
+| `UnitCountAdjustment` | [Number update value](_objects.md#number-update-value) | required | Adjustment value to be applied on the interval, can be both positive and negative (relative adjustment, not an absolute number). If specified without `Value` parameter, removes all adjustments within the interval. |
 
 ### Response
 

--- a/operations/sourceassignments.md
+++ b/operations/sourceassignments.md
@@ -33,7 +33,7 @@ Returns all [Sources](sources.md#source) assigned to a [Reservation group](reser
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ReservationGroupIds` | array of string | required, max 1000 items | Unique identifiers of the [Reservation group](reservations.md#reservation-group). |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Reservation group](reservations.md#reservation-group) last update date and time. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of [Reservation group](reservations.md#reservation-group) last update date and time. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of source assignment data returned. |
 
 ### Response

--- a/operations/sources.md
+++ b/operations/sources.md
@@ -34,7 +34,7 @@ Returns all sources from which reservations can originate. Note this operation u
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Source](sources.md#source) was updated. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Source](sources.md#source) was updated. |
 | `SourceIds` | array of string | optional, max 1000 items | Unique identifiers of [Sources](sources.md#source). |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of source data returned. |
 

--- a/operations/tasks.md
+++ b/operations/tasks.md
@@ -89,16 +89,9 @@ Returns all tasks of the enterprise, filtered by identifiers or other filters.
 | `TaskIds` | array of string | optional, max 1000 items | Unique identifiers of [Tasks](#task). |
 | `DepartmentIds` | array of string | optional, max 1000 items | Unique identifiers of [Departments](departments.md#department). Not possible to be used standalone, needs to be used in combination with other filters. |
 | `ServiceOrderIds` | array of string  | optional, max 1000 items | Unique identifiers of Service orders (for example a [Reservation](reservations.md#reservation) or Product order). |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Task](#task) was created. |
-| `ClosedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Task](#task) was closed. |
-| `DeadlineUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Task](#task) has a deadline. |
-
-#### Time interval
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `StartUtc` | string | required | Start of the interval in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | End of the interval in UTC timezone in ISO 8601 format. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Task](#task) was created. |
+| `ClosedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Task](#task) was closed. |
+| `DeadlineUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Task](#task) has a deadline. |
 
 ### Response
 


### PR DESCRIPTION
#### Summary

* Added new page 'Common objects' under Operations
* Removed all duplicate instances of common object definitions, like `time interval` and `string update value`
* Updated all references to point to the common objects

In due course I will update the Style Guide to describe the change in policy.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
