### PR TITLE
Reservation cancel parameter name fix

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3rd April 2023
+
+* Fixed name of parameter `PostCancellationFee` in [Reservation cancel](../operations/reservations.md#cancel-reservation).
+
 ## 27th March 2023
 
 * Updated [loyalty programs](../operations/loyaltyprograms.md) and [loyalty memberships](../operations/loyaltymemberships.md) operations as restricted.

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -952,7 +952,7 @@ Cancels all reservation with specified identifiers. Succeeds only if the reserva
     "ReservationIds": [
         "5ca70705-cbb7-48c4-8cc4-abb900aa278c"
     ],
-    "ChargeCancellationFee": true,
+    "PostCancellationFee": true,
     "Notes": "Cancellation through Connector API"
 }
 ```
@@ -963,7 +963,7 @@ Cancels all reservation with specified identifiers. Succeeds only if the reserva
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `ReservationIds` | array of string | required | Unique identifiers of the [Reservations](#reservation) to cancel. |
-| `ChargeCancellationFee` | boolean | required | Whether cancellation fees should be charged according to rate conditions. |
+| `PostCancellationFee` | boolean | required | Whether cancellation fees should be charged according to rate conditions. |
 | `Notes` | string | required | Additional notes describing the reason for the cancellation. |
 
 ### Response


### PR DESCRIPTION
#### Summary

Fixed mistake in parameter name in `reservations/cancel`.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
