### PR TITLE
Add travel agency id to rules/getall

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5th April 2023
+
+* Extended [Get all rules](../operations/rules.md#get-all-rules) response with `TravelAgencyId` in [Rule conditions](../operations/rules.md#rule-conditions).
+
 ## 4th April 2023
 
 * Added operation [Get all payments](../operations/payments.md#get-all-payments).

--- a/operations/rules.md
+++ b/operations/rules.md
@@ -130,7 +130,7 @@ Returns all rules applied with the reservations.
 | `ResourceCategoryId` | [Rule condition](#rule-condition) | required | Condition based on [Resource category](resources.md#resource-category). |
 | `ResourceCategoryType` | [Rule condition](#rule-condition) | required | Condition based on [Resource category type](resources.md#resource-category-type). |
 | `Origin` | [Rule condition](#rule-condition) | required | Condition based on [Reservation origin](reservations.md#reservation-origin). |
-| `TravelAgencyId` | [Rule condition](#rule-condition) | required | Condition based on [Company](companies.md#company) that is travel agency. |
+| `TravelAgencyId` | [Rule condition](#rule-condition) | required | Condition based on [Company](companies.md#company). |
 | `MinimumTimeUnitCount` | string | required | Condition based on minimum amount of time units. |
 | `MaximumTimeUnitCount` | string | required | Condition based on maximum amount of time units. |
 

--- a/operations/rules.md
+++ b/operations/rules.md
@@ -65,6 +65,7 @@ Returns all rules applied with the reservations.
                     "Value": "Connector",
                     "ConditionType": "NotEquals"
                 },
+                "TravelAgencyId": null,
                 "MinimumTimeUnitCount": null,
                 "MaximumTimeUnitCount": null
             }
@@ -129,6 +130,7 @@ Returns all rules applied with the reservations.
 | `ResourceCategoryId` | [Rule condition](#rule-condition) | required | Condition based on [Resource category](resources.md#resource-category). |
 | `ResourceCategoryType` | [Rule condition](#rule-condition) | required | Condition based on [Resource category type](resources.md#resource-category-type). |
 | `Origin` | [Rule condition](#rule-condition) | required | Condition based on [Reservation origin](reservations.md#reservation-origin). |
+| `TravelAgencyId` | [Rule condition](#rule-condition) | required | Condition based on [Company](companies.md#company) that is travel agency. |
 | `MinimumTimeUnitCount` | string | required | Condition based on minimum amount of time units. |
 | `MaximumTimeUnitCount` | string | required | Condition based on maximum amount of time units. |
 


### PR DESCRIPTION
#### Summary

Extended `rule-conditions` in `rules/getall` with `TravelAgencyId`.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
