### PR TITLE
Fix description of external identifiers

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -84,7 +84,7 @@
 
 ## 20th January 2023
 
-* Added `ExternalIdentifier` to each of the following entities. `ExternalIdentifier` is used for portfolio management to link the entities at an above-enterprise level.
+* Added `ExternalIdentifier` to each of the following entities.
   * [Product](../operations/products.md#product)
   * [Company](../operations/companies.md#company)
   * [Service](../operations/services.md#service)

--- a/operations/companies.md
+++ b/operations/companies.md
@@ -48,7 +48,7 @@ Returns all company profiles of the enterprise, possibly filtered by identifiers
 | `Names` | array of string | optional, max 1000 items | Names of [Companies](#company). |
 | `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Company](#company) creation date and time. |
 | `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval of [Company](#company) last update date and time. |
-| `ExternalIdentifiers` | array of string | optional, max 1000 items | Portfolio-level company identifiers, used for portfolio management; called Company Key in Mews Operations. |
+| `ExternalIdentifiers` | array of string | optional, max 1000 items | External identifier of [Company](#company) from external system. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of customers returned. |
 
 #### Time interval
@@ -174,7 +174,7 @@ Returns all company profiles of the enterprise, possibly filtered by identifiers
 | `CreditRating` | [Credit rating](#credit-rating) | optional | Credit rating to define creditworthiness of the company. |
 | `ReferenceIdentifier` | string | optional | External system identifier - custom identifier used by an external system such as an external database. |
 | `WebsiteUrl` | string | optional | The website url of the company. |
-| `ExternalIdentifier` | string | optional, max 255 characters | Portfolio-level company identifier, chosen by the user for the purposes of portfolio management; called Company Key in Mews Operations. |
+| `ExternalIdentifier` | string | optional, max 255 characters | External identifier of company from external system. |
 
 #### Company options
 
@@ -259,7 +259,7 @@ Adds a new company to the enterprise.
 | `Department` | string | optional | The internal segmentation of a company, e.g. sales department. |
 | `DunsNumber` | string | optional | The Dun & Bradstreet unique 9-digit DUNS number. |
 | `CreditRating` | [Credit rating](#credit-rating) | optional | Credit rating to define creditworthiness of the company. |
-| `ExternalIdentifier` | string | optional, max 255 characters | Portfolio-level company identifier, chosen by the user for the purposes of portfolio management; called Company Key in Mews Operations. |
+| `ExternalIdentifier` | string | optional, max 255 characters | External identifier of the company from external system. |
 | `ReferenceIdentifier` | string | optional | External system identifier - custom identifier used by an external system such as an external database. |
 | `WebsiteUrl` | string | optional | The website url of the company. |
 
@@ -367,7 +367,7 @@ Updates information of the company.
 | `Department` | [String update value](#string-update-value) | optional | The internal segmentation of a company, e.g. sales department. |
 | `DunsNumber` | [String update value](#string-update-value) | optional | The Dun & Bradstreet unique 9-digit DUNS number. |
 | `CreditRating` | [Credit rating update value](#credit-rating-update-value) | optional | Credit rating to define creditworthiness of the company. |
-| `ExternalIdentifier` | string | [String update value](#string-update-value) | optional | Portfolio-level company identifier, chosen by the user for the purposes of portfolio management; called Company Key in Mews Operations. |
+| `ExternalIdentifier` | string | [String update value](#string-update-value) | optional | External identifier of the company from external system. |
 | `ReferenceIdentifier` |  [String update value](#string-update-value)  | optional | External system identifier - custom identifier used by an external system such as an external database. |
 | `WebsiteUrl` |  [String update value](#string-update-value)  | optional | The website url of the company. |
 

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -124,7 +124,7 @@ Returns configuration of the enterprise and the client.
 | `Currencies` | array of [Accepted currency](#accepted-currency) | required | Currencies accepted by the enterprise. |
 | `Pricing` | string | required | [Pricing](#pricing) of the enterprise. |
 | `TaxPrecision` | string | optional | Tax precision used for financial calculations in the enterprise. If `null`, [Currency](currencies.md#currency) precision is used. |
-| `ExternalIdentifier` | string | optional, max 255 characters | Portfolio-level enterprise identifier, chosen by the user for the purposes of portfolio management; called Enterprise Key in Mews Operations. |
+| `ExternalIdentifier` | string | optional, max 255 characters | External identifier of the enterprise from external system. |
 | `AccountingConfiguration` | [Accounting configuration](#accounting-configuration) | optional | Configuration information containg financial information about the property. |
 
 #### Address

--- a/operations/products.md
+++ b/operations/products.md
@@ -145,7 +145,7 @@ Returns all products offered together with the specified services.
 | `Promotions` | [Promotions](services.md#promotions) | required | Promotions of the service. |
 | `Classifications` | [Product classifications](#product-classifications) | required | Classifications of the service. |
 | `UnitAmount` | [Amount value](accountingitems.md#amount-value) | required | Unit amount representing price of the product. |
-| `ExternalIdentifier` | string | optional, max 255 characters | Portfolio-level product identifier, chosen by the user for the purposes of portfolio management; called Product Key in Mews Operations. |
+| `ExternalIdentifier` | string | optional, max 255 characters | External identifier of the product from external system. |
 
 #### Product charging mode
 

--- a/operations/rates.md
+++ b/operations/rates.md
@@ -117,7 +117,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 | `Name` | string | required | Name of the rate. |
 | `ShortName` | string | required | Short name of the rate. |
 | `ExternalNames` | [Localized text](resources.md#localized-text) | required | All translations of the external name of the rate. |
-| `ExternalIdentifier` | string | optional, max 255 characters | Portfolio-level rate identifier, chosen by the user for the purposes of portfolio management; called Rate Key in Mews Operations. |
+| `ExternalIdentifier` | string | optional, max 255 characters | External identifier of the rate from external system. |
 
 #### Rate group
 
@@ -127,7 +127,7 @@ Returns all rates \(pricing setups\) and rate groups \(condition settings\) of t
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service). |
 | `IsActive` | boolean | required | Whether the rate group is still active. |
 | `Name` | string | required | Name of the rate group. |
-| `ExternalIdentifier` | string | optional, max 255 characters | Portfolio-level rate group identifier, chosen by the user for the purposes of portfolio management; called Rate Group Key in Mews Operations. |
+| `ExternalIdentifier` | string | optional, max 255 characters | External identifier of the rate group from external system. |
 
 #### Availability block assignment
 

--- a/operations/resources.md
+++ b/operations/resources.md
@@ -224,7 +224,7 @@ Returns all resources of an enterprise associated with the connector integration
 | `Ordering` | number | required | Ordering of the category, lower number corresponds to lower category \(note that uniqueness nor continuous sequence is guaranteed\). |
 | `Capacity` | number | required | Capacity that can be served \(e.g. bed count\). |
 | `ExtraCapacity` | number | required | Extra capacity that can be served \(e.g. extra bed count\). |
-| `ExternalIdentifier` | string | optional, max 255 characters | Portfolio-level resource category identifier, chosen by the user for the purposes of portfolio management; called Resource Category Key in Mews Operations. |
+| `ExternalIdentifier` | string | optional, max 255 characters | External identifier of the resource category from external system. |
 
 #### Resource category type
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -85,7 +85,7 @@ Returns all services offered by the enterprise.
 | `Name` | string | required | Name of the service. |
 | `Options` | [Service options](#service-options) | required | Options of the service. |
 | `Data` | [Service data](#service-data) | required | Additional information about the specific service. |
-| `ExternalIdentifier` | string | optional, max 255 characters | Portfolio-level service identifier, chosen by the user for the purposes of portfolio management; called Service Key in Mews Operations. |
+| `ExternalIdentifier` | string | optional, max 255 characters | External identifier of the service from external system. |
 
 #### Service options
 

--- a/operations/vouchers.md
+++ b/operations/vouchers.md
@@ -133,7 +133,7 @@ Returns all rate vouchers filtered by [Service](services.md#service), voucher co
 | `ActivityState` | string [Activity state](#activity-state) | required | Whether voucher is active or deleted. |
 | `CompanyId` | string | optional | Unique identifier of [Company](companies.md#company) the voucher is related to. |
 | `TravelAgencyId` | string | optional | Unique identifier of [Company](companies.md#company) with [Travel agency contract](companycontracts.md#travel-agency-contract) the voucher is related to. |
-| `ExternalIdentifier` | string | optional, max 255 characters | Portfolio-level voucher identifier, chosen by the user for the purposes of portfolio management; called Voucher Key in Mews Operations. |
+| `ExternalIdentifier` | string | optional, max 255 characters | External identifier of the voucher from external system. |
 
 #### Voucher code
 


### PR DESCRIPTION
#### Summary

External identifiers contains wrong description, it has nothing to do with portfolio.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
