### PR TITLE
Add enterpriseId parameter and addressId property

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 11th April 2023
+
+* Extended [Get configuration](../operations/configuration.md#get-configuration) request with `EnterpriseId` parameter.
+* Deprecated `Address` in [Enterprise](../operations/configuration.md#enterprise) and replaced with `AddressId`.
+
 ## 6th April 2023
 
 * Updated definitions for external identifiers throughout the API

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -36,6 +36,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
+| `Address` in [enterprise configuration](../operations/configuration.md#enterprise) | Replaced by [AddressId](../operations/configuration.md#enterprise) | 11 Apr 2023 | 11 Oct 2023 |
 | `AssigneeData` in [Get all bills ](../operations/bills.md#get-all-bills) | Replaced by [Owner data](../operations/bills.md#bill-owner-data) | 20 Feb 2023 | 20 Feb 2024 |
 | `ItalianFiscalCode`, `ItalianLotteryCode` <br>in [Get all bills](../operations/bills.md#response) | Retrievable in LegalIdentifiers [Bill customer data](../operations/bills.md#bill-customer-data) | 20 Feb 2023 | 20 Feb 2024 |
 | `Address`<br>in [Company](../operations/companies.md#company) | Replaced by `AddressId` | 18 Jan 2023 | 18 July 2023 |

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -12,7 +12,8 @@ Returns configuration of the enterprise and the client.
 {
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0"
+    "Client": "Sample Client 1.0.0",
+    "EnterpriseId": "851df8c8-90f2-4c4a-8e01-a4fc46b25178"
 }
 ```
 
@@ -21,6 +22,7 @@ Returns configuration of the enterprise and the client.
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
+| `EnterpriseId` | string | optional | Identifies the enterprise to return when multiple are accessible. |
 
 ### Response
 
@@ -120,26 +122,13 @@ Returns configuration of the enterprise and the client.
 | `Phone` | string | optional | Phone number of the enterprise. |
 | `LogoImageId` | string | required | Unique identifier of the enterprise logo image. |
 | `CoverImageId` | string | required | Unique identifier of the enterprise cover image. |
-| `Address` | [Address](#address) | required | Address of the enterprise. |
+| `AddressId` | string | required | Identifier of the [Address](addresses.md#account-address) of the enterprise. |
+| ~~`Address`~~ | ~~[Address](#address)~~ | ~~required~~ | ~~Address of the enterprise.~~ **Deprecated!** |
 | `Currencies` | array of [Accepted currency](#accepted-currency) | required | Currencies accepted by the enterprise. |
 | `Pricing` | string | required | [Pricing](#pricing) of the enterprise. |
 | `TaxPrecision` | string | optional | Tax precision used for financial calculations in the enterprise. If `null`, [Currency](currencies.md#currency) precision is used. |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the enterprise from external system. |
 | `AccountingConfiguration` | [Accounting configuration](#accounting-configuration) | optional | Configuration information containg financial information about the property. |
-
-#### Address
-
-| Property | Type | Contract | Description |
-| :--- | :--- | :--- | :--- |
-| `Id` | string | required | Unique identifier of the address. |
-| `Line1` | string | optional | First line of the address. |
-| `Line2` | string | optional | Second line of the address. |
-| `City` | string | optional | The city. |
-| `PostalCode` | string | optional | Postal code. |
-| `CountryCode` | string | optional | ISO 3166-1 code of the [Country](countries.md#country). |
-| `CountrySubdivisionCode` | string | optional | ISO 3166-2 code of the administrative division, e.g. `DE-BW`. |
-| `Latitude` | number | optional | The latitude. |
-| `Longitude` | number | optional | The longitude. |
 
 #### Accepted currency
 


### PR DESCRIPTION
#### Summary

After enabling portfolio-level access token support in configuration/get endpoint (https://github.com/MewsSystems/mews/pull/41625) some modifications to the contract were made:

- EnterpriseId parameter added (now multiple enterprises can be accessed, so this is the way to specify which one to return, default is the parent portfolio enterprise).
- Deprecated Address and added AddressId property.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
