### PR TITLE
add EnterpriseIds for orderItems/getAll and payments/getAll

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 18th April 2023
+
+* Extended [Get order items](../operations/orderitems.md#get-all-order-items) with `EnterpriseIds` parameter and [Order item](../operations/orderitems.md#order-item) with `EnterpriseId` property.
+* Extended [Get payments](../operations/payments.md#get-all-payments) with `EnterpriseIds` parameter and [Payment](../operations/payments.md#payment) with `EnterpriseId` property.
+
 ## 17th April 2023
 
 * Extended [Get configuration](../operations/configuration.md#get-configuration) request with `EnterpriseId` parameter.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,8 +2,8 @@
 
 ## 18th April 2023
 
-* Extended [Get order items](../operations/orderitems.md#get-all-order-items) with `EnterpriseIds` parameter and [Order item](../operations/orderitems.md#order-item) with `EnterpriseId` property.
-* Extended [Get payments](../operations/payments.md#get-all-payments) with `EnterpriseIds` parameter and [Payment](../operations/payments.md#payment) with `EnterpriseId` property.
+* Extended [Get all order items](../operations/orderitems.md#get-all-order-items) with `EnterpriseIds` filter and [Order item](../operations/orderitems.md#order-item) with `EnterpriseId`.
+* Extended [Get all payments](../operations/payments.md#get-all-payments) with `EnterpriseIds` filter and [Payment](../operations/payments.md#payment) with `EnterpriseId`.
 
 ## 17th April 2023
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -13,7 +13,12 @@ One of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUt
 {
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",
+    "Client": "Sample Client 1.0.0",    
+    "EnterpriseIds": 
+    [
+        "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "4d0201db-36f5-428b-8d11-4f0a65e960cc"
+    ],
     "OrderItemIds": 
     [
         "3e982ab5-6245-4c39-80af-1118d40e7494",
@@ -75,6 +80,7 @@ One of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUt
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
+| `EnterpriseIds` | array of string | optional, max 1000 items | Unique identifiers of the [Enterprises](enterprises.md#enterprise). |
 | `OrderItemIds` | array of string | required, max 1000 items | Unique identifiers of the [Order items](orderitems.md#order-item). Required if no other filter is provided. |
 | `ServiceOrderIds` | array of string | required, max 1000 items | Unique identifiers of the [Service orders](serviceorders.md#service-order). Required if no other filter is provided. |
 | `ServiceIds` | array of string | required, max 1000 items | Unique identifiers of the [Services](services.md#service). Required if no other filter is provided. |
@@ -97,6 +103,7 @@ One of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUt
     "OrderItems": [
         {
             "Id": "53896156-f25b-4949-b55b-afd3007b1146",
+            "EnterpriseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
             "AccountId": "c173bb22-6ff8-4ffd-875f-afb900c92865",
             "ServiceOrderId": "ac5ef5eb-c5b2-4083-879f-83f04a5ebda5",
             "BillId": "d27ffe99-ff92-4afb-ac03-9268f24f0556",
@@ -177,6 +184,7 @@ One of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUt
         },
         {
             "Id": "bd11dc4a-8f9e-442b-bb1e-f5361b31dfa2",
+            "EnterpriseId": "4d0201db-36f5-428b-8d11-4f0a65e960cc",
             "AccountId": "c173bb22-6ff8-4ffd-875f-afb900c92865",
             "ServiceOrderId": "dd01a673-ee6e-4f10-9c93-afcd00759ddd",
             "BillId": "297de6f8-bd67-4ebd-98b6-ecc1cd8f920c",
@@ -272,6 +280,7 @@ One of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUt
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the order item. |
+| `EnterpriseId` | string | required | Unique identifier of the [Enterprise](enterprises.md#enterprise). |
 | `AccountId` | string | required | Unique identifier of the account (for example [Customer](customers.md#customer)) the order item belongs to. |
 | `ServiceOrderId` | string | optional | Unique identifier of the [Service order](serviceorders.md#service-order) the order item is assigned to. |
 | `BillId` | string | optional | Unique identifier of the [Bill](bills.md#bill) the order item is assigned to. |

--- a/operations/payments.md
+++ b/operations/payments.md
@@ -205,6 +205,11 @@ Returns all payments in the system, filtered by various parameters. At least one
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
     "Client": "Sample Client 1.0.0",
+    "EnterpriseIds": 
+    [
+        "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "4d0201db-36f5-428b-8d11-4f0a65e960cc"
+    ],
     "PaymentIds": 
     [
         "f6313945-94c1-4e27-b402-031c2a8c989f",
@@ -253,6 +258,7 @@ Returns all payments in the system, filtered by various parameters. At least one
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
+| `EnterpriseIds` | array of string | optional, max 1000 items | Unique identifiers of the [Enterprises](enterprises.md#enterprise). |
 | `PaymentIds` | array of string | optional, max 1000 items | Unique identifiers of specific [Payments](payments.md#payment). Required if no other filter is provided. |
 | `BillIds` | array of string | optional, max 1000 items | Unique identifiers of specific [Bills](bills.md#bill) to which payments are assigned. Required if no other filter is provided. |
 | `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Time interval during which the [Payment](#payment) was created. Required if no other filter is provided. |
@@ -272,6 +278,7 @@ Returns all payments in the system, filtered by various parameters. At least one
     "Payments": [
         {
             "Id": "f6313945-94c1-4e27-b402-031c2a8c989f",
+            "EnterpriseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
             "AccountId": "c173bb22-6ff8-4ffd-875f-afb900c92865",
             "BillId": "f5fb70b1-9e88-4b6b-9618-e50116aea96e",
             "AccountingCategoryId": null,
@@ -328,6 +335,7 @@ Returns all payments in the system, filtered by various parameters. At least one
         },
         {
             "Id": "be922eb7-bc5f-4877-b847-1120c0c2acd2",
+            "EnterpriseId": "4d0201db-36f5-428b-8d11-4f0a65e960cc",
             "AccountId": "4ce18db7-3444-460a-b8af-afb900c92864",
             "BillId": "d23ac52f-9b86-4a03-a6fe-5822dfcfc5c4",
             "AccountingCategoryId": null,
@@ -389,6 +397,7 @@ Returns all payments in the system, filtered by various parameters. At least one
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the payment. |
+| `EnterpriseId` | string | required | Unique identifier of the [Enterprise](enterprises.md#enterprise). |
 | `AccountId` | string | required | Unique identifier of the account (for example [Customer](customers.md#customer)) the payment belongs to. |
 | `BillId` | string | optional | Unique identifier of the [Bill](bills.md#bill) the payment is assigned to. |
 | `AccountingCategoryId` | string | optional | Unique identifier of the [Accounting category](accountingcategories.md#accounting-category) the payment belongs to. |


### PR DESCRIPTION
#### Summary

The orderItems/getAll and payments/getAll endpoints are the first to receive multi-property support. I did not make any specific descriptions of multi-property access in this PR, suggestions welcome.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
