### PR TITLE
Add CreatorProfile & UpdaterProfile explanation in orderitems.md

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 28th April 2023
+
+* Added missing property descriptions to [Get all order items](../operations/orderitems.md#get-all-order-items)
+
 ## 25th April 2023
 
 * Added clarification to values for [Reservation origin](../operations/reservations.md#reservation-origin).

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -300,6 +300,8 @@ One of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUt
 | `AccountingState` | string [Accounting item state](#accounting-item-state) | required | Accounting state of the order item. |
 | `Type` | string [Order item type](#order-item-type) | required | Order item type, e.g. whether product order or space order. |
 | `Data` | object [Order item data](#order-item-data) | optional | Additional order item data. |
+| `CreatorProfileId` | object [Creator Profile](#creator-profile) | optional | Id of user who created the order item |
+| `UpdaterProfileId` | object [Updater Profile](#updater profile) | optional | Id of user who updated the order item. |
 
 #### Order item data
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -275,6 +275,11 @@ One of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUt
 }
 ```
 
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `OrderItems` | array of [Order item](#order-item) | required | Set of requested order items. |
+| `Cursor` | string | required | Unique identifier of the last and hence oldest order item returned. This can be used in [Limitation](../guidelines/pagination.md#limitation) in a subsequent request to fetch the next batch of older order items. |
+
 #### Order item
 
 | Property | Type | Contract | Description |
@@ -291,6 +296,8 @@ One of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUt
 | `OriginalAmount` | [Amount value](#amount-value) | required | order item's original amount, negative amount represents either rebate or a payment. Contains the earliest known value in conversion chain. |
 | `Notes` | string | optional | Additional notes. |
 | `RevenueType` | string [Revenue type](#revenue-type) | required | Revenue type of the item. |
+| `CreatorProfileId` | string | required | Unique identifier of the user who created the order item. |
+| `UpdaterProfileId` | string | required | Unique identifier of the user who updated the order item. |
 | `ConsumedUtc` | string | required | Date and time of the item consumption in UTC timezone in ISO 8601 format. |
 | `ClosedUtc` | string | optional | Date and time of the item bill closure in UTC timezone in ISO 8601 format. |
 | `ChargedUtc` | string | optional | Charged date and time of the order item charged in UTC timezone in ISO 8601 format. |
@@ -300,8 +307,6 @@ One of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUt
 | `AccountingState` | string [Accounting item state](#accounting-item-state) | required | Accounting state of the order item. |
 | `Type` | string [Order item type](#order-item-type) | required | Order item type, e.g. whether product order or space order. |
 | `Data` | object [Order item data](#order-item-data) | optional | Additional order item data. |
-| `CreatorProfileId` | object [Creator Profile](#creator-profile) | optional | Id of user who created the order item |
-| `UpdaterProfileId` | object [Updater Profile](#updater profile) | optional | Id of user who updated the order item. |
 
 #### Order item data
 


### PR DESCRIPTION
Some endpoints include now "Creator Profile" and "Updater Profile" in the response. This is already displayed in the code example in the documentation, but not explained. I noticed it also in bills/getAll. Can we please add an explanation to all endpoints that return those values?

#### Summary

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
