### PR TITLE
LoyaltyMembership CreatorProfile and UpdaterProfile

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26th May 2023
+
+* Extended [Loyalty memberships](../operations/loyaltymemberships.md#loyalty-membership) with `CreatorProfileId` and `UpdaterProfileId`.
+
 ## 24th May 2023
 
 * Extended [Add external payment](../operations/payments.md#add-external-payment) with `AccountId` property to support [Company](../operations/companies.md#company) accounts. `CustomerId` property was deprecated.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1st June 2023
+## 7th June 2023
 
 * Extended [Loyalty memberships](../operations/loyaltymemberships.md#loyalty-membership) with `CreatorProfile` and `UpdaterProfile`.
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,7 +2,7 @@
 
 ## 26th May 2023
 
-* Extended [Loyalty memberships](../operations/loyaltymemberships.md#loyalty-membership) with `CreatorProfileId` and `UpdaterProfileId`.
+* Extended [Loyalty memberships](../operations/loyaltymemberships.md#loyalty-membership) with [CreatorProfile](../operations/loyaltymemberships.md#profile-data) and [UpdaterProfile](../operations/loyaltymemberships.md#profile-data).
 
 ## 24th May 2023
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 26th May 2023
+## 1st June 2023
 
-* Extended [Loyalty memberships](../operations/loyaltymemberships.md#loyalty-membership) with [CreatorProfile](../operations/loyaltymemberships.md#profile-data) and [UpdaterProfile](../operations/loyaltymemberships.md#profile-data).
+* Extended [Loyalty memberships](../operations/loyaltymemberships.md#loyalty-membership) with `CreatorProfile` and `UpdaterProfile`.
 
 ## 24th May 2023
 

--- a/operations/loyaltymemberships.md
+++ b/operations/loyaltymemberships.md
@@ -90,7 +90,9 @@ Note this operation uses [Pagination](../guidelines/pagination.md).
             "Points": 25,
             "ExpirationDate": null,
             "Url": null,
-            "LoyaltyTierId": null
+            "LoyaltyTierId": null`,
+            "CreatorProfileId": "52d19c34-b0aa-4635-905d-1326fa8b8e13",
+            "UpdaterProfileId": "2234693c-8745-42f7-9175-5e585cf7a820"
         }
     ],
     "Cursor": "ea7da00f-fdc9-4014-b0f7-71003b87e3d0"
@@ -115,6 +117,8 @@ Note this operation uses [Pagination](../guidelines/pagination.md).
 | `ExpirationDate` | string | optional | Expiration date of the loyalty membership in UTC timezone in ISO 8601 format. |
 | `Url` | string | optional | Url of the loyalty membership. |
 | `LoyaltyTierId` | string | optional | Unique identifier of the loyalty tier. | 
+| `CreatorProfileId` | string | required | Unique identifier of the user who created the loyalty membership. |
+| `UpdaterProfileId` | string | required | Unique identifier of the user who updated the loyalty membership. |
 
 ## Add loyalty memberships
 

--- a/operations/loyaltymemberships.md
+++ b/operations/loyaltymemberships.md
@@ -79,7 +79,17 @@ Note this operation uses [Pagination](../guidelines/pagination.md).
             "Points": 10,
             "ExpirationDate": "2024-12-31",
             "Url": "https://www.mews.com/",
-            "LoyaltyTierId": "34c29a01-c075-49e4-906a-3b1d4012463e"
+            "LoyaltyTierId": "34c29a01-c075-49e4-906a-3b1d4012463e",
+            "CreatorProfile": {
+                "Discriminator": "Enterprise",
+                "EnterpriseProfile": {
+                    "ProfileId": "52d19c34-b0aa-4635-905d-1326fa8b8e13"
+                }
+            },
+            "UpdaterProfile": {
+                "Discriminator": "Integration",
+                "EnterpriseProfile": null
+            }
         },
         {
             "Id": "ea7da00f-fdc9-4014-b0f7-71003b87e3d0",
@@ -90,9 +100,19 @@ Note this operation uses [Pagination](../guidelines/pagination.md).
             "Points": 25,
             "ExpirationDate": null,
             "Url": null,
-            "LoyaltyTierId": null`,
-            "CreatorProfileId": "52d19c34-b0aa-4635-905d-1326fa8b8e13",
-            "UpdaterProfileId": "2234693c-8745-42f7-9175-5e585cf7a820"
+            "LoyaltyTierId": null,
+            "CreatorProfile": {
+                "Discriminator": "Enterprise",
+                "EnterpriseProfile": {
+                    "ProfileId": "52d19c34-b0aa-4635-905d-1326fa8b8e13"
+                }
+            },
+            "UpdaterProfile": {
+                "Discriminator": "Enterprise",
+                "EnterpriseProfile": {
+                    "ProfileId": "2234693c-8745-42f7-9175-5e585cf7a820"
+                }
+            }
         }
     ],
     "Cursor": "ea7da00f-fdc9-4014-b0f7-71003b87e3d0"
@@ -117,8 +137,30 @@ Note this operation uses [Pagination](../guidelines/pagination.md).
 | `ExpirationDate` | string | optional | Expiration date of the loyalty membership in UTC timezone in ISO 8601 format. |
 | `Url` | string | optional | Url of the loyalty membership. |
 | `LoyaltyTierId` | string | optional | Unique identifier of the loyalty tier. | 
-| `CreatorProfileId` | string | required | Unique identifier of the user who created the loyalty membership. |
-| `UpdaterProfileId` | string | required | Unique identifier of the user who updated the loyalty membership. |
+| `CreatorProfile` | [Profile data](#profile-data) | required | The profile data of the user who created the loyalty membership. |
+| `UpdaterProfile` | [Profile data](#profile-data) | required | The profile data of the user who updated the loyalty membership. |
+
+#### Profile data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Discriminator` | string [Profile data discriminator](#profile-data-discriminator) | required | Type of the profile data (e.g. `Enterprise`). |
+| `EnterpriseProfile` | [Enterprise profile data](#enterprise-profile-data) | optional | Enterprise profile data. |
+
+#### Profile data discriminator
+
+  * `Personal`
+  * `Enterprise`
+  * `Platform`
+  * `Static`
+  * `Integration`
+
+#### Enterprise profile data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ProfileId` | string | required | Unique identifier of the profile. |
+
 
 ## Add loyalty memberships
 

--- a/operations/loyaltymemberships.md
+++ b/operations/loyaltymemberships.md
@@ -161,7 +161,6 @@ Note this operation uses [Pagination](../guidelines/pagination.md).
 | :-- | :-- | :-- | :-- |
 | `ProfileId` | string | required | Unique identifier of the profile. |
 
-
 ## Add loyalty memberships
 
 > ### Restricted!

--- a/operations/loyaltymemberships.md
+++ b/operations/loyaltymemberships.md
@@ -149,11 +149,12 @@ Note this operation uses [Pagination](../guidelines/pagination.md).
 
 #### Profile data discriminator
 
-  * `Personal`
-  * `Enterprise`
-  * `Platform`
-  * `Static`
-  * `Integration`
+* `Personal`
+* `Enterprise`
+* `Platform`
+* `Static`
+* `Integration`
+* ...
 
 #### Enterprise profile data
 


### PR DESCRIPTION
#### Summary

Added `CreatorProfile` and `UpdaterProfile` to the `LoyaltMembership` object. `ProfileData` will show the type of profile in `Discriminator,` and the `ProfileId` in `EnterpriseProfile`. For non-enterprise profiles, `LoyaltyMembership` will not show any data, and `EnterpriseProfile` object will be null.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
