### PR TITLE
improvements to localized text

### DIFF
--- a/operations/_objects.md
+++ b/operations/_objects.md
@@ -86,4 +86,15 @@ Dictionary is a collection of key-value pairs.
 
 ### Localized text
 
-An object where keys are the [Language](languages.md#language) codes and values texts in respective languages.
+A [Dictionary](#dictionary) object where the keys are [Language](languages.md#language) codes and the corresponding values are versions of the text in the respective language. For example:
+
+```javascript
+{
+    "cs-CZ": "Děti",
+    "da-DK": "Børn",
+    "de-CH": "Kinder",
+    "de-DE": "Kinder",
+    "el-GR": "Παιδιά",
+    "en-GB": "Children"
+}
+```

--- a/operations/agecategories.md
+++ b/operations/agecategories.md
@@ -95,4 +95,4 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `ServiceId` | string | required | Unique identifier of [Service](services.md#service) the age category belongs to. |
 | `MinimalAge` | number | optional | Minimal age for the age category. |
 | `MaximalAge` | number | optional | Maximal age for the age category. |
-| `Names` | [Localized text](resources.md#localized-text) | required | All translations of the name of the age category. |
+| `Names` | [Localized text](_objects.md#localized-text) | required | All translations of the name of the age category. |

--- a/operations/rates.md
+++ b/operations/rates.md
@@ -118,7 +118,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `IsPublic` | boolean | required | Whether the rate is publicly available. |
 | `Name` | string | required | Name of the rate. |
 | `ShortName` | string | required | Short name of the rate. |
-| `ExternalNames` | [Localized text](resources.md#localized-text) | required | All translations of the external name of the rate. |
+| `ExternalNames` | [Localized text](_objects.md#localized-text) | required | All translations of the external name of the rate. |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the rate from external system. |
 
 #### Rate group


### PR DESCRIPTION
#### Summary

* Corrected reference to `Localized text` in agecategories.md
* Corrected reference to `Localized text` in rates.md
* Updated definition of `Localized text`, including example JSON
* Probably doesn't need a Changelog entry

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
