### PR TITLE
Update ServiceIds to optional, not required

### DIFF
--- a/operations/services.md
+++ b/operations/services.md
@@ -32,7 +32,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `EnterpriseIds` | array of string | optional, max 1000 items | Unique identifiers of the [Enterprises](enterprises.md#enterprise). If not specified, the operation returns the resource categories for all enterprises within scope of the Access Token. |
-| `ServiceIds` | array of string | required, max 1000 items | Unique identifiers of [Services](services.md#service). |
+| `ServiceIds` | array of string | optional, max 1000 items | Unique identifiers of [Services](services.md#service). |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
 
 ### Response


### PR DESCRIPTION
#### Summary

This endpoint is used to fetch all services from Mews. It doesn't make sense to make Service Ids a required field, because those values are not known when using this endpoint.
`ServiceIds` should be an optional parameter when calling services/getAll.
