### PR TITLE
Change UnitAmount to Price in products.md

### DIFF
--- a/operations/products.md
+++ b/operations/products.md
@@ -62,7 +62,7 @@ Returns all products offered together with the specified services.
                 "Wellness": false,
                 "CityTax": false
             },
-            "UnitAmount": {
+            "Price": {
                 "GrossValue": 25,
                 "Currency": "EUR",
                 "TaxValues": [
@@ -104,7 +104,7 @@ Returns all products offered together with the specified services.
                 "Wellness": false,
                 "CityTax": false
             },
-            "UnitAmount": {
+            "Price": {
                 "GrossValue": 25,
                 "Currency": "EUR",
                 "TaxValues": [

--- a/operations/products.md
+++ b/operations/products.md
@@ -144,7 +144,7 @@ Returns all products offered together with the specified services.
 | `Options` | [Product options](#product-options) | required | Options of the product. |
 | `Promotions` | [Promotions](services.md#promotions) | required | Promotions of the service. |
 | `Classifications` | [Product classifications](#product-classifications) | required | Classifications of the service. |
-| `UnitAmount` | [Amount value](accountingitems.md#amount-value) | required | Unit amount representing price of the product. |
+| `Price` | [Amount value](accountingitems.md#amount-value) | required | Price representing price of the product. |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the product from external system. |
 
 #### Product charging mode


### PR DESCRIPTION
In the documentation, we still call the pricing part "UnitAmount" even though it was replaced by "Price" and "Pricing".
Can we please add all the necessary documentation as per swagger?

