### PR TITLE
CON-152: reservations/getAll: Update StartUtc docs, add ScheduledStartUtc and ActualStartUtc

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,16 +1,17 @@
 # Changelog
 
-## 4th September 2023
+## 5th September 2023
 
-* Deprecated `StartUtc` property in [Reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06). Use more explicit `ScheduledStartUtc` and `ActualStartUtc` properties instead. No discontinuation date has been set for now.
+* In [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06) response:
+  * Clarified behavior of `StartUtc` property, which is either the reservation's scheduled time, or the actual customer check-in time, whichever is earlier.
+  * Added new properties `ScheduledStartUtc` and `ActualStartUtc`, intended ultimately to replace `StartUtc`.
+  * Deprecated `StartUtc`, but no discontinuation date has been set for now.
 
 ## 31st August 2023
 
 * Enabled [Portfolio Access Tokens](../guidelines/multi-property.md) for the following operations:
   * [Get all message threads](../operations/messagethreads.md#get-all-message-threads)
   * [Get all messages](../operations/messages.md#get-all-messages)
-* Extended [Get all reservations](../operations/reservations.md#get-all-reservations-ver-2023-06-06) response with `ScheduledStartUtc` and `ActualStartUtc`.
-  * Clarified behavior of `StartUtc`, which returns either reservation's scheduled time, or the time of check-in, whichever is earlier.
 
 ## 29th August 2023
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,7 +2,7 @@
 
 ## 31st August 2023
 
-* Extended [Get all reservations](../operations/reservations.md#Get-all-reservations-ver-2023-06-06) response with `ScheduledStartUtc` and `ActualStartUtc`.
+* Extended [Get all reservations](../operations/reservations.md#get-all-reservations-ver-2023-06-06) response with `ScheduledStartUtc` and `ActualStartUtc`.
   * Clarified behavior of `StartUtc`, which returns either reservation's scheduled time, or the time of check-in, whichever is earlier.
 
 ## 29th August 2023

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4th September 2023
+
+* Deprecated `StartUtc` property in [Reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06). Use more explicit `ScheduledStartUtc` and `ActualStartUtc` properties instead. No discontinuation date has been set for now.
+
 ## 31st August 2023
 
 * Enabled [Portfolio Access Tokens](../guidelines/multi-property.md) for the following operations:

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 31st August 2023
+
+* Extended [Get all reservations](../operations/reservations.md#Get-all-reservations-ver-2023-06-06) response with `ScheduledStartUtc` and `ActualStartUtc`.
+  * Clarified behavior of `StartUtc`, which returns either reservation's scheduled time, or the time of check-in, whichever is earlier.
+
 ## 29th August 2023
 
 * Enabled [Portfolio Access Tokens](../guidelines/multi-property.md) for the following operations:

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -39,6 +39,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
+| `StartUtc`<br>in [Reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06) | Replaced by `ScheduledStartUtc` and `ActualStartUtc` | 4 Sep 2023 | - |
 | `BillCounters`, `ProformaCounters`, `BillPreviewCounters`, `ServiceOrderCounters`, `RegistrationCardCounters`<br>in [Get all counters](../operations/counters.md#get-all-counters) | Replaced by `Counters` | 21 Jun 2023 | 21 Dec 2023 |
 | `CustomerId`<br>in [Add external payment](../operations/payments.md#add-external-payment) | Replaced by `AccountId` | 24 May 2023 | 24 May 2024 |
 | `CustomerId`<br>in [Add order](../operations/orders.md#add-order) | Replaced by `AccountId` | 24 May 2023 | 24 May 2024 |

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -39,7 +39,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
-| `StartUtc`<br>in [Reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06) | Replaced by `ScheduledStartUtc` and `ActualStartUtc` | 4 Sep 2023 | - |
+| `StartUtc`<br>in [Reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06) | Replaced by `ScheduledStartUtc` and `ActualStartUtc` | 6 Sep 2023 | - |
 | `BillCounters`, `ProformaCounters`, `BillPreviewCounters`, `ServiceOrderCounters`, `RegistrationCardCounters`<br>in [Get all counters](../operations/counters.md#get-all-counters) | Replaced by `Counters` | 21 Jun 2023 | 21 Dec 2023 |
 | `CustomerId`<br>in [Add external payment](../operations/payments.md#add-external-payment) | Replaced by `AccountId` | 24 May 2023 | 24 May 2024 |
 | `CustomerId`<br>in [Add order](../operations/orders.md#add-order) | Replaced by `AccountId` | 24 May 2023 | 24 May 2024 |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -129,7 +129,9 @@ Returns all reservations within scope of the Access Token, filtered according to
 | `CreatorProfileId` | string | required | Unique identifier of the user who created the order item. |
 | `UpdaterProfileId` | string | required | Unique identifier of the user who updated the order item. |
 | `BookerId` | string | optional | Unique identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. |
-| `StartUtc` | string | required | Reservation start in UTC timezone in ISO 8601 format. |
+| `StartUtc` | string | required | Reservation start or check-in time (if it's earlier than scheduled start) in UTC timezone in ISO 8601 format. |
+| `ScheduledStartUtc` | string | required | Scheduled start time of reservation in UTC timezone in ISO 8601 format. |
+| `ActualStartUtc` | string | required | Time of check-in for started reservations in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | Reservation end in UTC timezone in ISO 8601 format. |
 | `Number` | string | required | Confirmation number of the reservation in Mews. |
 | `State` | string [Service order state](#service-order-state) | required | State of the reservation. |
@@ -453,7 +455,7 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `CreatedUtc` | string | required | Creation date and time of the reservation in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the reservation in UTC timezone in ISO 8601 format. |
 | `CancelledUtc` | string | optional | Cancellation date and time in UTC timezone in ISO 8601 format. |
-| `StartUtc` | string | required | Start of the reservation \(arrival\) in UTC timezone in ISO 8601 format. |
+| `StartUtc` | string | required | Reservation start \(arrival\) or check-in time (if it's earlier than scheduled start) in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | End of the reservation \(departure\) in UTC timezone in ISO 8601 format. |
 | `ReleasedUtc` | string | optional | Date when the optional reservation is released in UTC timezone in ISO 8601 format. |
 | `RequestedCategoryId` | string | required | Identifier of the requested [Resource category](resources.md#resource-category). |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -67,6 +67,8 @@ Returns all reservations within scope of the Access Token, filtered according to
             "UpdaterProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
             "BookerId": "ebd507c5-6bfd-4ca9-96aa-ffed6fa94f72",
             "StartUtc": "2023-04-23T14:00:00Z",
+            "ScheduledStartUtc": "2023-04-23T14:00:00Z",
+            "ActualStartUtc": null,
             "EndUtc": "2023-04-24T14:00:00Z",
             "Number": "52",
             "State": "Confirmed",
@@ -131,7 +133,7 @@ Returns all reservations within scope of the Access Token, filtered according to
 | `BookerId` | string | optional | Unique identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. |
 | `StartUtc` | string | required | Reservation start or check-in time (if it's earlier than scheduled start) in UTC timezone in ISO 8601 format. |
 | `ScheduledStartUtc` | string | required | Scheduled start time of reservation in UTC timezone in ISO 8601 format. |
-| `ActualStartUtc` | string | required | Time of check-in for started reservations in UTC timezone in ISO 8601 format. |
+| `ActualStartUtc` | string | optional | Time of check-in for started reservations in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | Reservation end in UTC timezone in ISO 8601 format. |
 | `Number` | string | required | Confirmation number of the reservation in Mews. |
 | `State` | string [Service order state](#service-order-state) | required | State of the reservation. |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -131,7 +131,7 @@ Returns all reservations within scope of the Access Token, filtered according to
 | `CreatorProfileId` | string | required | Unique identifier of the user who created the order item. |
 | `UpdaterProfileId` | string | required | Unique identifier of the user who updated the order item. |
 | `BookerId` | string | optional | Unique identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. |
-| `StartUtc` | string | required | Reservation start or check-in time (if it's earlier than scheduled start) in UTC timezone in ISO 8601 format. |
+| ~~`StartUtc`~~ | ~~string~~ | ~~required~~ | ~~Reservation start or check-in time (if it's earlier than scheduled start) in UTC timezone in ISO 8601 format.~~ **Deprecated!** Use `ScheduledStartUtc` and `ActualStartUtc` instead. |
 | `ScheduledStartUtc` | string | required | Scheduled start time of reservation in UTC timezone in ISO 8601 format. |
 | `ActualStartUtc` | string | optional | Time of check-in for started reservations in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | Reservation end in UTC timezone in ISO 8601 format. |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -133,7 +133,7 @@ Returns all reservations within scope of the Access Token, filtered according to
 | `BookerId` | string | optional | Unique identifier of the [Customer](customers.md#customer) on whose behalf the reservation was made. |
 | ~~`StartUtc`~~ | ~~string~~ | ~~required~~ | ~~Reservation start or check-in time (if it's earlier than scheduled start) in UTC timezone in ISO 8601 format.~~ **Deprecated!** Use `ScheduledStartUtc` and `ActualStartUtc` instead. |
 | `ScheduledStartUtc` | string | required | Scheduled start time of reservation in UTC timezone in ISO 8601 format. |
-| `ActualStartUtc` | string | optional | Time of check-in for started reservations in UTC timezone in ISO 8601 format. |
+| `ActualStartUtc` | string | optional | Actual customer check-in time of reservation in UTC timezone in ISO 8601 format. |
 | `EndUtc` | string | required | Reservation end in UTC timezone in ISO 8601 format. |
 | `Number` | string | required | Confirmation number of the reservation in Mews. |
 | `State` | string [Service order state](#service-order-state) | required | State of the reservation. |
@@ -457,7 +457,7 @@ Returns all reservations specified by any identifier, customer or other filter. 
 | `CreatedUtc` | string | required | Creation date and time of the reservation in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the reservation in UTC timezone in ISO 8601 format. |
 | `CancelledUtc` | string | optional | Cancellation date and time in UTC timezone in ISO 8601 format. |
-| `StartUtc` | string | required | Reservation start \(arrival\) or check-in time (if it's earlier than scheduled start) in UTC timezone in ISO 8601 format. |
+| `StartUtc` | string | required | Start of the reservation in UTC timezone in ISO 8601 format. This is either the scheduled reservation start time, or the actual customer check-in time if this is earlier than the scheduled start time. |
 | `EndUtc` | string | required | End of the reservation \(departure\) in UTC timezone in ISO 8601 format. |
 | `ReleasedUtc` | string | optional | Date when the optional reservation is released in UTC timezone in ISO 8601 format. |
 | `RequestedCategoryId` | string | required | Identifier of the requested [Resource category](resources.md#resource-category). |


### PR DESCRIPTION
#### Summary

StartUtc had an undocumented behavior: when guest checked-in earlier before the original StartUtc, the time of reservation would change to this time. Some partners relied on this behavior, until it was unintentionally changed by separating out `StartUtc` to `StartedUtc` property. `StartUtc` now holds the scheduled time of reservation, and `StartedUtc` holds the actual, check-in time.

We've recovered this original behavior and added two new properties which expose the raw values:

- `ActualStartUtc` is mapped to `StartedUtc`
- `ScheduledStartUtc` is mapped to unmodified `StartUtc`.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
