### PR TITLE
productServiceOrders/getAll: Fix documenation

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6th September 2023
+
+* Updated [Get all product service orders](../operations/productserviceorders.md#get-all-product-service-orders) documentation:
+  * Removed `StartUtc` and `EndUtc` properties which were never exposed.
+  * Added documentation for `CommanderOrigin` property.
+
 ## 31st August 2023
 
 * Enabled [Portfolio Access Tokens](../guidelines/multi-property.md) for the following operations:

--- a/operations/productserviceorders.md
+++ b/operations/productserviceorders.md
@@ -56,11 +56,10 @@ Returns all product service orders orders associated with the given enterprise. 
             "CreatorProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
             "UpdaterProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
             "BookerId": "ebd507c5-6bfd-4ca9-96aa-ffed6fa94f72",
-            "StartUtc": "2023-04-23T14:00:00Z",
-            "EndUtc": "2023-04-24T14:00:00Z",
             "Number": "52",
             "State": "Confirmed",
             "Origin": "Connector",
+            "CommanderOrigin": null,
             "OriginDetails": null,
             "CreatedUtc": "2023-04-23T14:58:02Z",
             "UpdatedUtc": "2023-04-23T14:58:02Z",
@@ -94,12 +93,11 @@ Returns all product service orders orders associated with the given enterprise. 
 | `AccountType` | string | required | A discriminator specifying the [type of account](accounts.md#account-type), e.g. customer or company. |
 | `CreatorProfileId` | string | required | Unique identifier of the user who created the order item. |
 | `UpdaterProfileId` | string | required | Unique identifier of the user who updated the order item. |
-| `StartUtc` | string | required | Product service order start in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | Product service order end in UTC timezone in ISO 8601 format. |
 | `BookerId` | string | optional | Unique identifier of the [Customer](customers.md#customer) on whose behalf the service order was made. |
 | `Number` | string | required | Confirmation number of the service order in Mews. |
 | `State` | string [Service order state](#service-order-state) | required | State of the product service order. |
 | `Origin` | string [Service order origin](#service-order-origin) | required | Origin of the product service order. |
+| `CommanderOrigin` | string [Commander origin](./reservations.md#commander-origin) | optional | Further detail about origin in case of Origin `Commander`. |
 | `OriginDetails`| string | optional | Details about the product service order [Origin](#service-order-origin). |
 | `CreatedUtc` | string | required | Creation date and time of the product service order in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the product service order in UTC timezone in ISO 8601 format. |


### PR DESCRIPTION
#### Summary

The endpoint now returns `CommanderOrigin` which was not documented. The documentation also mentioned `StartUtc` and `EndUtc` properties which were never exposed in the first place.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
