### PR TITLE
Add external identifier to rates/add

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1st November 2023
+
+* Extended [Add rate](../operations/rates.md#add-rate) with `ExternalIdentifier` parameter.
+
 ## 26th October 2023
 
 * Enabled [Portfolio Access Tokens](../guidelines/multi-property.md) for the [Add order](../operations/orders.md#add-order) operation.

--- a/operations/rates.md
+++ b/operations/rates.md
@@ -126,7 +126,8 @@ Adds rates to the enterprise. Note this operation supports [Portfolio Access Tok
           "Type": "Public",
           "AccountingCategoryId": "3620c660-a4ec-4e0f-a0bc-b06f008eb8bf",
           "Names": { "EN": "My rate" },
-          "PricingType": "DependentRatePricing",
+          "ExternalIdentifier": "D001",
+          "PricingType": "DependentRatePricing",          
           "Pricing": {
               "DependentRatePricing": {
                   "BaseRateId": "1a1ddd3b-e106-4a70-aef1-54a75b483943",
@@ -161,6 +162,7 @@ Adds rates to the enterprise. Note this operation supports [Portfolio Access Tok
 | `ShortNames` | [Localized text](_objects.md#localized-text) | optional | All translations of the short name of the rate. |
 | `ExternalNames` | [Localized text](_objects.md#localized-text) | optional | All translations of the external name of the rate. |
 | `Descriptions` | [Localized text](_objects.md#localized-text) | optional | All translations of the description. |
+| `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the rate from external system. |
 | `PricingType` | [Pricing type](rates.md#pricing-type) | required | Discriminator in which field inside `Pricing` contains additional data. |
 | `Pricing` | [Rate pricing](rates.md#rate-pricing-parameters) | required | Contains additional data about pricing of the rate. |
 


### PR DESCRIPTION
#### Summary

Added `ExternalIdentifier` to `rates/add`

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
