### PR TITLE
OPS-2882: bills/getAll response - fix JSON example

### DIFF
--- a/operations/bills.md
+++ b/operations/bills.md
@@ -147,7 +147,7 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
                         },
                         "LegalIdentifiers": {
                             "TaxIdentifier": "CZ8810310963",
-                            "CityOfRegistration": "Prague",
+                            "CityOfRegistration": "Prague"
                         },
                         "BillingCode": "billing code value",
                         "Name": "Company Name Inc.",

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -133,35 +133,38 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
                 }
             },
             "AssociatedAccountData": [
-                "Discriminator": "BillCompanyData",
-                "BillCompanyData" : {
-                    "Id": "26afba60-06c3-455b-92db-0e3983be0b1d",
-                    "Address": {
-                        "Line1": "Joe Doe street",
-                        "Line2": "Very long ave",
-                        "City": "Townston",
-                        "PostalCode": "154 00",
-                        "SubdivisionCode": "AU-NSW",
-                        "CountryCode": "AU"
+                {
+                    "Discriminator": "BillCompanyData",
+                    "BillCompanyData": {
+                        "Id": "26afba60-06c3-455b-92db-0e3983be0b1d",
+                        "Address": {
+                            "Line1": "Joe Doe street",
+                            "Line2": "Very long ave",
+                            "City": "Townston",
+                            "PostalCode": "154 00",
+                            "SubdivisionCode": "AU-NSW",
+                            "CountryCode": "AU"
+                        },
+                        "LegalIdentifiers": {
+                            "TaxIdentifier": "CZ8810310963",
+                            "CityOfRegistration": "Prague",
+                        },
+                        "BillingCode": "billing code value",
+                        "Name": "Company Name Inc.",
+                        "FiscalIdentifier": "Fiscal identifier",
+                        "AdditionalTaxIdentifier": "Additional tax identifier"
                     },
-                    "LegalIdentifiers": {
-                        "TaxIdentifier": "CZ8810310963",
-                        "CityOfRegistration": "Prague",
-                    },
-                    "BillingCode": "billing code value",
-                    "Name": "Company Name Inc.",
-                    "FiscalIdentifier": "Fiscal identifier",
-                    "AdditionalTaxIdentifier": "Additional tax identifier"
+                    "BillCustomerData": null
                 }
             ],
             "EnterpriseData": {
-                AdditionalTaxIdentifier: "XY00112233445",
-                CompanyName: "The Sample Hotel Group AS",
-                BankAccount: "CZ3808000000000012345678",
-                BankName: "CESKA SPORITELNA A.S.",
-                Iban: "CZ6508000000192000145399",
-                Bic: "GIBACZPX"
-            }            
+                "AdditionalTaxIdentifier": "XY00112233445",
+                "CompanyName": "The Sample Hotel Group AS",
+                "BankAccount": "CZ3808000000000012345678",
+                "BankName": "CESKA SPORITELNA A.S.",
+                "Iban": "CZ6508000000192000145399",
+                "Bic": "GIBACZPX"
+            }
         }
     ],
     "Cursor": "8d02142f-31cf-4115-90bf-ae5200c7a1ba"


### PR DESCRIPTION
#### Summary

Fix invalid JSON and null property in JSON example for `bills/getAll` response.

Follow up to #517.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
