### PR TITLE
CON-675: Add Name and Notes to resourceBlocks/getAll

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 29th November 2023
+* Extended [Get all resource blocks](../operations/resourceblocks.md#get-all-resource-blocks) response with `Name` and `Notes` parameters.
+
 ## 28th November 2023
 * Added operation [Delete addresses](../operations/addresses.md#delete-addresses).
 

--- a/operations/resourceblocks.md
+++ b/operations/resourceblocks.md
@@ -76,7 +76,9 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "IsActive": true,
             "StartUtc": "2016-01-01T10:00:00Z",
             "Type": "InternalUse",
-            "UpdatedUtc": "2016-03-29T22:02:34Z"
+            "UpdatedUtc": "2016-03-29T22:02:34Z",
+            "Name": "Resource block 1",
+            "Notes": "Note"
         },
         {
             "AssignedResourceId": "f7c4b4f5-ac83-4977-a41a-63d27cc6e3e9",
@@ -86,7 +88,9 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "IsActive": true,
             "StartUtc": "2016-01-01T10:00:00Z",
             "Type": "OutOfOrder",
-            "UpdatedUtc": "2016-03-29T15:14:06Z"
+            "UpdatedUtc": "2016-03-29T15:14:06Z",
+            "Name": "Resource block 2",
+            "Notes": null
         }
     ]
 }
@@ -108,6 +112,8 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `EndUtc` | string | required | End of the block in UTC timezone in ISO 8601 format. |
 | `CreatedUtc` | string | required | Creation date and time of the block in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the block in UTC timezone in ISO 8601 format. |
+| `Name` | string | required | Name of the resource block. |
+| `Notes` | string | optional | Note describing the resource block. |
 
 #### Resource block type
 


### PR DESCRIPTION
#### Summary

Expose `Name` and `Notes` in `resourceBlocks/getAll`. Apparently we allowed for setting these with `add`, but never exposed them.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
