### PR TITLE
Replace EditableHistoryInterval property

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5th December 2023
+* Deprecated `EditableHistoryInterval` property in [Get configuration](../operations/configuration.md#get-configuration) and [Get all enterprises](../operations/enterprises.md#get-all-enterprises). Use `AccountingEditableHistoryInterval` and `OperationalEditableHistoryInterval` instead.
+
 ## 29th November 2023
 * Extended [Get all resource blocks](../operations/resourceblocks.md#get-all-resource-blocks) response with `Name` and `Notes` parameters.
 

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -39,6 +39,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
+| `EditableHistoryInterval` in [Get configuration](../operations/configuration.md#get-configuration) and [Get all enterprises](../operations/enterprises.md#get-all-enterprises) | Replaced by `AccountingEditableHistoryInterval` and `OperationalEditableHistoryInterval` | 5 Dec 2023 | 5 Dec 2024 |
 | `TaxIdentifier` in [Close bill](../operations/bills.md#close-bill) | Replaced by `AccountTaxIdentifier` | 21 Nov 2023 | 21 Nov 2024 |
 | `CompanyTaxIdentifier` in [Close bill](../operations/bills.md#close-bill) | Replaced by [AssociatedAccountData](../operations/bills.md#bill-associated-account-data) | 21 Nov 2023 | 21 Nov 2024 |
 | `Address` in [Close bill](../operations/bills.md#close-bill) | Replaced by `AccountAddress` | 21 Nov 2023 | 21 Nov 2024 |

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -38,7 +38,8 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
         "TimeZoneIdentifier": "Europe/Budapest",
         "LegalEnvironmentCode": "UK",
         "DefaultLanguageCode": "en-US",
-        "EditableHistoryInterval": "P0M3DT0H0M0S",
+        "AccountingEditableHistoryInterval": "P0M7DT0H0M0S",
+        "OperationalEditableHistoryInterval": "P0M5DT0H0M0S",
         "WebsiteUrl": "https://en.wikipedia.org/wiki/St._Vitus_Cathedral",
         "Email": "charging-api@mews.li",
         "Phone": "00000 123 456 789",
@@ -121,7 +122,9 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
 | `TimeZoneIdentifier` | string | required | IANA timezone identifier of the enterprise. |
 | `LegalEnvironmentCode` | string | required | Unique identifier of the legal environment where the enterprise resides. |
 | `DefaultLanguageCode` | string | required | Language-culture codes of the enterprise default [Language](languages.md#language). |
-| `EditableHistoryInterval` | string | required | Editable history interval in ISO 8601 duration format. |
+| ~~`EditableHistoryInterval`~~ | ~~string~~ | ~~required~~ | ~~Editable history interval in ISO 8601 duration format.~~ **Deprecated!** |
+| `AccountingEditableHistoryInterval` | string | required | Editable history interval for accounting data in ISO 8601 duration format. |
+| `OperationalEditableHistoryInterval` | string | required | Editable history interval for oprational data in ISO 8601 duration format. |
 | `WebsiteUrl` | string | optional | URL of the enterprise website. |
 | `Email` | string | optional | Email address of the enterprise. |
 | `Phone` | string | optional | Phone number of the enterprise. |

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -124,7 +124,7 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
 | `DefaultLanguageCode` | string | required | Language-culture codes of the enterprise default [Language](languages.md#language). |
 | ~~`EditableHistoryInterval`~~ | ~~string~~ | ~~required~~ | ~~Editable history interval in ISO 8601 duration format.~~ **Deprecated!** |
 | `AccountingEditableHistoryInterval` | string | required | Editable history interval for accounting data in ISO 8601 duration format. |
-| `OperationalEditableHistoryInterval` | string | required | Editable history interval for oprational data in ISO 8601 duration format. |
+| `OperationalEditableHistoryInterval` | string | required | Editable history interval for operational data in ISO 8601 duration format. |
 | `WebsiteUrl` | string | optional | URL of the enterprise website. |
 | `Email` | string | optional | Email address of the enterprise. |
 | `Phone` | string | optional | Phone number of the enterprise. |

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -102,7 +102,7 @@ Returns all enterprises within scope of the `Access Token`, optionally filtered 
 | `DefaultLanguageCode` | string | required | Language-culture codes of the enterprise default [Language](languages.md#language). |
 | ~~`EditableHistoryInterval`~~ | ~~string~~ | ~~required~~ | ~~Editable history interval in ISO 8601 duration format.~~ **Deprecated!** |
 | `AccountingEditableHistoryInterval` | string | required | Editable history interval for accounting data in ISO 8601 duration format. |
-| `OperationalEditableHistoryInterval` | string | required | Editable history interval for oprational data in ISO 8601 duration format. |
+| `OperationalEditableHistoryInterval` | string | required | Editable history interval for operational data in ISO 8601 duration format. |
 | `WebsiteUrl` | string | optional | URL of the enterprise website. |
 | `Email` | string | optional | Email address of the enterprise. |
 | `Phone` | string | optional | Phone number of the enterprise. |

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -63,7 +63,8 @@ Returns all enterprises within scope of the `Access Token`, optionally filtered 
       "AccountingEnvironmentCode": "DE",
       "TaxEnvironmentCode": "DE-2020-1",
       "DefaultLanguageCode": "en-US",
-      "EditableHistoryInterval": "P0M7DT0H0M0S",
+      "AccountingEditableHistoryInterval": "P0M7DT0H0M0S",
+      "OperationalEditableHistoryInterval": "P0M5DT0H0M0S",
       "WebsiteUrl": "https://www.sample-portfolio-hotel-10004.com/",
       "Email": "email@sample-portfolio-hotel.com",
       "Phone": "(555) 555-1234",
@@ -99,7 +100,9 @@ Returns all enterprises within scope of the `Access Token`, optionally filtered 
 | `AccountingEnvironmentCode` | string | optional | Unique identifier of the enterprise's accounting environment. |
 | `TaxEnvironmentCode` | string | optional | Unique identifier of the enterprise's tax environment. |
 | `DefaultLanguageCode` | string | required | Language-culture codes of the enterprise default [Language](languages.md#language). |
-| `EditableHistoryInterval` | string | required | Editable history interval in ISO 8601 duration format. |
+| ~~`EditableHistoryInterval`~~ | ~~string~~ | ~~required~~ | ~~Editable history interval in ISO 8601 duration format.~~ **Deprecated!** |
+| `AccountingEditableHistoryInterval` | string | required | Editable history interval for accounting data in ISO 8601 duration format. |
+| `OperationalEditableHistoryInterval` | string | required | Editable history interval for oprational data in ISO 8601 duration format. |
 | `WebsiteUrl` | string | optional | URL of the enterprise website. |
 | `Email` | string | optional | Email address of the enterprise. |
 | `Phone` | string | optional | Phone number of the enterprise. |


### PR DESCRIPTION
#### Summary

Replace EditableHistoryInterval property with separate accounting and operational history interval properties.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
