### PR TITLE
De-duplicate EnterpriseId in Get all reservation groups

### DIFF
--- a/operations/reservationgroups.md
+++ b/operations/reservationgroups.md
@@ -51,8 +51,7 @@ Returns all reservation groups, filtered by unique identifiers and other filters
             "EnterpriseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
             "Name": "Mr and Mrs smith wedding",
             "ChannelManager": "2023-04-27T11:48:57Z",
-            "ChannelManagerGroupNumber": "152fg645-834f-63a7-he6a-vsy845c4753a",
-            "EnterpriseId": "Creation"
+            "ChannelManagerGroupNumber": "152fg645-834f-63a7-he6a-vsy845c4753a"
         }
     ],
     "Cursor": "723jd664-235f-36a4-tg6d-gfy850c645f"
@@ -69,8 +68,7 @@ Returns all reservation groups, filtered by unique identifiers and other filters
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the reservation group. |
-| `EnterpriseId` | string | required | Unique identifier of the [Enterprise](enterprises.md#enterprise). |
+| `EnterpriseId` | string | required | Unique identifier of the [Enterprise](enterprises.md#enterprise) the reservation group belongs to. |
 | `Name` | string | optional | Name of the reservation group, might be empty or same for multiple groups. |
 | `ChannelManager` | string | optional | Name of the corresponding channel manager. |
 | `ChannelManagerGroupNumber` | string | optional | Identifier of the channel manager. |
-| `EnterpriseId` | string | required | Unique identifier of an enterprise the reservation group belongs to. |


### PR DESCRIPTION
#### Summary

* I assume the duplicate EnterpriseId in 'Get all reservation groups' was added in error, so I have removed it
* The change occurred as part of the work to support Portfolio Access Tokens (21st June 2023, to be precise)
* I have not added a Changelog entry as this is just a minor bug fix

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
