### PR TITLE
Better explanation of accounts

### DIFF
--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -45,7 +45,7 @@ Returns all reservations within scope of the Access Token, filtered according to
 | `EnterpriseIds` | array of string | optional, max 1000 items | Unique identifiers of the [Enterprises](enterprises.md#enterprise). |
 | `ReservationIds` | array of string | optional, max 1000 items | Unique identifiers of the [Reservations](#reservation-ver-2023-06-06). |
 | `ServiceIds` | array of string | optional, max 1000 items | Unique identifiers of the [Services](services.md#service). If not provided, all bookable services are used. |
-| `AccountIds` | array of string | optional, max 1000 items | Unique identifiers of accounts (for example [Customers](customers.md#customer) or [Companies](companies.md#company)) the reservation is associated with. |
+| `AccountIds` | array of string | optional, max 1000 items | Unique identifiers of accounts (currently only [Customers](customers.md#customer), in the future also [Companies](companies.md#company)) the reservation is associated with. |
 | `ReservationGroupIds` | array of string | optional, max 1000 items | Unique identifiers of [Reservation groups](#reservation-group). |
 | `States` | array of string [Service order state](./productserviceorders.md#service-order-state) | optional | A list of service order states to filter by. |
 | `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Reservations](#reservation-ver-2023-06-06) were updated. |


### PR DESCRIPTION
The more generic "account Id" has replaced "company Id" and "customer Id" in some newer endpoints. 

Currently, accounts can only be customers. In the future, also companies might fall under accounts. See the slack conversation for more details.

To avoid confusion, I've updated the definition to make it clear which data can be expected in accountId. This might also need to be updated in other endpoints that reference accountId.
