### PR TITLE
Update accounts.md (quick fix)

### DIFF
--- a/operations/accounts.md
+++ b/operations/accounts.md
@@ -51,10 +51,10 @@ Merges two or more accounts of the same account type together. The given source 
 | `SourceAccountIds` | array of string | required, max 1000 items | Unique identifiers of the source accounts ([Customer](../operations/customers.md#customer) or [Company](../operations/companies.md#company)). |
 | `TargetAccountId` | string | required | Unique identifier of the target account ([Customer](../operations/customers.md#customer) or [Company](../operations/companies.md#company)). |
 
-### Account type
+#### Account type
 
-* [Company](companies.md#company)
-* [Customer](customers.md#customer)
+* Company
+* Customer
 * ...
 
 ### Response

--- a/operations/accounts.md
+++ b/operations/accounts.md
@@ -53,8 +53,8 @@ Merges two or more accounts of the same account type together. The given source 
 
 #### Account type
 
-* Company
-* Customer
+* `Company`
+* `Customer`
 * ...
 
 ### Response


### PR DESCRIPTION
Quick fix to correct heading level for 'Account type' definition

#### Summary

* Changed `Account type` from heading-3 to heading-4 in the Accounts page
* Also removed unhelpful Company and Customer links within the `Account type` definition
* Also added '`' characters, following standard convention for string enumerations in the docs

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
