### PR TITLE
Introduce ActualEndUtc and ScheduledEndUtc

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 19th April 2024
+* Deprecated `EndUtc` in [Get all reservations](../operations/reservations.md#get-all-reservations-ver-2023-06-06) response object and replaced with `ActualEndUtc` and  `ScheduledEndUtc` parameter.
+
 ## 12th April 2024
 * Extended [Add order](../operations/orders.md#add-order) request with `LinkedReservationId` parameter.
 * Extended [Product service order](../operations/productserviceorders.md#product-service-order) response object with `LinkedReservationId`, this affects the following operations:

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## 19th April 2024
-* Deprecated `EndUtc` in [Get all reservations](../operations/reservations.md#get-all-reservations-ver-2023-06-06) response object and replaced with `ActualEndUtc` and  `ScheduledEndUtc` parameter.
+* Extended [Reservation (ver 2023-06-06)](../operations/reservations.md#reservation-ver-2023-06-06) response object with `ActualEndUtc` and  `ScheduledEndUtc`, this affects the following operations:
+  * [Get all reservations (ver 2023-06-06)](../operations/reservations.md#reservation-ver-2023-06-06)
+* Deprecated `EndUtc` in [Get all reservations](../operations/reservations.md#get-all-reservations-ver-2023-06-06) response object.
 
 ## 12th April 2024
 * Extended [Add order](../operations/orders.md#add-order) request with `LinkedReservationId` parameter.

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -39,6 +39,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
+| `EndUtc`<br>in [Reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06) | Replaced by `ScheduledEndUtc` and `ActualEndUtc` | 19 Apr 2024 | - |
 | Extent `RateGroups`<br>in [Get all rates](../operations/rates.md#get-all-rates) | Use [Get all rate groups](../operations/rategroups.md#get-all-rate-groups) instead | 2 Feb 2024 | 10 Jan 2026 |
 | `Name` in [Product](../operations/products.md#product) | Replaced by `Names` | 12 Dec 2023 | |
 | `ExternalName` in [Product](../operations/products.md#product) | Replaced by `ExternalNames` | 12 Dec 2023 | |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -74,6 +74,8 @@ Returns all reservations within scope of the Access Token, filtered according to
             "ScheduledStartUtc": "2023-04-23T14:00:00Z",
             "ActualStartUtc": null,
             "EndUtc": "2023-04-24T14:00:00Z",
+            "ScheduledEndUtc": "2023-04-24T14:00:00Z",
+            "ActualEndUtc": null,
             "Number": "52",
             "State": "Confirmed",
             "Origin": "Connector",
@@ -140,7 +142,9 @@ Returns all reservations within scope of the Access Token, filtered according to
 | ~~`StartUtc`~~ | ~~string~~ | ~~required~~ | ~~Reservation start or check-in time (if it's earlier than scheduled start) in UTC timezone in ISO 8601 format.~~ **Deprecated!** Use `ScheduledStartUtc` and `ActualStartUtc` instead. |
 | `ScheduledStartUtc` | string | required | Scheduled start time of reservation in UTC timezone in ISO 8601 format. |
 | `ActualStartUtc` | string | optional | Actual customer check-in time of reservation in UTC timezone in ISO 8601 format. |
-| `EndUtc` | string | required | Scheduled end time of reservation in UTC timezone in ISO 8601 format. |
+| ~~`EndUtc`~~ | ~~string~~ | ~~required~~ | ~~Scheduled end time of reservation in UTC timezone in ISO 8601 format.~~ **Deprecated!** Use `ScheduledEndUtc` and `ActualEndUtc` instead. |
+| `ScheduledEndUtc` | string | required | Scheduled end time of reservation in UTC timezone in ISO 8601 format. |
+| `ActualEndUtc` | string | optional | Actual customer check-out time of reservation in UTC timezone in ISO 8601 format. |
 | `Number` | string | required | Confirmation number of the reservation in Mews. |
 | `State` | string [Service order state](./productserviceorders.md#service-order-state) | required | State of the reservation. |
 | `Origin` | string [Service order origin](productserviceorders.md#service-order-origin) | required | Origin of the reservation. |


### PR DESCRIPTION
#### Summary

Introduce `ActualEndUtc` and `ScheduledEndUtc` and deprecate `EndUtc`

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
