### PR TITLE
Bill type description correction

### DIFF
--- a/operations/bills.md
+++ b/operations/bills.md
@@ -212,7 +212,7 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
 After a bill is closed, the Bill Type is set to `Receipt` or `Invoice`. `Receipt` indicates that the bill has been fully paid and the balance is zero. `Invoice` indicates that the bill has not yet been fully paid but an invoice has been issued. Prior to closing, Bill Type should not be used.
 
 * `Receipt` (default) - the bill has been paid in full; only applicable after the bill is closed
-* `Invoice` - the bill is supposed to be paid in the future. Before closing it is balanced with an invoice payment.
+* `Invoice` - the bill has not been paid in full but an invoice has been issued to request payment
 
 #### Bill options
 

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -209,7 +209,7 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
 
 #### Bill type
 
-In default, a bill is `Receipt` indicating that it has been partially or fully paid or has not yet been paid. Alternatively, it may be `Invoice` that is supposed to be paid in the future.
+After a bill is closed, the Bill Type is set to `Receipt` or `Invoice`. `Receipt` indicates that the bill has been fully paid and the balance is zero. `Invoice` indicates that the bill has not yet been fully paid but an invoice has been issued. Prior to closing, Bill Type should not be used.
 
 * `Receipt` - the bill has been partially or fully paid or has not yet been paid.
 * `Invoice` - the bill is supposed to be paid in the future. Before closing it is balanced with an invoice payment.

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -211,7 +211,7 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
 
 After a bill is closed, the Bill Type is set to `Receipt` or `Invoice`. `Receipt` indicates that the bill has been fully paid and the balance is zero. `Invoice` indicates that the bill has not yet been fully paid but an invoice has been issued. Prior to closing, Bill Type should not be used.
 
-* `Receipt` - the bill has been partially or fully paid or has not yet been paid.
+* `Receipt` (default) - the bill has been paid in full; only applicable after the bill is closed
 * `Invoice` - the bill is supposed to be paid in the future. Before closing it is balanced with an invoice payment.
 
 #### Bill options

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -209,9 +209,9 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
 
 #### Bill type
 
-A bill is either a `Receipt` which means that it has been fully paid, or `Invoice` that is supposed to be paid in the future.
+In default, a bill is `Receipt` indicating that it has been partially or fully paid or has not yet been paid. Alternatively, it may be `Invoice` that is supposed to be paid in the future.
 
-* `Receipt` - the bill has already been fully paid.
+* `Receipt` - the bill has been partially or fully paid or has not yet been paid.
 * `Invoice` - the bill is supposed to be paid in the future. Before closing it is balanced with an invoice payment.
 
 #### Bill options


### PR DESCRIPTION
#### Summary

The current description of Receipt is not correct, because the bill can be only the Receipt or Invoice and with current description there is a blank spot. The endpoints returns even bills type of Receipt which has not been full paid.

This discrepancy is probably coming from the report, where it shows only closed bills (which means they have been paid).

This is suggestion of description.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
