### PR TITLE
Update ResourceIds Property Type for "Get all resources" Request

### DIFF
--- a/operations/resources.md
+++ b/operations/resources.md
@@ -49,7 +49,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `EnterpriseIds` | array of string | optional, max 1000 items | Unique identifiers of the [Enterprises](enterprises.md#enterprise). If not specified, the operation returns data for all enterprises within scope of the Access Token. |
-| `ResourceIds` | string | optional, max 1000 items | Unique identifiers of the requested [Resources](#resource). |
+| `ResourceIds` | array of string | optional, max 1000 items | Unique identifiers of the requested [Resources](#resource). |
 | `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Resources](#resource) were created. |
 | `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Resources](#resource) were updated. |
 | `Extent` | [Resource extent](#resource-extent) | required | Extent of data to be returned. |


### PR DESCRIPTION
#### Summary

Small fix to make the documentation match the example within the same file.
I believe `ResourceIds` is an array of strings, not a string.

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
