### PR TITLE
Migrate order items to docs generator

### DIFF
--- a/_generator/overrides.yaml
+++ b/_generator/overrides.yaml
@@ -12,6 +12,7 @@ types:
   ActivityStates: '[Activity state](_objects.md#activity-state)'
   ProfileData: '[Profile data](_objects.md#profile-data)'
   BooleanUpdateValue: '[Bool update value](_objects.md#bool-update-value)'
+  Amount: '[Amount](_objects.md#amount)'
 
 properties: {}
 

--- a/_generator/overrides.yaml
+++ b/_generator/overrides.yaml
@@ -10,6 +10,7 @@ types:
   TimeFilterIntervalMax1: '[Time interval](_objects.md#time-interval)'
   DateTimeIntervalUtc: '[Time interval](_objects.md#time-interval)'
   ActivityStates: '[Activity state](_objects.md#activity-state)'
+  AccountingStateEnum: '[Accounting State](accountingitems#accounting-item-state)'
   ProfileData: '[Profile data](_objects.md#profile-data)'
   BooleanUpdateValue: '[Bool update value](_objects.md#bool-update-value)'
   Amount: '[Amount](_objects.md#amount)'

--- a/_generator/page.js
+++ b/_generator/page.js
@@ -53,6 +53,7 @@ export async function renderPage(tagName, operations, outputPath) {
   const mdAdjusted =
     md
       .trim()
+      .replace(/\([^\(]+connector-api\/operations\/(.+?)\/(.+?)\)/g, '($1.md$2)')
       .replace(/\r\n/g, '\n')
       .replace(/\n{3,}/g, '\n\n') + '\n';
   return fs.writeFile(fileName, mdAdjusted, 'utf-8');

--- a/_generator/schema.js
+++ b/_generator/schema.js
@@ -5,6 +5,7 @@ import {
   propertyDescription,
   propertyType,
 } from './jsonschema.js';
+import { Comparer } from './utils.js';
 
 /**
  * @typedef { import('oas/operation').Operation } Operation
@@ -85,11 +86,13 @@ function createEnumTemplateSchema(schema) {
  * @returns {TemplateSchema}
  */
 function createTemplateSchema(schema, schemaId, path) {
+  const propertyComparer = new Comparer(propertySortOrder, function(propertySchema) { return propertySchema.name.toLowerCase(); })
+
   const properties =
     schema.properties &&
     Object.entries(schema.properties).map(([name, property]) =>
       createTemplateProperty(name, property)
-    ).sort(propertiesSort);
+    ).sort(propertyComparer.compare);
   let baseObject = {};
   if (isEnum(schema)) {
     baseObject = createEnumTemplateSchema(schema, schemaId, path);
@@ -165,26 +168,29 @@ const propertySortOrder = {
   clienttoken: -99,
   accesstoken: -98,
   client: -97,
+  serviceid: 50,
+  serviceorderid: 51,
+  billid: 52,
+  accountingcategoryid: 53,
+  unitcount: 54,
+  unitamount: 55,
+  amount: 56,
+  originalamount: 57,
+  notes: 58,
+  revenuetype: 59,
+  creatorprofileid: 60,
+  updaterprofileid: 61,
+  consumedutc: 62,
+  closedutc: 63,
+  chargedutc: 64,
+  createdutc: 65,
+  updatedutc: 66,
+  startutc: 67,
+  accountingstate: 68,
+  type: 69,
+  options: 70,
+  data: 71,  
   currency: 98,
   limitation: 99,
-  fallback: 0
+  default: 0
 };
-
-/**
- * @param {TemplateSchema} propertySchema
- * @returns {number}
- */
-function getPropertyOrder(propertySchema) {
-  const propertyName = propertySchema.name.toLowerCase();
-  let order = propertySortOrder[propertyName];
-  return order || propertySortOrder.fallback;
-}
-
-/**
- * @param {TemplateSchema} a
- * @param {TemplateSchema} b
- * @returns {number}
- */
-function propertiesSort(a, b) {
-  return getPropertyOrder(a) - getPropertyOrder(b);
-}

--- a/_generator/schema.js
+++ b/_generator/schema.js
@@ -89,7 +89,7 @@ function createTemplateSchema(schema, schemaId, path) {
     schema.properties &&
     Object.entries(schema.properties).map(([name, property]) =>
       createTemplateProperty(name, property)
-    );
+    ).sort(propertiesSort);
   let baseObject = {};
   if (isEnum(schema)) {
     baseObject = createEnumTemplateSchema(schema, schemaId, path);
@@ -104,6 +104,32 @@ function createTemplateSchema(schema, schemaId, path) {
     properties,
     ...baseObject,
   };
+}
+
+const propertySortOrder = {
+  clienttoken: -10,
+  accesstoken: -9,
+  limitation: 999,
+  fallback: 0
+};
+
+/**
+ * @param {TemplateSchema} propertySchema
+ * @returns {number}
+ */
+function getPropertyOrder(propertySchema) {
+  const propertyName = propertySchema.name.toLowerCase();
+  let order = propertySortOrder[propertyName];
+  return order || propertySortOrder.fallback;
+}
+
+/**
+ * @param {TemplateSchema} a
+ * @param {TemplateSchema} b
+ * @returns {number}
+ */
+function propertiesSort(a, b) {
+  return getPropertyOrder(a) - getPropertyOrder(b);
 }
 
 // Traverse schema, collect all nested schemas

--- a/_generator/schema.js
+++ b/_generator/schema.js
@@ -106,32 +106,6 @@ function createTemplateSchema(schema, schemaId, path) {
   };
 }
 
-const propertySortOrder = {
-  clienttoken: -10,
-  accesstoken: -9,
-  limitation: 999,
-  fallback: 0
-};
-
-/**
- * @param {TemplateSchema} propertySchema
- * @returns {number}
- */
-function getPropertyOrder(propertySchema) {
-  const propertyName = propertySchema.name.toLowerCase();
-  let order = propertySortOrder[propertyName];
-  return order || propertySortOrder.fallback;
-}
-
-/**
- * @param {TemplateSchema} a
- * @param {TemplateSchema} b
- * @returns {number}
- */
-function propertiesSort(a, b) {
-  return getPropertyOrder(a) - getPropertyOrder(b);
-}
-
 // Traverse schema, collect all nested schemas
 /**
  * @param {SchemaObject} schema
@@ -185,4 +159,32 @@ export function getSchemaId(schema) {
     return `X-Ref-Name-${refName}`;
   }
   return null;
+}
+
+const propertySortOrder = {
+  clienttoken: -99,
+  accesstoken: -98,
+  client: -97,
+  currency: 98,
+  limitation: 99,
+  fallback: 0
+};
+
+/**
+ * @param {TemplateSchema} propertySchema
+ * @returns {number}
+ */
+function getPropertyOrder(propertySchema) {
+  const propertyName = propertySchema.name.toLowerCase();
+  let order = propertySortOrder[propertyName];
+  return order || propertySortOrder.fallback;
+}
+
+/**
+ * @param {TemplateSchema} a
+ * @param {TemplateSchema} b
+ * @returns {number}
+ */
+function propertiesSort(a, b) {
+  return getPropertyOrder(a) - getPropertyOrder(b);
 }

--- a/_generator/utils.js
+++ b/_generator/utils.js
@@ -17,3 +17,21 @@ export function slugify(str) {
 export function firstLine(str = '') {
   return str.split(/\r\n|\r|\n/)[0];
 }
+
+export class Comparer {
+  constructor(orderMap, sortValueSelector) {
+    this.orderMap = orderMap;
+    this.sortValueSelector = sortValueSelector;
+    this.compare = this.compare.bind(this)
+  }
+
+  getOrder(obj) {
+    const sortValue = this.sortValueSelector(obj);
+    let order = this.orderMap[sortValue];
+    return order || this.orderMap.default;
+  }
+
+  compare(a, b) {
+    return this.getOrder(a) - this.getOrder(b);
+  }
+}

--- a/operations/_objects.md
+++ b/operations/_objects.md
@@ -146,3 +146,34 @@ The profile data of the user who created or last updated the record.
 - `Platform`
 - `Static`
 - `Integration`
+
+### Amount
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Currency` | string | required | ISO-4217 code of the [Currency](currencies.md#currency). |
+| `NetValue` | number | required | Net value without taxes. |
+| `GrossValue` | number | required | Gross value including all taxes. |
+| `TaxValues` | array of [Tax value](#tax-value) | required | The tax values applied. |
+| `Breakdown` | [Tax breakdown](#tax-breakdown) | required | Information about individual tax amounts. |
+
+#### Tax value
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Code` | string | optional | Code corresponding to tax type. |
+| `Value` | number | required | Amount of tax applied. |
+
+#### Tax breakdown
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Items` | array of [Tax breakdown item](#tax-breakdown-item) | required | Tax breakdown items per each tax rate applied. |
+
+#### Tax breakdown item
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `TaxRateCode` | string | optional | Tax rate code for the item. `null` for untaxed amounts. |
+| `NetValue` | number | required | The net value that the tax is calculated from. |
+| `TaxValue` | number | required | The value of the tax. |

--- a/operations/accountnotes.md
+++ b/operations/accountnotes.md
@@ -43,15 +43,15 @@ Note this operation uses [Pagination](https://mews-systems.gitbook.io/connector-
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Client` | string | required | Name and version of the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
 | `ClientToken` | string | required | Token identifying the client application. |
-| `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
 | `ChainIds` | array of string | optional, max 1000 items | Unique identifiers of the chain. If not specified, the operation returns data for all chains within scope of the Access Token. |
 | `AccountNoteIds` | array of string | optional, max 1000 items | Unique identifiers of [Account note](https://mews-systems.gitbook.io/connector-api/operations/#account-note). |
-| `AccountIds` | array of string | optional, max 1000 items | Unique identifiers of the accounts ([Customer](https://mews-systems.gitbook.io/connector-api/operations/customers/#customer) or [Company](https://mews-systems.gitbook.io/connector-api/operations/companies/#company)). |
-| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of Account note's last update date and time. |
+| `AccountIds` | array of string | optional, max 1000 items | Unique identifiers of the accounts ([Customer](customers.md#customer) or [Company](companies.md#company)). |
 | `ActivityStates` | array of [Activity state](_objects.md#activity-state) | optional | Whether to return only active, only deleted or both records. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval of Account note's last update date and time. |
+| `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
 
 ### Response
 
@@ -169,9 +169,9 @@ Adds account notes to an account of the enterprise chain. Note this operation su
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Client` | string | required | Name and version of the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
 | `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
 | `ChainId` | string | optional | Unique identifier of the chain. Required when using [Portfolio Access Tokens](https://mews-systems.gitbook.io/connector-api/guidelines/multi-property), ignored otherwise. |
 | `AccountNotes` | array of [Account note parameters](#account-note-parameters) | required, max 1000 items | Account notes to be added. |
 
@@ -250,9 +250,9 @@ Updates information about the specified account notes.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Client` | string | required | Name and version of the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
 | `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
 | `ChainId` | string | optional | Unique identifier of the chain. Required when using [Portfolio Access Tokens](https://mews-systems.gitbook.io/connector-api/guidelines/multi-property), ignored otherwise. |
 | `AccountNoteUpdates` | array of [Account note update parameters](#account-note-update-parameters) | required, max 1000 items | Account notes to be updated. |
 
@@ -336,9 +336,9 @@ Deletes specified account notes.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Client` | string | required | Name and version of the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
 | `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
 | `ChainId` | string | optional | Unique identifier of the chain. Required when using [Portfolio Access Tokens](https://mews-systems.gitbook.io/connector-api/guidelines/multi-property), ignored otherwise. |
 | `AccountNoteIds` | array of string | required, max 1000 items | Unique identifiers of the account notes to be deleted. |
 

--- a/operations/countries.md
+++ b/operations/countries.md
@@ -19,9 +19,9 @@ Returns all countries supported by the API.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Client` | string | required | Name and version of the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
 | `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
 
 ### Response
 

--- a/operations/currencies.md
+++ b/operations/currencies.md
@@ -19,9 +19,9 @@ Returns all currencies supported by the API.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Client` | string | required | Name and version of the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
 | `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
 
 ### Response
 

--- a/operations/devices.md
+++ b/operations/devices.md
@@ -19,9 +19,9 @@ Returns all devices in the enterprise.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Client` | string | required | Name and version of the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
 | `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
 
 ### Response
 

--- a/operations/devices.md
+++ b/operations/devices.md
@@ -46,9 +46,9 @@ Returns all devices in the enterprise.
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the device. |
-| `Type` | [Device type](#device-type) | required | Type of the device. |
 | `Name` | string | required | Name of the device. |
 | `Identifier` | string | optional | Device identifier (for internal purposes). |
+| `Type` | [Device type](#device-type) | required | Type of the device. |
 
 #### Device type
 

--- a/operations/exchangerates.md
+++ b/operations/exchangerates.md
@@ -3,7 +3,7 @@
 
 ## Get all exchange rates
 
-Returns all available exchange rates among currencies of the [Enterprise](https://mews-systems.gitbook.io/connector-api/operations/configuration/#enterprise).
+Returns all available exchange rates among currencies of the [Enterprise](configuration.md#enterprise).
 
 ### Request
 
@@ -19,11 +19,11 @@ Returns all available exchange rates among currencies of the [Enterprise](https:
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Client` | string | required | Name and version of the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
 | `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
 | `Ids` | array of string | optional | Unique identifiers of the Exchange Rates. If not specified, the operation returns all exchange rates. |
-| `EnterpriseIds` | array of string | optional | Unique identifiers of the [Enterprises](https://mews-systems.gitbook.io/connector-api/operations/configuration/#enterprise). If not specified, the operation returns the exchange rates for all enterprises within scope of the Access Token. |
+| `EnterpriseIds` | array of string | optional | Unique identifiers of the [Enterprises](configuration.md#enterprise). If not specified, the operation returns the exchange rates for all enterprises within scope of the Access Token. |
 
 ### Response
 
@@ -53,7 +53,7 @@ Returns all available exchange rates among currencies of the [Enterprise](https:
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the Exchange Rate. |
-| `EnterpriseId` | string | required | Unique identifier of the [Enterprise](https://mews-systems.gitbook.io/connector-api/operations/configuration/#enterprise) to which the Exchange Rate belongs. |
-| `SourceCurrency` | string | required | ISO-4217 code of the source [Currency](https://mews-systems.gitbook.io/connector-api/operations/currencies/#currency). |
-| `TargetCurrency` | string | required | ISO-4217 code of the target [Currency](https://mews-systems.gitbook.io/connector-api/operations/currencies/#currency). |
+| `EnterpriseId` | string | required | Unique identifier of the [Enterprise](configuration.md#enterprise) to which the Exchange Rate belongs. |
+| `SourceCurrency` | string | required | ISO-4217 code of the source [Currency](currencies.md#currency). |
+| `TargetCurrency` | string | required | ISO-4217 code of the target [Currency](currencies.md#currency). |
 | `Value` | number | required | The exchange rate from the source currency to the target currency. |

--- a/operations/images.md
+++ b/operations/images.md
@@ -27,9 +27,9 @@ Returns URLs of the specified images.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Client` | string | required | Name and version of the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
 | `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
 | `Images` | array of [Image size parameters](#image-size-parameters) | required | Parameters of images whose URLs should be returned. |
 
 #### Image size parameters

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -293,8 +293,11 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | `EnterpriseId` | string | required | Unique identifier of the [Enterprise](enterprises.md#enterprise). |
 | `AccountId` | string | optional | Unique identifier of the account (for example [Customer](customers.md#customer)) the order item belongs to. |
 | `AccountType` | [Account type](#account-type) | optional | A discriminator specifying the [type of account](accounts.md#account-type), e.g. customer or company. |
+| `ExternalIdentifier` | string | optional | Identifier of the entity from external system. |
+| `CanceledUtc` | string | optional | Cancellation date and time of the order item in UTC timezone in ISO 8601 format. |
+| `ClaimedUtc` | string | optional | Date and time when the order item was claimed in UTC timezone in ISO 8601 format. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) the order item is assigned to. |
-| `ServiceOrderId` | string | optional | Unique identifier of the [Service order](serviceorders.md#service-order) the order item is assigned to. |
+| `ServiceOrderId` | string | required | Unique identifier of the [Service order](serviceorders.md#service-order) the order item is assigned to. |
 | `BillId` | string | optional | Unique identifier of the [Bill](bills.md#bill) the order item is assigned to. |
 | `AccountingCategoryId` | string | optional | Unique identifier of the [Accounting category](accountingcategories.md#accounting-category) the order item belongs to. |
 | `UnitCount` | integer | required | Unit count of item, i.e. the number of sub-items or units, if applicable. |
@@ -302,18 +305,18 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | `Amount` | [Amount](_objects.md#amount) | required | Amount of item; note a negative amount represents a rebate or payment. |
 | `OriginalAmount` | [Amount](_objects.md#amount) | required | Order item's original amount. Negative amount represents either rebate or a payment. Contains the earliest known value in conversion chain. |
 | `Notes` | string | optional | Additional notes. |
-| `RevenueType` | string [Revenue type](#revenue-type) | required | Revenue type of the item. |
+| `RevenueType` | [Revenue type](#revenue-type) | required | Revenue type of the item. |
 | `CreatorProfileId` | string | required | Unique identifier of the user who created the order item. |
 | `UpdaterProfileId` | string | required | Unique identifier of the user who updated the order item. |
 | `ConsumedUtc` | string | required | Date and time of the item consumption in UTC timezone in ISO 8601 format. |
 | `ClosedUtc` | string | optional | Date and time of the item bill closure in UTC timezone in ISO 8601 format. |
 | `CreatedUtc` | string | required | Creation date and time of the order item created in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the order item in UTC timezone in ISO 8601 format. |
-| `StartUtc` | string | required | Start of the order item in UTC timezone in ISO 8601 format. |
-| `AccountingState` | string [Accounting item state](#accounting-item-state) | required | Accounting state of the order item. |
-| `Type` | string [Order item type](#order-item-type) | required | Order item type, e.g. whether product order or space order. |
+| `StartUtc` | string | optional | Start of the order item in UTC timezone in ISO 8601 format. |
+| `AccountingState` | [Order item accounting state](#order-item-accounting-state) | required | Accounting state of the order item. |
+| `Type` | [Order item type](#order-item-type) | required | Order item type, e.g. whether product order or space order. |
 | `Options` | [Order item options](#order-item-options) | required | Options of the order item. |
-| `Data` | object [Order item data](#order-item-data) | optional | Additional order item data. |
+| `Data` | [Order item data](#order-item-data) | optional | Additional order item data. |
 
 #### Order item data
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -341,21 +341,21 @@ Additional order item data.
 | `AgeCategoryId` | string | optional | Unique identifier of the [Age Category](agecategories.md#age-category). |
 
 #### Order item options
+Options of the order item.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `CanceledWithReservation` | bool | required | Order item was canceled with reservation cancelation. |
+| `CanceledWithReservation` | boolean | required | Order item was canceled with reservation cancellation. |
 
+#### Order item accounting state
 
-#### Accounting item state
-
-* `Open` - Accounting items which carry a non-zero value, are open, and have not been closed on a bill or invoice.
-* `Closed` - Accounting items which carry a non-zero value and have been closed on a bill or invoice.
-* `Inactive` - Accounting items which are either of zero value and have not been canceled, if the state of the payment item is Pending or Failed, or items of optional reservations. Until the reservation is confirmed, all its accounting items are Inactive.
-* `Canceled` - Accounting items which have been canceled, regardless of whether the item is of zero value.
-* ...
+* `Open` - Order items which carry a non-zero value, are open, and have not been closed on a bill or invoice.
+* `Closed` - Order items which carry a non-zero value and have been closed on a bill or invoice.
+* `Inactive` - Order items which are either of zero value and have not been canceled, if the state of the payment item is Pending or Failed, or items of optional reservations. Until the reservation is confirmed, all its accounting items are Inactive.
+* `Canceled` - Order items which have been canceled, regardless of whether the item is of zero value.
 
 #### Order item type
+
 * `CancellationFee`
 * `NightRebate`
 * `ProductOrderRebate`
@@ -370,17 +370,21 @@ Additional order item data.
 * `ProductOrder`
 * `Surcharge`
 * `TaxCorrection`
-* ...
+* `ResourceUpgradeFee`
+* `InvoiceFee`
 
 #### Revenue type
 
 * `Service`
 * `Product`
 * `Additional`
-* ...
 
 #### Order item data discriminator
 
 * `Rebate`
 * `Product`
-* ...
+
+#### Account type
+
+* `Company`
+* `Customer`

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -84,7 +84,7 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | `ConsumedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was consumed. Required if no other filter is provided. |
 | `CanceledUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was canceled. Required if no other filter is provided. |
 | `ClosedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was closed. Required if no other filter is provided. |
-| `AccountingStates` | array of [Order item accounting state](#order-item-accounting-state) | optional, max 1000 items | Accounting state of the item. |
+| `AccountingStates` | array of [Accounting State](accountingitems#accounting-item-state) | optional, max 1000 items | Accounting state of the item. |
 | `Types` | array of [Order item type](#order-item-type) | optional, max 1000 items | Order item type, e.g. whether product order or space order. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](currencies.md#currency) the item costs should be converted to. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
@@ -313,7 +313,7 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | `CreatedUtc` | string | required | Creation date and time of the order item created in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the order item in UTC timezone in ISO 8601 format. |
 | `StartUtc` | string | optional | Start of the order item in UTC timezone in ISO 8601 format. |
-| `AccountingState` | [Order item accounting state](#order-item-accounting-state) | required | Accounting state of the order item. |
+| `AccountingState` | [Accounting State](accountingitems#accounting-item-state) | required | Accounting state of the order item. |
 | `Type` | [Order item type](#order-item-type) | required | Order item type, e.g. whether product order or space order. |
 | `Options` | [Order item options](#order-item-options) | required | Options of the order item. |
 | `Data` | [Order item data](#order-item-data) | optional | Additional order item data. |
@@ -346,13 +346,6 @@ Options of the order item.
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `CanceledWithReservation` | boolean | required | Order item was canceled with reservation cancellation. |
-
-#### Order item accounting state
-
-* `Open` - Order items which carry a non-zero value, are open, and have not been closed on a bill or invoice.
-* `Closed` - Order items which carry a non-zero value and have been closed on a bill or invoice.
-* `Inactive` - Order items which are either of zero value and have not been canceled, if the state of the payment item is Pending or Failed, or items of optional reservations. Until the reservation is confirmed, all its accounting items are Inactive.
-* `Canceled` - Order items which have been canceled, regardless of whether the item is of zero value.
 
 #### Order item type
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -86,7 +86,6 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | `BillIds` | array of string | required, max 1000 items | Unique identifiers of the [Bills](bills.md#bill) to which order item is assigned. Required if no other filter is provided. |
 | `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was created. Required if no other filter is provided. |
 | `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was updated. Required if no other filter is provided. |
-| `ChargedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was charged. Required if no other filter is provided. |
 | `ConsumedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was consumed. Required if no other filter is provided. |
 | `CanceledUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was canceled. Required if no other filter is provided. |
 | `ClosedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was closed. Required if no other filter is provided. |

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -298,9 +298,9 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | `BillId` | string | optional | Unique identifier of the [Bill](bills.md#bill) the order item is assigned to. |
 | `AccountingCategoryId` | string | optional | Unique identifier of the [Accounting category](accountingcategories.md#accounting-category) the order item belongs to. |
 | `UnitCount` | integer | required | Unit count of item, i.e. the number of sub-items or units, if applicable. |
-| `UnitAmount` | [Amount value](#amount-value) | required | Unit amount of item, i.e. the amount of each individual sub-item or unit, if applicable. |
-| `Amount` | [Amount value](#amount-value) | required | Amount of item; note a negative amount represents a rebate or payment. |
-| `OriginalAmount` | [Amount value](#amount-value) | required | order item's original amount, negative amount represents either rebate or a payment. Contains the earliest known value in conversion chain. |
+| `UnitAmount` | [Amount](_objects.md#amount) | required | Unit amount of item, i.e. the amount of each individual sub-item or unit, if applicable. |
+| `Amount` | [Amount](_objects.md#amount) | required | Amount of item; note a negative amount represents a rebate or payment. |
+| `OriginalAmount` | [Amount](_objects.md#amount) | required | Order item's original amount. Negative amount represents either rebate or a payment. Contains the earliest known value in conversion chain. |
 | `Notes` | string | optional | Additional notes. |
 | `RevenueType` | string [Revenue type](#revenue-type) | required | Revenue type of the item. |
 | `CreatorProfileId` | string | required | Unique identifier of the user who created the order item. |

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -319,18 +319,19 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | `Data` | [Order item data](#order-item-data) | optional | Additional order item data. |
 
 #### Order item data
+Additional order item data.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Discriminator` | string [Order item data discriminator](#order-item-data-discriminator) | required | Discriminator pointing to the fields within this object that contains additional data. |
-| `Rebate` | object [Rebate data](#rebate-data)| optional | Contains additional data in the case of rebate item. |
-| `Product` | object [Product data](#product-data) | optional | Contains additional data in the case of product item. |
+| `Discriminator` | [Order item data discriminator](#order-item-data-discriminator) | required | Discriminator pointing to the fields within this object that contains additional data. |
+| `Rebate` | [Rebate data](#rebate-data) | optional | Contains additional data in the case of rebate item. |
+| `Product` | [Product data](#product-data) | optional | Contains additional data in the case of product item. |
 
 #### Rebate data
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `RebatedItemId` | string | required | Unique identifier of [Order item](orders.md#order-item) which has been rebated by current item. |
+| `RebatedItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been rebated by current item. |
 
 #### Product data
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -10,67 +10,62 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 
 ```javascript
 {
-    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",    
-    "EnterpriseIds": 
-    [
-        "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        "4d0201db-36f5-428b-8d11-4f0a65e960cc"
-    ],
-    "OrderItemIds": 
-    [
-        "3e982ab5-6245-4c39-80af-1118d40e7494",
-        "bd11dc4a-8f9e-442b-bb1e-f5361b31dfa2"
-    ],
-    "ServiceOrderIds": 
-    [
-        "ac5ef5eb-c5b2-4083-879f-83f04a5ebda5",
-        "5d603823-b40a-43a4-8244-d5d2b515deb5"
-    ],
-    "ServiceIds": 
-    [
-        "294c7859-63ba-46ad-a8bf-34fad2019383",
-        "05089c0c-5d55-4756-827b-c4bcee1edf00"
-    ],
-    "BillIds": 
-    [
-        "d27ffe99-ff92-4afb-ac03-9268f24f0556",
-        "297de6f8-bd67-4ebd-98b6-ecc1cd8f920c"
-    ],
-    "CreatedUtc": {
-        "StartUtc": "2023-03-01T00:00:00Z",
-        "EndUtc": "2023-03-31T00:00:00Z"
-    },
-    "UpdatedUtc": {
-        "StartUtc": "2023-03-01T00:00:00Z",
-        "EndUtc": "2023-03-31T00:00:00Z"
-    },
-    "ConsumedUtc": {
-        "StartUtc": "2023-03-01T00:00:00Z",
-        "EndUtc": "2023-03-31T00:00:00Z"
-    },
-    "CanceledUtc": {
-        "StartUtc": "2023-03-01T00:00:00Z",
-        "EndUtc": "2023-03-31T00:00:00Z"
-    },
-    "ClosedUtc": {
-        "StartUtc": "2023-03-01T00:00:00Z",
-        "EndUtc": "2023-03-31T00:00:00Z"
-    },    
-    "AccountingStates": [
-        "Open",
-        "Closed"
-    ],
-    "Types": [
-        "CityTax",
-        "SpaceOrder"
-    ],
-    "Currency": "EUR",
-    "Limitation": {
-        "Count": 10, 
-        "Cursor": null
-    }
+  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+  "Client": "Sample Client 1.0.0",
+  "EnterpriseIds": [
+    "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "4d0201db-36f5-428b-8d11-4f0a65e960cc"
+  ],
+  "OrderItemIds": [
+    "3e982ab5-6245-4c39-80af-1118d40e7494",
+    "bd11dc4a-8f9e-442b-bb1e-f5361b31dfa2"
+  ],
+  "ServiceOrderIds": [
+    "ac5ef5eb-c5b2-4083-879f-83f04a5ebda5",
+    "5d603823-b40a-43a4-8244-d5d2b515deb5"
+  ],
+  "ServiceIds": [
+    "294c7859-63ba-46ad-a8bf-34fad2019383",
+    "05089c0c-5d55-4756-827b-c4bcee1edf00"
+  ],
+  "BillIds": [
+    "d27ffe99-ff92-4afb-ac03-9268f24f0556",
+    "297de6f8-bd67-4ebd-98b6-ecc1cd8f920c"
+  ],
+  "CreatedUtc": {
+    "StartUtc": "2023-03-01T00:00:00Z",
+    "EndUtc": "2023-03-31T00:00:00Z"
+  },
+  "UpdatedUtc": {
+    "StartUtc": "2023-03-01T00:00:00Z",
+    "EndUtc": "2023-03-31T00:00:00Z"
+  },
+  "ConsumedUtc": {
+    "StartUtc": "2023-03-01T00:00:00Z",
+    "EndUtc": "2023-03-31T00:00:00Z"
+  },
+  "CanceledUtc": {
+    "StartUtc": "2023-03-01T00:00:00Z",
+    "EndUtc": "2023-03-31T00:00:00Z"
+  },
+  "ClosedUtc": {
+    "StartUtc": "2023-03-01T00:00:00Z",
+    "EndUtc": "2023-03-31T00:00:00Z"
+  },
+  "AccountingStates": [
+    "Open",
+    "Closed"
+  ],
+  "Types": [
+    "CityTax",
+    "SpaceOrder"
+  ],
+  "Currency": "EUR",
+  "Limitation": {
+    "Count": 10,
+    "Cursor": null
+  }
 }
 ```
 
@@ -98,190 +93,190 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 
 ```javascript
 {
-    "OrderItems": [
-        {
-            "Id": "53896156-f25b-4949-b55b-afd3007b1146",
-            "EnterpriseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "AccountId": "c173bb22-6ff8-4ffd-875f-afb900c92865",
-            "AccountType": "Customer",
-            "Notes": "Additional note",
-            "ServiceId": "294c7859-63ba-46ad-a8bf-34fad2019383",
-            "ServiceOrderId": "ac5ef5eb-c5b2-4083-879f-83f04a5ebda5",
-            "BillId": "d27ffe99-ff92-4afb-ac03-9268f24f0556",
-            "AccountingCategoryId": "c0610937-0165-4091-a79c-44eb34173daf",
-            "UnitCount": 1,
-            "UnitAmount": {
-                "Currency": "EUR",
-                "NetValue": 5.00,
-                "GrossValue": 5.00,
-                "TaxValues": [
-                    {
-                        "Code": "DE-2020-1-Z",
-                        "Value": 0.00
-                    }
-                ],
-                "Breakdown": {
-                    "Items": [
-                        {
-                            "TaxRateCode": "DE-2020-1-Z",
-                            "NetValue": 5.00,
-                            "TaxValue": 0.00
-                        }
-                    ]
-                }
-            },
-            "Amount": {
-                "Currency": "EUR",
-                "NetValue": 5.00,
-                "GrossValue": 5.00,
-                "TaxValues": [
-                    {
-                        "Code": "DE-2020-1-Z",
-                        "Value": 0.00
-                    }
-                ],
-                "Breakdown": {
-                    "Items": [
-                        {
-                            "TaxRateCode": "DE-2020-1-Z",
-                            "NetValue": 5.00,
-                            "TaxValue": 0.00
-                        }
-                    ]
-                }
-            },
-            "OriginalAmount": {
-                "Currency": "EUR",
-                "NetValue": 5.00,
-                "GrossValue": 5.00,
-                "TaxValues": [
-                    {
-                        "Code": "DE-2020-1-Z",
-                        "Value": 0.00
-                    }
-                ],
-                "Breakdown": {
-                    "Items": [
-                        {
-                            "TaxRateCode": "DE-2020-1-Z",
-                            "NetValue": 5.00,
-                            "TaxValue": 0.00
-                        }
-                    ]
-                }
-            },
-            "RevenueType": "Additional",
-            "CreatorProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
-            "UpdaterProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
-            "CreatedUtc": "2023-03-28T07:28:04Z",
-            "UpdatedUtc": "2023-03-28T07:28:04Z",
-            "ConsumedUtc": "2023-03-31T00:00:00Z",
-            "CanceledUtc": null,
-            "ClosedUtc": null,
-            "StartUtc": "2023-03-30T22:00:00Z",
-            "AccountingState": "Open",
-            "Type": "CityTax",   
-            "Options": {
-                "CanceledWithReservation": false
-            },         
-            "Data": null
-        },
-        {
-            "Id": "bd11dc4a-8f9e-442b-bb1e-f5361b31dfa2",
-            "EnterpriseId": "4d0201db-36f5-428b-8d11-4f0a65e960cc",
-            "AccountId": "c173bb22-6ff8-4ffd-875f-afb900c92865",
-            "AccountType": "Company",
-            "Notes": "Additional note",
-            "ServiceId": "05089c0c-5d55-4756-827b-c4bcee1edf00",
-            "ServiceOrderId": "dd01a673-ee6e-4f10-9c93-afcd00759ddd",
-            "BillId": "297de6f8-bd67-4ebd-98b6-ecc1cd8f920c",
-            "AccountingCategoryId": "c5819fe7-d67c-4c24-b02e-6ce84a1d3b1d",
-            "UnitCount": 1,
-            "UnitAmount": {
-                "Currency": "EUR",
-                "NetValue": 93.46,
-                "GrossValue": 100.00,
-                "TaxValues": [
-                    {
-                        "Code": "DE-2020-1-L",
-                        "Value": 6.54
-                    }
-                ],
-                "Breakdown": {
-                    "Items": [
-                        {
-                            "TaxRateCode": "DE-2020-1-L",
-                            "NetValue": 93.46,
-                            "TaxValue": 6.54
-                        }
-                    ]
-                }
-            },
-            "Amount": {
-                "Currency": "EUR",
-                "NetValue": 93.46,
-                "GrossValue": 100.00,
-                "TaxValues": [
-                    {
-                        "Code": "DE-2020-1-L",
-                        "Value": 6.54
-                    }
-                ],
-                "Breakdown": {
-                    "Items": [
-                        {
-                            "TaxRateCode": "DE-2020-1-L",
-                            "NetValue": 93.46,
-                            "TaxValue": 6.54
-                        }
-                    ]
-                }
-            },
-            "OriginalAmount": {
-                "Currency": "EUR",
-                "NetValue": 93.46,
-                "GrossValue": 100.00,
-                "TaxValues": [
-                    {
-                        "Code": "DE-2020-1-L",
-                        "Value": 6.54
-                    }
-                ],
-                "Breakdown": {
-                    "Items": [
-                        {
-                            "TaxRateCode": "DE-2020-1-L",
-                            "NetValue": 93.46,
-                            "TaxValue": 6.54
-                        }
-                    ]
-                }
-            },
-            "RevenueType": "Service",
-            "CreatorProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
-            "UpdaterProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
-            "CreatedUtc": "2023-03-28T07:28:01Z",
-            "UpdatedUtc": "2023-03-28T07:28:04Z",
-            "ConsumedUtc": "2023-03-31T00:00:00Z",
-            "CanceledUtc": null,
-            "ClosedUtc": null,
-            "StartUtc": "2023-03-30T22:00:00Z",
-            "AccountingState": "Open",
-            "Type": "SpaceOrder", 
-            "Options": {
-                "CanceledWithReservation": false
-            },           
-            "Data": {
-                "Discriminator": "Product",
-                "Rebate": null,
-                "Product": {
-                    "ProductId": "8c8dbd02-f2e2-4845-b964-afb900c8f919",
-                    "AgeCategoryId": null
-                }
+  "OrderItems": [
+    {
+      "Id": "53896156-f25b-4949-b55b-afd3007b1146",
+      "EnterpriseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "AccountId": "c173bb22-6ff8-4ffd-875f-afb900c92865",
+      "AccountType": "Customer",
+      "Notes": "Additional note",
+      "ServiceId": "294c7859-63ba-46ad-a8bf-34fad2019383",
+      "ServiceOrderId": "ac5ef5eb-c5b2-4083-879f-83f04a5ebda5",
+      "BillId": "d27ffe99-ff92-4afb-ac03-9268f24f0556",
+      "AccountingCategoryId": "c0610937-0165-4091-a79c-44eb34173daf",
+      "UnitCount": 1,
+      "UnitAmount": {
+        "Currency": "EUR",
+        "NetValue": 5,
+        "GrossValue": 5,
+        "TaxValues": [
+          {
+            "Code": "DE-2020-1-Z",
+            "Value": 0
+          }
+        ],
+        "Breakdown": {
+          "Items": [
+            {
+              "TaxRateCode": "DE-2020-1-Z",
+              "NetValue": 5,
+              "TaxValue": 0
             }
+          ]
         }
-    ],
-    "Cursor": "d98c9611-0006-4691-a835-af2e00b170c4"
+      },
+      "Amount": {
+        "Currency": "EUR",
+        "NetValue": 5,
+        "GrossValue": 5,
+        "TaxValues": [
+          {
+            "Code": "DE-2020-1-Z",
+            "Value": 0
+          }
+        ],
+        "Breakdown": {
+          "Items": [
+            {
+              "TaxRateCode": "DE-2020-1-Z",
+              "NetValue": 5,
+              "TaxValue": 0
+            }
+          ]
+        }
+      },
+      "OriginalAmount": {
+        "Currency": "EUR",
+        "NetValue": 5,
+        "GrossValue": 5,
+        "TaxValues": [
+          {
+            "Code": "DE-2020-1-Z",
+            "Value": 0
+          }
+        ],
+        "Breakdown": {
+          "Items": [
+            {
+              "TaxRateCode": "DE-2020-1-Z",
+              "NetValue": 5,
+              "TaxValue": 0
+            }
+          ]
+        }
+      },
+      "RevenueType": "Additional",
+      "CreatorProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
+      "UpdaterProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
+      "CreatedUtc": "2023-03-28T07:28:04Z",
+      "UpdatedUtc": "2023-03-28T07:28:04Z",
+      "ConsumedUtc": "2023-03-31T00:00:00Z",
+      "CanceledUtc": null,
+      "ClosedUtc": null,
+      "StartUtc": "2023-03-30T22:00:00Z",
+      "AccountingState": "Open",
+      "Type": "CityTax",
+      "Options": {
+        "CanceledWithReservation": false
+      },
+      "Data": null
+    },
+    {
+      "Id": "bd11dc4a-8f9e-442b-bb1e-f5361b31dfa2",
+      "EnterpriseId": "4d0201db-36f5-428b-8d11-4f0a65e960cc",
+      "AccountId": "c173bb22-6ff8-4ffd-875f-afb900c92865",
+      "AccountType": "Company",
+      "Notes": "Additional note",
+      "ServiceId": "05089c0c-5d55-4756-827b-c4bcee1edf00",
+      "ServiceOrderId": "dd01a673-ee6e-4f10-9c93-afcd00759ddd",
+      "BillId": "297de6f8-bd67-4ebd-98b6-ecc1cd8f920c",
+      "AccountingCategoryId": "c5819fe7-d67c-4c24-b02e-6ce84a1d3b1d",
+      "UnitCount": 1,
+      "UnitAmount": {
+        "Currency": "EUR",
+        "NetValue": 93.46,
+        "GrossValue": 100,
+        "TaxValues": [
+          {
+            "Code": "DE-2020-1-L",
+            "Value": 6.54
+          }
+        ],
+        "Breakdown": {
+          "Items": [
+            {
+              "TaxRateCode": "DE-2020-1-L",
+              "NetValue": 93.46,
+              "TaxValue": 6.54
+            }
+          ]
+        }
+      },
+      "Amount": {
+        "Currency": "EUR",
+        "NetValue": 93.46,
+        "GrossValue": 100,
+        "TaxValues": [
+          {
+            "Code": "DE-2020-1-L",
+            "Value": 6.54
+          }
+        ],
+        "Breakdown": {
+          "Items": [
+            {
+              "TaxRateCode": "DE-2020-1-L",
+              "NetValue": 93.46,
+              "TaxValue": 6.54
+            }
+          ]
+        }
+      },
+      "OriginalAmount": {
+        "Currency": "EUR",
+        "NetValue": 93.46,
+        "GrossValue": 100,
+        "TaxValues": [
+          {
+            "Code": "DE-2020-1-L",
+            "Value": 6.54
+          }
+        ],
+        "Breakdown": {
+          "Items": [
+            {
+              "TaxRateCode": "DE-2020-1-L",
+              "NetValue": 93.46,
+              "TaxValue": 6.54
+            }
+          ]
+        }
+      },
+      "RevenueType": "Service",
+      "CreatorProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
+      "UpdaterProfileId": "3cd637ef-4728-47f9-8fb1-afb900c9cdcf",
+      "CreatedUtc": "2023-03-28T07:28:01Z",
+      "UpdatedUtc": "2023-03-28T07:28:04Z",
+      "ConsumedUtc": "2023-03-31T00:00:00Z",
+      "CanceledUtc": null,
+      "ClosedUtc": null,
+      "StartUtc": "2023-03-30T22:00:00Z",
+      "AccountingState": "Open",
+      "Type": "SpaceOrder",
+      "Options": {
+        "CanceledWithReservation": false
+      },
+      "Data": {
+        "Discriminator": "Product",
+        "Rebate": null,
+        "Product": {
+          "ProductId": "8c8dbd02-f2e2-4845-b964-afb900c8f919",
+          "AgeCategoryId": null
+        }
+      }
+    }
+  ],
+  "Cursor": "d98c9611-0006-4691-a835-af2e00b170c4"
 }
 ```
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -307,7 +307,6 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | `UpdaterProfileId` | string | required | Unique identifier of the user who updated the order item. |
 | `ConsumedUtc` | string | required | Date and time of the item consumption in UTC timezone in ISO 8601 format. |
 | `ClosedUtc` | string | optional | Date and time of the item bill closure in UTC timezone in ISO 8601 format. |
-| `ChargedUtc` | string | optional | Charged date and time of the order item charged in UTC timezone in ISO 8601 format. |
 | `CreatedUtc` | string | required | Creation date and time of the order item created in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the order item in UTC timezone in ISO 8601 format. |
 | `StartUtc` | string | required | Start of the order item in UTC timezone in ISO 8601 format. |

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -282,8 +282,8 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `OrderItems` | array of [Order item](#order-item) | required | Set of requested order items. |
-| `Cursor` | string | required | Unique identifier of the last and hence oldest order item returned. This can be used in [Limitation](../guidelines/pagination.md#limitation) in a subsequent request to fetch the next batch of older order items. |
+| `OrderItems` | array of [Order item](#order-item) | required, max 1000 items | Set of requested order items. |
+| `Cursor` | string | optional | Unique identifier of the last and hence oldest order item returned. This can be used in [Limitation](https://mews-systems.gitbook.io/connector-api/guidelines/pagination/#limitation) in a subsequent request to fetch the next batch of older order items. |
 
 #### Order item
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -2,11 +2,11 @@
 
 ## Get all order items
 
-Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUtc`, `UpdatedUtc`, `ChargedUtc`, `ClosedUtc` filters must be specified in the request. Note this operation uses [Pagination](../guidelines/pagination.md) and supports [Portfolio Access Tokens](../guidelines/multi-property.md).
+Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, `ServiceIds` `BillIds`, `CreatedUtc`, `UpdatedUtc`, `ChargedUtc`, `ClosedUtc` filters must be specified in the request. Note this operation uses [Pagination](https://mews-systems.gitbook.io/connector-api/guidelines/pagination/) and supports [Portfolio Access Tokens](https://mews-systems.gitbook.io/connector-api/guidelines/multi-property/).
 
 ### Request
 
-`[PlatformAddress]/api/connector/v1/orderitems/getAll`
+`[PlatformAddress]/api/connector/v1/orderItems/getAll`
 
 ```javascript
 {
@@ -75,17 +75,17 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `EnterpriseIds` | array of string | optional, max 1000 items | Unique identifiers of the [Enterprises](enterprises.md#enterprise). If not specified, the operation returns the order items for all enterprises within scope of the Access Token. |
-| `OrderItemIds` | array of string | required, max 1000 items | Unique identifiers of the [Order items](orderitems.md#order-item). Required if no other filter is provided. |
-| `ServiceOrderIds` | array of string | required, max 1000 items | Unique identifiers of the service orders \([product service orders](productserviceorders.md#product-service-order) or [reservations](reservations.md#reservation-ver-2023-06-06)\). Required if no other filter is provided. |
-| `ServiceIds` | array of string | required, max 1000 items | Unique identifiers of the [Services](services.md#service). Required if no other filter is provided. |
-| `BillIds` | array of string | required, max 1000 items | Unique identifiers of the [Bills](bills.md#bill) to which order item is assigned. Required if no other filter is provided. |
-| `CreatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was created. Required if no other filter is provided. |
-| `UpdatedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was updated. Required if no other filter is provided. |
-| `ConsumedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was consumed. Required if no other filter is provided. |
-| `CanceledUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was canceled. Required if no other filter is provided. |
-| `ClosedUtc` | [Time interval](#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was closed. Required if no other filter is provided. |
-| `AccountingStates` | string [Accounting state](#accounting-item-state) | required | Accounting state of the item. |
-| `Types` | string [Order item type](#order-item-type) | required | Order item type, e.g. whether product order or space order. |
+| `OrderItemIds` | array of string | optional, max 1000 items | Unique identifiers of the [Order items](orderitems.md#order-item). Required if no other filter is provided. |
+| `ServiceOrderIds` | array of string | optional, max 1000 items | Unique identifiers of the service orders ([product service orders](productserviceorders.md#product-service-order) or [reservations](reservations.md#reservation-ver-2023-06-06)). Required if no other filter is provided. |
+| `ServiceIds` | array of string | optional, max 1000 items | Unique identifiers of the [Services](services.md#service). Required if no other filter is provided. |
+| `BillIds` | array of string | optional, max 1000 items | Unique identifiers of the [Bills](bills.md#bill) to which order item is assigned. Required if no other filter is provided. |
+| `CreatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was created. Required if no other filter is provided. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was updated. Required if no other filter is provided. |
+| `ConsumedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was consumed. Required if no other filter is provided. |
+| `CanceledUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was canceled. Required if no other filter is provided. |
+| `ClosedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Order item](orderitems.md#order-item) was closed. Required if no other filter is provided. |
+| `AccountingStates` | array of [Order item accounting state](#order-item-accounting-state) | optional, max 1000 items | Accounting state of the item. |
+| `Types` | array of [Order item type](#order-item-type) | optional, max 1000 items | Order item type, e.g. whether product order or space order. |
 | `Currency` | string | optional | ISO-4217 code of the [Currency](currencies.md#currency) the item costs should be converted to. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -291,8 +291,8 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the order item. |
 | `EnterpriseId` | string | required | Unique identifier of the [Enterprise](enterprises.md#enterprise). |
-| `AccountId` | string | required | Unique identifier of the account (for example [Customer](customers.md#customer)) the order item belongs to. |
-| `AccountType` | string | required | A discriminator specifying the [type of account](accounts.md#account-type), e.g. customer or company. |
+| `AccountId` | string | optional | Unique identifier of the account (for example [Customer](customers.md#customer)) the order item belongs to. |
+| `AccountType` | [Account type](#account-type) | optional | A discriminator specifying the [type of account](accounts.md#account-type), e.g. customer or company. |
 | `ServiceId` | string | required | Unique identifier of the [Service](services.md#service) the order item is assigned to. |
 | `ServiceOrderId` | string | optional | Unique identifier of the [Service order](serviceorders.md#service-order) the order item is assigned to. |
 | `BillId` | string | optional | Unique identifier of the [Bill](bills.md#bill) the order item is assigned to. |


### PR DESCRIPTION
#### Summary

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

https://mews.atlassian.net/browse/CON-2227

A few changes to the generator logic:

- make URLs which point to `operations` pages relative
- add ordering for properties and schemas
- show common schemas in the response section

This PR also includes specific ordering for order item properties in order to get clearer diff with the previous version. The ordering is removed in a subsequent [PR](https://github.com/MewsSystems/gitbook-connector-api/pull/598).

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
