### PR TITLE
Expose deprecationMessage in reference docs

### DIFF
--- a/_generator/.editorconfig
+++ b/_generator/.editorconfig
@@ -8,3 +8,6 @@ trim_trailing_whitespace = true
 [*.{js,jsx,ts,tsx,mjs,yaml,yml}]
 indent_size = 2
 indent_style = space
+
+[*.edge]
+insert_final_newline = false

--- a/_generator/jsonschema.js
+++ b/_generator/jsonschema.js
@@ -4,7 +4,7 @@
  */
 
 import { resolvePropertyType } from './types-resolver.js';
-import { getSchemaId, getSchemaAnchor, firstLine } from './utils.js';
+import { getSchemaAnchor, firstLine } from './utils.js';
 
 /**
  * @param {SchemaObject} schema

--- a/_generator/page.js
+++ b/_generator/page.js
@@ -18,18 +18,7 @@ import { compareOperations } from './sorting/operationSort.js';
  * @typedef { import('oas').default } Oas
  * @typedef { import('./types.js').PageContext } PageContext
  * @typedef { import('./types.js').TemplateSchema } TemplateSchema
- * @typedef {{
- *    summary: string,
- *    operationId: string,
- *    description: string,
- *    path: string,
- *    method: string,
- *    deprecated: boolean,
- *    requestExample: any,
- *    requestSchemas: SchemaObject[],
- *    responseExample: any,
- *    responseSchemas: SchemaObject[],
- * }} OperationTemplateData
+ * @typedef { import('./types.js').TemplateOperation } OperationTemplateData
  */
 
 const edge = Edge.create();
@@ -153,13 +142,17 @@ function prepareTemplateData(tagName, oasOperations, pageContext) {
         resolver.createSectionSchemasAccumulator()
       );
 
+      const deprecatedMessage = operation.schema['x-deprecatedMessage'] || '';
+      const description = operation.getDescription();
+
       return {
         summary: operation.getSummary(),
         operationId,
-        description: operation.getDescription(),
+        description: description === deprecatedMessage ? '' : description,
         path: operation.path,
         method: operation.method,
         deprecated: operation.isDeprecated(),
+        deprecatedMessage: deprecatedMessage,
         restricted: operation.schema['x-restricted'],
         requestExample,
         requestSchemas: prepareTemplateSchemas(

--- a/_generator/page.js
+++ b/_generator/page.js
@@ -142,7 +142,7 @@ function prepareTemplateData(tagName, oasOperations, pageContext) {
         resolver.createSectionSchemasAccumulator()
       );
 
-      const deprecatedMessage = operation.schema['x-deprecatedMessage'] || '';
+      const deprecatedMessage = operation.schema['x-deprecatedMessage'] ?? '';
       const description = operation.getDescription();
 
       return {

--- a/_generator/template-schema.js
+++ b/_generator/template-schema.js
@@ -96,11 +96,14 @@ export function createTemplateSchema(schema) {
   if (isEnum(schema)) {
     baseObject = createEnumTemplateSchema(schema, schemaId, path);
   }
+  const description = schema.description?.trim() ?? '';
+  const deprecatedMessage = schema.deprecatedMessage ?? '';
   const templateSchema = {
     path: [...path],
     id: schemaId,
     title: schema.title || schema['x-readme-ref-name'],
-    description: schema.description?.trim() ?? '',
+    description: description === deprecatedMessage ? '' : description,
+    deprecatedMessage,
     enum: schema.enum,
     deprecated: schema.deprecated ?? false,
     properties,

--- a/_generator/template-schema.js
+++ b/_generator/template-schema.js
@@ -26,9 +26,13 @@ import { capitalize } from './utils.js';
  * @returns {TemplateProperty}
  */
 function createTemplateProperty(name, property) {
+  const description = propertyDescription(name, property);
+  const deprecatedMessage = property['x-deprecatedMessage'] ?? '';
+
   return {
     name: capitalize(name),
-    description: propertyDescription(name, property),
+    description: description === deprecatedMessage ? '' : description,
+    deprecatedMessage,
     type: propertyType(property),
     contract: propertyContract(property),
     deprecated: property.deprecated ?? false,

--- a/_generator/templates/deprecatedProperty.edge
+++ b/_generator/templates/deprecatedProperty.edge
@@ -1,4 +1,4 @@
 | ~~`{{ prop.name }}`~~ | ~~{{{
 prop.type }}}~~ | ~~{{{
 prop.contract }}}~~ | {{{
-prop.description ? `~~${prop.description}~~ ` : '' }}}**Deprecated!** |
+prop.description ? `~~${prop.description}~~ ` : '' }}}**Deprecated!** {{{ prop.deprecatedMessage }}}|

--- a/_generator/templates/resource.edge
+++ b/_generator/templates/resource.edge
@@ -7,7 +7,7 @@
 
 @if(operation.deprecated)
 > ### Deprecated!
-> This operation is [deprecated](../deprecations/README.md).
+> This operation is [deprecated](../deprecations/README.md). {{ operation.deprecatedMessage }}
 @end
 @if(operation.restricted)
 > ### Restricted!

--- a/_generator/types.d.ts
+++ b/_generator/types.d.ts
@@ -8,9 +8,24 @@ export type TemplateSchema = {
   properties?: TemplateProperty[];
 };
 
+export type TemplateOperation = {
+  summary: string;
+  operationId: string;
+  description: string;
+  path: string;
+  method: string;
+  deprecated: boolean;
+  deprecatedMessage: string;
+  requestExample: any;
+  requestSchemas: TemplateSchema[];
+  responseExample: any;
+  responseSchemas: TemplateSchema[];
+};
+
 export type TemplateProperty = {
   name: string;
   deprecated: boolean;
+  deprecatedMessage: string;
   type: string;
   contract: string;
   description: string;
@@ -26,11 +41,11 @@ export type PageContext = {
   tagName: string;
   fileName: string;
   outputPath: string;
-}
+};
 
 export type TypeLink = {
   id: string;
   file: string;
   anchor: string;
   titleOverride: string;
-}
+};

--- a/_generator/types.d.ts
+++ b/_generator/types.d.ts
@@ -5,6 +5,7 @@ export type TemplateSchema = {
   description?: string;
   enum: TemplateEnumEntry[];
   deprecated: boolean;
+  deprecatedMessage: string;
   properties?: TemplateProperty[];
 };
 

--- a/operations/services.md
+++ b/operations/services.md
@@ -165,7 +165,7 @@ Additional information about the specific service.
 | `OccupancyStartOffset` | string | required | Offset from the start of the [time unit](../concepts/time-units.md) which defines the occupancy start of the service; expressed in ISO 8601 duration format. 'Occupancy start' is used for availability and reporting purposes, it implies the time at which the booked resource is considered occupied. |
 | `OccupancyEndOffset` | string | required | Offset from the end of the [time unit](../concepts/time-units.md) which defines the occupancy end of the service; expressed in ISO 8601 duration format. 'Occupancy end' is used for availability and reporting purposes, it implies the time at which the booked resource is no longer considered occupied. |
 | `TimeUnitPeriod` | [Time unit period](services.md#time-unit-period) | required | The length of time or period represented by a [time unit](../concepts/time-units.md), for which the service can be booked. |
-| ~~`TimeUnit`~~ | ~~[Time unit period](services.md#time-unit-period)~~ | ~~required~~ | **Deprecated!** |
+| ~~`TimeUnit`~~ | ~~[Time unit period](services.md#time-unit-period)~~ | ~~required~~ | **Deprecated!** Use `TimeUnitPeriod` instead.|
 
 #### Time unit period
 


### PR DESCRIPTION
#### Summary

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
