### PR TITLE
Small tweaks to Common objects

### DIFF
--- a/operations/_objects.md
+++ b/operations/_objects.md
@@ -132,14 +132,12 @@ A [Dictionary](#dictionary) object where the keys are [Language](languages.md#la
 
 ### Profile data
 
-The profile data of the user who created or last updated the record.
+| Property            | Type                                                      | Contract | Description               |
+| :------------------ | :-------------------------------------------------------- | :------- | :------------------------ |
+| `Discriminator`     | [Profile data discriminator](#profile-data-discriminator) | required | Type of the profile data. |
+| `EnterpriseProfile` | [Enterprise profile data](#enterprise-profile-data)       | optional | Enterprise profile data.  |
 
-| Property            | Type                                                    | Contract | Description               |
-| :------------------ | :------------------------------------------------------ | :------- | :------------------------ |
-| `Discriminator`     | [ProfileDataDiscriminator](#profile-data-discriminator) | required | Type of the profile data. |
-| `EnterpriseProfile` | [Enterprise profile data](#enterprise-profile-data)     | optional | Enterprise profile data.  |
-
-#### ProfileDataDiscriminator
+#### Profile data discriminator
 
 - `Personal`
 - `Enterprise`
@@ -184,7 +182,7 @@ The profile data of the user who created or last updated the record.
 | `NetValue` | number | required | The net value that the tax is calculated from. |
 | `TaxValue` | number | required | The value of the tax. |
 
-#### Currency value (ver 2018-06-07)
+### Currency value (ver 2018-06-07)
 
 Usage of this value is **deprecated**. Where possible, use the properties exposing the [Amount](#amount) instead.
 


### PR DESCRIPTION
#### Summary

* Minor tweaks to **Common objects** (documentation-only):
  * Removed bogus description from `ProfileData`
  * Changed `ProfileDataDiscriminator` to `Profile data discriminator`
  * Corrected heading level for `Currency value (ver 2018-06-07)`

#### Follow style guide

[Style guide](https://app.getguru.com/card/c98GRexi/Style-Guide-for-Mews-Open-API-Documentation)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
