### PR TITLE
CON-2201 Migrate Cancellation Policies documentation

### DIFF
--- a/_generator/config.yaml
+++ b/_generator/config.yaml
@@ -11,7 +11,7 @@ tags:
   # - availabilityblocks
   # - bills
   # - businesssegments
-  # - cancellationpolicies
+  - cancellationpolicies
   # - cashiers
   # - cashiertransactions
   # - commands

--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -542,3 +542,21 @@ types:
   reservationoldorigin:
     file: reservations.md
     anchor: reservation-origin-ver-2017-04-12
+  cancellationpolicyresult:
+    file: cancellationpolicies.md
+    anchor: cancellationpolicyresult
+  cancellationpolicy:
+    file: cancellationpolicies.md
+    anchor: cancellation-policy
+  cancellationpolicyapplicability:
+    file: cancellationpolicies.md
+    anchor: cancellation-policy-applicability
+  cancellationfeeextent:
+    file: cancellationpolicies.md
+    anchor: cancellation-fee-extent
+  currencyvalue:
+    file: cancellationpolicies.md
+    anchor: currency-value-ver-2023-02-02
+  cancellationpolicyfilterparameters:
+    file: cancellationpolicies.md
+    anchor: cancellationpolicyfilterparameters

--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -555,7 +555,7 @@ types:
     file: cancellationpolicies.md
     anchor: cancellation-fee-extent
   currencyvalue:
-    file: cancellationpolicies.md
+    file: _objects.md
     anchor: currency-value-ver-2023-02-02
   cancellationpolicyfilterparameters:
     file: cancellationpolicies.md

--- a/operations/_objects.md
+++ b/operations/_objects.md
@@ -193,3 +193,10 @@ Usage of this value is **deprecated**. Where possible, use the properties exposi
 | ~~`Net`~~ | ~~number~~ | ~~optional~~ | **Deprecated!** |
 | ~~`Tax`~~ | ~~number~~ | ~~optional~~ | **Deprecated!** |
 | ~~`TaxRate`~~ | ~~number~~ | ~~optional~~ | **Deprecated!** |
+
+#### Currency value (ver 2023-02-02)
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Currency` | string | required |  |
+| `Value` | number | required |  |

--- a/operations/cancellationpolicies.md
+++ b/operations/cancellationpolicies.md
@@ -1,10 +1,10 @@
+<!-- AUTOMATICALLY GENERATED, DO NOT MODIFY -->
 # Cancellation policies
 
 ## Get all cancellation policies
 
 > ### Restricted!
 > This operation is currently in beta-test and as such it is subject to change.
-
 Returns all cancellation policies, filtered by services, rate groups and other filters. 
 Note this operation uses [Pagination](../guidelines/pagination.md) and supports [Portfolio Access Tokens](../guidelines/multi-property.md).
 
@@ -14,27 +14,29 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 
 ```javascript
 {
-    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",
-    "EnterpriseIds": [
-        "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        "4d0201db-36f5-428b-8d11-4f0a65e960cc"
-    ],
-    "ServiceIds": [
-        "e654f217-d1b5-46be-a820-e93ba568dfac"
-    ],
-    "CancellationPolicyIds": [
-        "fe795f96-0b64-445b-89ed-c032563f2bac"
-    ],
-    "RateGroupIds": [
-        "deb9444e-6897-4f2a-86b4-aff100c2896e"
-    ],
-    "UpdatedUtc": {
-        "StartUtc": "2023-04-27T11:48:57Z",
-        "EndUtc": "2023-04-27T11:48:57Z",
-    },
-    "Limitation": { "Count": 10 }
+  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+  "Client": "Sample Client 1.0.0",
+  "EnterpriseIds": [
+    "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "4d0201db-36f5-428b-8d11-4f0a65e960cc"
+  ],
+  "ServiceIds": [
+    "e654f217-d1b5-46be-a820-e93ba568dfac"
+  ],
+  "CancellationPolicyIds": [
+    "fe795f96-0b64-445b-89ed-c032563f2bac"
+  ],
+  "RateGroupIds": [
+    "deb9444e-6897-4f2a-86b4-aff100c2896e"
+  ],
+  "UpdatedUtc": {
+    "StartUtc": "2023-04-27T11:48:57Z",
+    "EndUtc": "2023-04-27T11:48:57Z"
+  },
+  "Limitation": {
+    "Count": 10
+  }
 }
 ```
 
@@ -44,43 +46,44 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
 | `EnterpriseIds` | array of string | optional, max 1000 items | Unique identifiers of the [Enterprises](enterprises.md#enterprise). If not specified, the operation returns data for all enterprises within scope of the Access Token. |
-| `ServiceIds` | array of string | required, max 1000 items | Unique identifiers of the [Service](services.md#service). |
-| `CancellationPolicyIds` | array of string | optional, max 1000 items | Unique identifiers of the [Cancellation Policy](#cancellationpolicy). Required if no other filter is provided. |
+| `ServiceIds` | array of string | required, max 100 items | Unique identifiers of the [Service](services.md#service). |
+| `CancellationPolicyIds` | array of string | optional, max 1000 items | Unique identifiers of the [Cancellation Policy](cancellationpolicies.md#cancellationpolicy). Required if no other filter is provided. |
 | `RateGroupIds` | array of string | optional, max 1000 items | Unique identifiers of the [Rate group](rates.md#rategroup). Required if no other filter is provided. |
-| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Cancellation Policy](#cancellation-policy) was updated. Required if no other filter is provided. |
-| `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of cancellation policies returned. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the Cancellation Policy was updated. Required if no other filter is provided. |
+| `ActivityStates` | array of [Activity state](_objects.md#activity-state) | optional | Whether to return only active, only deleted or both records. When null, only active records are returned. |
+| `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
 
 ### Response
 
 ```javascript
 {
-    "CancellationPolicies": [
-        {
-            "Id": "769fc613-838f-41a7-ac2a-aff100c3189f",
-            "RateGroupId": "deb9444e-6897-4f2a-86b4-aff100c2896e",
-            "CreatedUtc": "2023-04-27T11:48:57Z",
-            "UpdatedUtc": "2023-04-27T11:48:57Z",
-            "Applicability": "Creation",
-            "FeeExtent": [
-                "TimeUnits",
-                "Products"
-            ],
-            "ApplicabilityOffset": "0M0D0:0:0.0",
-            "FeeMaximumTimeUnits": 0,
-            "AbsoluteFee": {
-                "Currency": "EUR",
-                "Value": 15.00
-            },
-            "RelativeFee": 0.00000000
-        }
-    ],
-    "Cursor": "769fc613-838f-41a7-ac2a-aff100c3189f"
+  "CancellationPolicies": [
+    {
+      "Id": "769fc613-838f-41a7-ac2a-aff100c3189f",
+      "RateGroupId": "deb9444e-6897-4f2a-86b4-aff100c2896e",
+      "CreatedUtc": "2023-04-27T11:48:57Z",
+      "UpdatedUtc": "2023-04-27T11:48:57Z",
+      "Applicability": "Creation",
+      "FeeExtent": [
+        "TimeUnits",
+        "Products"
+      ],
+      "ApplicabilityOffset": "0M0D0:0:0.0",
+      "FeeMaximumTimeUnits": 0,
+      "AbsoluteFee": {
+        "Currency": "EUR",
+        "Value": 15
+      },
+      "RelativeFee": 0
+    }
+  ],
+  "Cursor": "769fc613-838f-41a7-ac2a-aff100c3189f"
 }
 ```
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `CancellationPolicies` | array of [Cancellation Policy](#cancellation-policy) | required | The filtered cancellation policies. |
+| `CancellationPolicies` | array of [Cancellation Policy](cancellationpolicies.md#cancellation-policy) | required, max 1000 items | The filtered cancellation policies. |
 | `Cursor` | string | required | Unique identifier of the last and hence oldest cancellation policy returned. This can be used in [Limitation](../guidelines/pagination.md#limitation) in a subsequent request to fetch the next batch of older cancellation policies. |
 
 #### Cancellation Policy
@@ -91,22 +94,29 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `RateGroupId` | string | required | Unique identifier of the rate group the cancellation policy belongs to. |
 | `CreatedUtc` | string | required | Date and time of the cancellation policy creation in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Date and time of the cancellation policy update in UTC timezone in ISO 8601 format. |
-| `Applicability` | string [Applicability](#cancellation-policy-applicability) | required | Applicability mode of the cancellation policy. |
-| `FeeExtent` | array of string [Fee Extent](#fee-extent) | required | Extent for the cancellation fee, i.e. what should be in scope for the automatic payment. |
-| `ApplicabilityOffset` | string | required | Offset for order start (assuming Applicability is set to `Start`) from which the fee is applied. |
-| `FeeMaximumTimeUnits` | int | required | Maximum number of time units the cancellation fee is applicable to. |
-| `AbsoluteFee` | [Currency value](../operations/accountingitems.md#currency-value) | optional | Absolute value of the fee. |
-| `RelativeFee` | decimal | required | Relative value of the fee, as a percentage of the reservation price. |
+| `Applicability` | [Cancellation Policy Applicability](cancellationpolicies.md#cancellation-policy-applicability) | required | Applicability mode of the cancellation policy. |
+| `FeeExtent` | array of [Cancellation Fee Extent](cancellationpolicies.md#cancellation-fee-extent) | required | Extent for the cancellation fee, i.e. what should be in scope for the automatic payment. |
+| `ApplicabilityOffset` | string | required | Offset for order start (assuming Applicability is set to Start) from which the fee is applied. |
+| `FeeMaximumTimeUnits` | integer | required | Maximum number of time units the cancellation fee is applicable to. |
+| `AbsoluteFee` | [Currency value (ver 2023-02-02)](cancellationpolicies.md#currency-value-ver-2023-02-02) | required | Absolute value of the fee. |
+| `RelativeFee` | number | required | Relative value of the fee, as a percentage of the reservation price. |
+| `IsActive` | boolean | required | Whether the cancellation policy is still active. |
 
 #### Cancellation Policy Applicability
 
-* `Creation` - Cancellation fee is applicable from the time of creating the reservation.
-* `Start` - Cancellation fee is applicable as soon as the reservation starts, i.e. at arrival time.
-* `StartDate` - Cancellation fee is applicable on the date the reservation starts, i.e., at midnight.
-* ...
+* `Creation`
+* `Start`
+* `StartDate`
 
-#### Fee Extent
+#### Cancellation Fee Extent
 
 * `TimeUnits`
 * `Products`
-* ...
+
+#### Currency value (ver 2023-02-02)
+Absolute value of the fee.
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Currency` | string | required |  |
+| `Value` | number | required |  |

--- a/operations/cancellationpolicies.md
+++ b/operations/cancellationpolicies.md
@@ -50,7 +50,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `CancellationPolicyIds` | array of string | optional, max 1000 items | Unique identifiers of the [Cancellation Policy](cancellationpolicies.md#cancellationpolicy). Required if no other filter is provided. |
 | `RateGroupIds` | array of string | optional, max 1000 items | Unique identifiers of the [Rate group](rates.md#rategroup). Required if no other filter is provided. |
 | `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the Cancellation Policy was updated. Required if no other filter is provided. |
-| `ActivityStates` | array of [Activity state](_objects.md#activity-state) | optional | Whether to return only active, only deleted or both records. When null, only active records are returned. |
+| `ActivityStates` | array of [Activity state](_objects.md#activity-state) | optional | Whether to return only active, only deleted, or both types of record. If not specified, only active records will be returned. |
 | `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
 
 ### Response

--- a/operations/cancellationpolicies.md
+++ b/operations/cancellationpolicies.md
@@ -98,7 +98,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `FeeExtent` | array of [Cancellation Fee Extent](cancellationpolicies.md#cancellation-fee-extent) | required | Extent for the cancellation fee, i.e. what should be in scope for the automatic payment. |
 | `ApplicabilityOffset` | string | required | Offset for order start (assuming Applicability is set to Start) from which the fee is applied. |
 | `FeeMaximumTimeUnits` | integer | required | Maximum number of time units the cancellation fee is applicable to. |
-| `AbsoluteFee` | [Currency value (ver 2023-02-02)](cancellationpolicies.md#currency-value-ver-2023-02-02) | required | Absolute value of the fee. |
+| `AbsoluteFee` | [Currency value (ver 2023-02-02)](_objects.md#currency-value-ver-2023-02-02) | required | Absolute value of the fee. |
 | `RelativeFee` | number | required | Relative value of the fee, as a percentage of the reservation price. |
 | `IsActive` | boolean | required | Whether the cancellation policy is still active. |
 
@@ -112,11 +112,3 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 
 * `TimeUnits`
 * `Products`
-
-#### Currency value (ver 2023-02-02)
-Absolute value of the fee.
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `Currency` | string | required |  |
-| `Value` | number | required |  |


### PR DESCRIPTION
#### Summary
https://mews.atlassian.net/browse/CON-2201:  Migrate Cancellation Policies documentation

 - Implemented automatic documentation generation for the cancellation policy endpoint
 - Generated the cancellation policy page


#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
