### PR TITLE
CON-3539-Regenerate-documentation-for-services-endpoint

### DIFF
--- a/operations/services.md
+++ b/operations/services.md
@@ -112,13 +112,14 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `Id` | string | required | Unique identifier of the service. |
 | `EnterpriseId` | string | required | Unique identifier of the [Enterprise](enterprises.md#enterprise). |
 | `IsActive` | boolean | required | Whether the service is still active. |
-| `Name` | string | required | Name of the service. |
+| `Names` | object | required | All translations of the name. |
 | `Options` | [Service options](services.md#service-options) | required | Options of the service. |
 | `Ordering` | integer | required | Order value for presentation purposes. |
 | `Data` | [Service data](services.md#service-data) | required | Additional information about the specific service. |
 | `ExternalIdentifier` | string | optional, max length 255 characters | Identifier of the service from external system. |
 | `CreatedUtc` | string | required | Creation date and time of the service in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the service in UTC timezone in ISO 8601 format. |
+| ~~`Name`~~ | ~~string~~ | ~~required~~ | ~~Name of the service.~~ **Deprecated!** Use `Names` instead|
 | ~~`StartTime`~~ | ~~string~~ | ~~optional~~ | **Deprecated!** |
 | ~~`EndTime`~~ | ~~string~~ | ~~optional~~ | **Deprecated!** |
 | ~~`Promotions`~~ | ~~[Promotions](services.md#promotions)~~ | ~~optional~~ | ~~Promotions of the service.~~ **Deprecated!** |


### PR DESCRIPTION
#### Summary

https://mews.atlassian.net/browse/CON-3539: Regenerate documentation after adding adding translations in `getAll` services

Note: 
 -[ here is the connected PR](https://github.com/MewsSystems/mews/pull/57987/files) in service endpoint 

#### Follow style guide

[Style guide](https://mews.atlassian.net/wiki/x/KJAoCw)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
