### PR TITLE
OPS-18782 Add Connector API documentation for missing AvailabilityBlock fields

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## 6th September 2024
-  * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block). Documentation fix for change since 
-    * `ReleasedUtc` is no longer required in the response (change introduced on 8th January 2024 with [rolling release offsets](https://releases.mews.com/en/introducing-rolling-release-dates-to-unlock-allotments-for-availability-blocks)).
-    
+* Added rolling release support in [Availability blocks](../operations/availabilityblocks.md) (initially released on July 30th 2024).
+  * Extended [Add Availability blocks](../operations/availabilityblocks.md#add-availability-blocks) with `RollingReleaseOffset`
+  * Extended [Update Availability blocks](../operations/availabilityblocks.md#update-availability-blocks) with `RollingReleaseOffset` and `ReleaseStrategy` properties
+  * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block). 
+* **Breaking:** `ReleasedUtc` is no longer required in the response (change introduced on 8th January 2024 with [rolling release offsets](https://releases.mews.com/en/introducing-rolling-release-dates-to-unlock-allotments-for-availability-blocks)).
 
 ## 4th September 2024
 * Mark filtering parameter `VoucherIds` as required to reflect reality in [Get all voucher codes](../operations/vouchercodes.md#get-all-voucher-codes). Documentation-only.
@@ -43,11 +45,6 @@
 ## 1st August 2024
 * Extended [Voucher code](../operations/vouchercodes.md#voucher-code) response object with `IsActive` property.
   * [Get all voucher codes](../operations/vouchercodes.md#get-all-voucher-codes)
-
-## 30th July 2024
-* Added rolling release support in [Availability blocks](../operations/availabilityblocks.md)
-  * Extended [Add Availability blocks](../operations/availabilityblocks.md#add-availability-blocks) with `RollingReleaseOffset`
-  * Extended [Update Availability blocks](../operations/availabilityblocks.md#update-availability-blocks) with `RollingReleaseOffset` and `ReleaseStrategy` properties
 
 ## 8th July 2024
 * Extended [Payment data](../operations/payments.md#payment-data) response object with `Type` for Invoice payment type.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -187,6 +187,10 @@
 ## 15th January 2024
 * Updated [Request limits](../guidelines/README.md#request-limits) for both Demo and Production environments.
 
+## 8th January 2023
+  * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block).
+    * `ReleasedUtc` is no longer required in the response.
+
 | Changelog by year |
 | :-- |
 | [Changelog 2023](changelog2023.md) |

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -27,6 +27,11 @@
 * Extended [Voucher code](../operations/vouchercodes.md#voucher-code) response object with `IsActive` property.
   * [Get all voucher codes](../operations/vouchercodes.md#get-all-voucher-codes)
 
+## 30th July 2024
+* Added rolling release support in [Availability blocks](../operations/availabilityblocks.md)
+  * Extended [Add Availability blocks](../operations/availabilityblocks.md#add-availability-blocks) with `RollingReleaseOffset`
+  * Extended [Update Availability blocks](../operations/availabilityblocks.md#update-availability-blocks) with `RollingReleaseOffset` and `ReleaseStrategy` properties
+
 ## 8th July 2024
 * Extended [Payment data](../operations/payments.md#payment-data) response object with `Type` for Invoice payment type.
   * [Get all payments](../operations/payments.md#get-all-payments)

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 6th September 2024
-* **Breaking:** `ReleasedUtc` is no longer required in the response (change introduced on 8th January 2024 with [rolling release offsets](https://releases.mews.com/en/introducing-rolling-release-dates-to-unlock-allotments-for-availability-blocks)).
+## 9th September 2024
+* **Breaking:** In [Availability block response object](../operations/availabilityblocks.md#availability-block) `ReleasedUtc` property is no longer required. The breaking change was introduced on 8th of January 2024 with [rolling release offsets](https://releases.mews.com/en/introducing-rolling-release-dates-to-unlock-allotments-for-availability-blocks). The following operations are affected:
+  * [Get all availability blocks](../operations/availabilityblocks.md#get-all-availability-blocks)
+  * [Update availability blocks](../operations/availabilityblocks.md#update-availability-blocks)
 * Added rolling release support in [Availability blocks](../operations/availabilityblocks.md) (initially released on July 30th 2024).
   * Extended [Add Availability blocks](../operations/availabilityblocks.md#add-availability-blocks) with `RollingReleaseOffset`
   * Extended [Update Availability blocks](../operations/availabilityblocks.md#update-availability-blocks) with `RollingReleaseOffset` and `ReleaseStrategy` properties

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,11 +1,17 @@
 # Changelog
 
 ## 6th September 2024
+* **Breaking:** `ReleasedUtc` is no longer required in the response (change introduced on 8th January 2024 with [rolling release offsets](https://releases.mews.com/en/introducing-rolling-release-dates-to-unlock-allotments-for-availability-blocks)).
 * Added rolling release support in [Availability blocks](../operations/availabilityblocks.md) (initially released on July 30th 2024).
   * Extended [Add Availability blocks](../operations/availabilityblocks.md#add-availability-blocks) with `RollingReleaseOffset`
   * Extended [Update Availability blocks](../operations/availabilityblocks.md#update-availability-blocks) with `RollingReleaseOffset` and `ReleaseStrategy` properties
-  * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block). 
-* **Breaking:** `ReleasedUtc` is no longer required in the response (change introduced on 8th January 2024 with [rolling release offsets](https://releases.mews.com/en/introducing-rolling-release-dates-to-unlock-allotments-for-availability-blocks)).
+  * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block).
+* Documented missing fields in [Availability block update parameters](../operations/availabilityblocks.md#availability-block-update-parameters):
+  * `State`
+  * `ReservationPurpose`
+  * `BookerId`
+  * `Notes`
+  * `Budget`
 
 ## 4th September 2024
 * Mark filtering parameter `VoucherIds` as required to reflect reality in [Get all voucher codes](../operations/vouchercodes.md#get-all-voucher-codes). Documentation-only.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6th September 2024
+  * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block). Documentation fix for change since 
+    * `ReleasedUtc` is no longer required in the response (change introduced on 8th January 2024 with [rolling release offsets](https://releases.mews.com/en/introducing-rolling-release-dates-to-unlock-allotments-for-availability-blocks)).
+    
+
 ## 4th September 2024
 * Mark filtering parameter `VoucherIds` as required to reflect reality in [Get all voucher codes](../operations/vouchercodes.md#get-all-voucher-codes). Documentation-only.
 * Removed 'per Client Token' [request limits](../guidelines/environments.md). This is no longer checked in the API. 
@@ -198,10 +203,6 @@
 
 ## 15th January 2024
 * Updated [Request limits](../guidelines/README.md#request-limits) for both Demo and Production environments.
-
-## 8th January 2023
-  * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block).
-    * `ReleasedUtc` is no longer required in the response.
 
 | Changelog by year |
 | :-- |

--- a/changelog/changelog2023.md
+++ b/changelog/changelog2023.md
@@ -139,10 +139,6 @@
 ## 6th October 2023
   * Updated [Pagination](../guidelines/pagination.md) documentation
 
-## 20th September 2023
-  * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block).
-    * `ReleasedUtc` is no longer required in the response.
-
 ## 14th September 2023
   * Added operation [Add rates](../operations/rates.md#add-rates)
   * Extended [Rate](../operations/rates.md#rate) with new properties `Type` and `Descriptions`

--- a/changelog/changelog2023.md
+++ b/changelog/changelog2023.md
@@ -143,6 +143,10 @@
   * Added operation [Add rates](../operations/rates.md#add-rates)
   * Extended [Rate](../operations/rates.md#rate) with new properties `Type` and `Descriptions`
 
+## 20th September 2023
+  * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block).
+    * `ReleasedUtc` is no longer required in the response.
+
 ## 12th September 2023
 
 * Removed `AccountingCounter` from [Counter Type Discriminator](../operations/counters.md#counter-type-discriminator) since it is never used.

--- a/changelog/changelog2023.md
+++ b/changelog/changelog2023.md
@@ -139,13 +139,13 @@
 ## 6th October 2023
   * Updated [Pagination](../guidelines/pagination.md) documentation
 
-## 14th September 2023
-  * Added operation [Add rates](../operations/rates.md#add-rates)
-  * Extended [Rate](../operations/rates.md#rate) with new properties `Type` and `Descriptions`
-
 ## 20th September 2023
   * Added `RollingReleaseOffset` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block).
     * `ReleasedUtc` is no longer required in the response.
+
+## 14th September 2023
+  * Added operation [Add rates](../operations/rates.md#add-rates)
+  * Extended [Rate](../operations/rates.md#rate) with new properties `Type` and `Descriptions`
 
 ## 12th September 2023
 

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -317,10 +317,9 @@ Updates information about the specified [Availability block](#availability-block
     "AvailabilityBlocks": [
         {
             "AvailabilityBlockId": "aaaa654a4a94-4f96-9efc-86da-bd26d8db",
-            "Name": {"Value": "Mr. John Snow block"},
-            "FirstTimeUnitStartUtc":{"Value": "2021-07-05T00:00:00Z"},
-            "LastTimeUnitStartUtc":{"Value": "2021-07-15T00:00:00Z"},
-            "ReleasedUtc":{"Value": "2021-07-04T00:00:00Z"},
+            "Name": { "Value": "Mr. John Snow block" },
+            "FirstTimeUnitStartUtc": { "Value": "2021-07-05T00:00:00Z" },
+            "LastTimeUnitStartUtc": { "Value": "2021-07-15T00:00:00Z" },
             "ExternalIdentifier": {"Value": "123456798"}
             "State": { "Value": "Confirmed" },
             "ReservationPurpose": { "Value": "Leisure" },

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -197,8 +197,8 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `UpdatedUtc` | string | required | Last update date and time of the block in UTC timezone in ISO 8601 format. |
 | `FirstTimeUnitStartUtc` | string | required | Start of the time interval, expressed as the timestamp for the start of the first time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
 | `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
-| `ReleasedUtc` | string | optional | The moment when the block and its availability is released in UTC timezone in ISO 8601 format. Mutually exclusive with `RollingReleaseOffset` |
-| `RollingReleaseOffset` | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Mutually exclusive with `ReleasedUtc` |
+| `ReleasedUtc` | string | optional | The moment when the block and its availability is released in UTC timezone in ISO 8601 format. Mutually exclusive with `RollingReleaseOffset`; the block will not be automaticaly released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
+| `RollingReleaseOffset` | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Mutually exclusive with `ReleasedUtc`; the block will not be automaticaly released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the block from external system. |
 | `Name` | string | optional | The name of the block in Mews. |
 | `Notes` | string | optional | Additional notes of the block. |

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -124,7 +124,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "Notes": "Have a nice stay"
         },
         {
-            "Id": "aaaa654a4a94-4f96-9efc-86da-bd26d8db",
+            "Id": "82ce1bb4-78b2-4b4e-aef3-edfc28d26773",
             "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
             "RateId": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
             "VoucherId": null,
@@ -192,7 +192,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "UpdatedUtc": "2021-10-21T13:32:32Z"
         }
     ],
-     "Cursor": "aaaa654a4a94-4f96-9efc-86da-bd26d8db"
+     "Cursor": "82ce1bb4-78b2-4b4e-aef3-edfc28d26773"
 }
 ```
 
@@ -375,7 +375,7 @@ Updates information about the specified [Availability block](#availability-block
             "ReleaseStrategy": { "Value": "None" }
         },
         {
-            "AvailabilityBlockId": "aaaa654a4a94-4f96-9efc-86da-bd26d8db",
+            "AvailabilityBlockId": "82ce1bb4-78b2-4b4e-aef3-edfc28d26773",
             "Name": { "Value": "Rolling release block" },
             "FirstTimeUnitStartUtc": { "Value": "2022-07-05T00:00:00Z" },
             "LastTimeUnitStartUtc": { "Value": "2022-07-15T00:00:00Z" },

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -118,6 +118,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "FirstTimeUnitStartUtc": "2021-10-14T00:00:00Z",
             "LastTimeUnitStartUtc": "2021-10-17T00:00:00Z",
             "ReleasedUtc": "2021-10-13T00:00:00Z",
+            "RollingReleaseOffset": "P-3DT4H",
             "ExternalIdentifier": "Block-0001",
             "Name": "Wedding group",
             "Notes": "Have a nice stay"
@@ -196,7 +197,8 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `UpdatedUtc` | string | required | Last update date and time of the block in UTC timezone in ISO 8601 format. |
 | `FirstTimeUnitStartUtc` | string | required | Start of the time interval, expressed as the timestamp for the start of the first time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
 | `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
-| `ReleasedUtc` | string | required | The moment when the block and its availability is released in UTC timezone in ISO 8601 format. |
+| `ReleasedUtc` | string | optional | The moment when the block and its availability is released in UTC timezone in ISO 8601 format. Mutually exclusive with `RollingReleaseOffset` |
+| `RollingReleaseOffset` | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Mutually exclusive with `ReleasedUtc` |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the block from external system. |
 | `Name` | string | optional | The name of the block in Mews. |
 | `Notes` | string | optional | Additional notes of the block. |
@@ -226,6 +228,7 @@ Adds availability blocks which are used to group related [Availability updates](
             "FirstTimeUnitStartUtc": "2020-11-05T00:00:00Z",
             "LastTimeUnitStartUtc": "2020-11-06T00:00:00Z",
             "ReleasedUtc": "2020-11-04T00:00:00Z",
+            "RollingReleaseOffset": "P-3DT4H",
             "ExternalIdentifier": "Block-0001",
             "Budget": {  
                "Value": 500,
@@ -258,7 +261,8 @@ Adds availability blocks which are used to group related [Availability updates](
 | `Name` | string | optional | The name of the block. |
 | `FirstTimeUnitStartUtc` | string | required | Start of the time interval, expressed as the timestamp for the start of the first time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
 | `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
-| `ReleasedUtc` | string | required | The moment when the block and its availability is released. |
+| `ReleasedUtc` | string | optional | The moment when the block and its availability is released, in UTC timezone ISO 8601 format. |
+| `RollingReleaseOffset` | string | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Ignored if `ReleasedUtc` is specified. |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the block from external system. |
 | `Budget` | [Currency value](accountingitems.md#currency-value) | optional | The tentative budget for the total price of reservations. |
 | `ReservationPurpose` | string [Reservation purpose](reservations.md#reservation-purpose) | optional | The purpose of the block. |
@@ -318,6 +322,19 @@ Updates information about the specified [Availability block](#availability-block
             "LastTimeUnitStartUtc":{"Value": "2021-07-15T00:00:00Z"},
             "ReleasedUtc":{"Value": "2021-07-04T00:00:00Z"},
             "ExternalIdentifier": {"Value": "123456798"}
+            "State": { "Value": "Confirmed" },
+            "ReservationPurpose": { "Value": "Leisure" },
+            "BookerId": { "Value": "bdc54ad5-e3bd-4393-80b9-f96d6f63f92e" },
+            "Notes": { "Value": "Have a nice stay" },
+            "Budget": { 
+                "Value": {
+                    "Value": 500,
+                    "Currency": "EUR"
+                }
+            },
+            "RollingReleaseOffset": { "Value": "P-3DT4H" },
+            "ReleasedUtc": { "Value": "2021-07-01T00:00:00Z" },
+            "ReleaseStrategy": { "Value": "None" },
         }
     ]
 }
@@ -339,8 +356,24 @@ Updates information about the specified [Availability block](#availability-block
 | `Name` | [String update value](_objects.md#string-update-value) | optional | The name of the block \(or `null` if the name should not be updated\). |
 | `FirstTimeUnitStartUtc` | [String update value](_objects.md#string-update-value) | required | Start of the time interval, expressed as the timestamp for the start of the first time unit, in UTC timezone ISO 8601 format \(or `null` if the start time should not be updated\). See [Time units](../concepts/time-units.md). |
 | `LastTimeUnitStartUtc` | [String update value](_objects.md#string-update-value) | required | End of the time interval, expressed as the timestamp for the start of the last time unit, in UTC timezone ISO 8601 format \(or `null` if the end time should not be updated\). See [Time units](../concepts/time-units.md). |
-| `ReleasedUtc` | [String update value](_objects.md#string-update-value) | required | The moment when the block and its availability is released \(or `null` if the released time should not be updated\). |
 | `ExternalIdentifier` | [String update value](_objects.md#string-update-value) | optional, max 255 characters | Identifier of the block from external system \(or `null` if the identifier should not be updated\). |
+| `State` | [String update value](_objects.md#string-update-value) for [Availability block state](#availability-block-state) | optional | State of the availability block (or `null` if not updated). |
+| `ReservationPurpose` | [String update value](_objects.md#string-update-value) for [Reservation purpose](#reservation-purpose) | optional | The purpose of the block (or `null` if not updated). |
+| `BookerId` | [Guid update value](_objects.md#string-update-value) | optional | Unique identifier of the Booker as a creator of an availability block (or `null` if not updated). |
+| `Notes` | [String update value](_objects.md#string-update-value) | optional | Additional notes of the block (or `null` if not updated). |
+| `Budget` | [Currency](accountingitems.md#currency-value) update value | optional | The tentative budget for the total price of reservations (or `null` if not updated). |
+| `RollingReleaseOffset` | [String update value](_objects.md#string-update-value) | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Required if `ReleaseStrategy` is set to `RollingRelease`, ignored otherwise. |
+| `ReleasedUtc` | [String update value](_objects.md#string-update-value) | optional | The moment when the block and its availability is released, in UTC timezone ISO 8601 format. Required if `ReleaseStrategy` is set to `FixedRelease`, or used when `ReleaseStrategy` update is unspecified. |
+| `ReleaseStrategy` | [String update value](_objects.md#string-update-value) for [Release strategy](#release-strategy) | optional | The strategy for automatic release of the availability block (or `null` if not updated). |
+
+#### Release strategy
+
+The strategy for automatic release of the availability block.
+
+- `FixedRelease` - The availability block is released at a fixed time.
+- `RollingRelease` - Each availability ajdustment is released at a fixed offset from its start.
+- `None` - The availability block is not automatically released.
+
 
 ### Response
 

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -118,10 +118,33 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "FirstTimeUnitStartUtc": "2021-10-14T00:00:00Z",
             "LastTimeUnitStartUtc": "2021-10-17T00:00:00Z",
             "ReleasedUtc": "2021-10-13T00:00:00Z",
-            "RollingReleaseOffset": "P-3DT4H",
+            "RollingReleaseOffset": null,
             "ExternalIdentifier": "Block-0001",
             "Name": "Wedding group",
             "Notes": "Have a nice stay"
+        },
+        {
+            "Id": "aaaa654a4a94-4f96-9efc-86da-bd26d8db",
+            "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
+            "RateId": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
+            "VoucherId": null,
+            "BookerId": null,
+            "CompanyId": null,
+            "Budget": {
+                "Currency": "USD",
+                "Value": 48.0
+            },
+            "State": "Confirmed",
+            "ReservationPurpose": "Leisure",
+            "CreatedUtc": "2022-10-11T13:32:32Z",
+            "UpdatedUtc": "2022-10-11T13:32:32Z",
+            "FirstTimeUnitStartUtc": "2022-10-14T00:00:00Z",
+            "LastTimeUnitStartUtc": "2022-11-17T00:00:00Z",
+            "ReleasedUtc": null,
+            "RollingReleaseOffset": "P-3DT4H",
+            "ExternalIdentifier": "Block-0002",
+            "Name": "Rolling release",
+            "Notes": null
         }
     ],
     "ServiceOrders": [
@@ -197,8 +220,8 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `UpdatedUtc` | string | required | Last update date and time of the block in UTC timezone in ISO 8601 format. |
 | `FirstTimeUnitStartUtc` | string | required | Start of the time interval, expressed as the timestamp for the start of the first time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
 | `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
-| `ReleasedUtc` | string | optional | The moment when the block and its availability is released in UTC timezone in ISO 8601 format. Mutually exclusive with `RollingReleaseOffset`; the block will not be automaticaly released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
-| `RollingReleaseOffset` | string | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Mutually exclusive with `ReleasedUtc`; the block will not be automaticaly released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
+| `ReleasedUtc` | string | optional | The moment when the block and its availability is released in UTC timezone in ISO 8601 format. Mutually exclusive with `RollingReleaseOffset`; the block will not be automatically released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
+| `RollingReleaseOffset` | string | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Mutually exclusive with `ReleasedUtc`; the block will not be automatically released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the block from external system. |
 | `Name` | string | optional | The name of the block in Mews. |
 | `Notes` | string | optional | Additional notes of the block. |
@@ -228,8 +251,25 @@ Adds availability blocks which are used to group related [Availability updates](
             "FirstTimeUnitStartUtc": "2020-11-05T00:00:00Z",
             "LastTimeUnitStartUtc": "2020-11-06T00:00:00Z",
             "ReleasedUtc": "2020-11-04T00:00:00Z",
-            "RollingReleaseOffset": "P-3DT4H",
             "ExternalIdentifier": "Block-0001",
+            "Budget": {  
+               "Value": 500,
+               "Currency": "EUR"
+            },
+            "ReservationPurpose": null,
+            "Notes": null,
+            "State": "Confirmed",
+            "BookerId": null
+        },
+        {
+            "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
+            "RateId": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
+            "VoucherCode": null,
+            "Name": "ROlling release block",
+            "FirstTimeUnitStartUtc": "2021-11-05T00:00:00Z",
+            "LastTimeUnitStartUtc": "2021-11-06T00:00:00Z",
+            "RollingReleaseOffset": "P-3DT4H",
+            "ExternalIdentifier": "Block-0002",
             "Budget": {  
                "Value": 500,
                "Currency": "EUR"
@@ -331,9 +371,26 @@ Updates information about the specified [Availability block](#availability-block
                     "Currency": "EUR"
                 }
             },
-            "RollingReleaseOffset": { "Value": "P-3DT4H" },
             "ReleasedUtc": { "Value": "2021-07-01T00:00:00Z" },
-            "ReleaseStrategy": { "Value": "None" },
+            "ReleaseStrategy": { "Value": "None" }
+        },
+        {
+            "AvailabilityBlockId": "aaaa654a4a94-4f96-9efc-86da-bd26d8db",
+            "Name": { "Value": "Rolling release block" },
+            "FirstTimeUnitStartUtc": { "Value": "2022-07-05T00:00:00Z" },
+            "LastTimeUnitStartUtc": { "Value": "2022-07-15T00:00:00Z" },
+            "ExternalIdentifier": { "Value": "Block2" }
+            "State": { "Value": "Confirmed" },
+            "ReservationPurpose": { "Value": "Leisure" },
+            "BookerId": { "Value": "bdc54ad5-e3bd-4393-80b9-f96d6f63f92e" },
+            "Budget": { 
+                "Value": {
+                    "Value": 500,
+                    "Currency": "EUR"
+                }
+            },
+            "RollingReleaseOffset": { "Value": "P-3DT4H" },
+            "ReleaseStrategy": { "Value": "RollingRelease" }
         }
     ]
 }

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -301,7 +301,7 @@ Adds availability blocks which are used to group related [Availability updates](
 | `Name` | string | optional | The name of the block. |
 | `FirstTimeUnitStartUtc` | string | required | Start of the time interval, expressed as the timestamp for the start of the first time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
 | `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
-| `ReleasedUtc` | string | optional | The moment when the block and its availability is released, in UTC timezone ISO 8601 format. |
+| `ReleasedUtc` | string | optional | The moment when the block and its availability is released, in UTC timezone ISO 8601 format. Takes precedence over `RollingReleaseOffset`. |
 | `RollingReleaseOffset` | string | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Ignored if `ReleasedUtc` is specified. |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the block from external system. |
 | `Budget` | [Currency value](accountingitems.md#currency-value) | optional | The tentative budget for the total price of reservations. |

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -198,7 +198,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `FirstTimeUnitStartUtc` | string | required | Start of the time interval, expressed as the timestamp for the start of the first time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
 | `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
 | `ReleasedUtc` | string | optional | The moment when the block and its availability is released in UTC timezone in ISO 8601 format. Mutually exclusive with `RollingReleaseOffset`; the block will not be automaticaly released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
-| `RollingReleaseOffset` | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Mutually exclusive with `ReleasedUtc`; the block will not be automaticaly released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
+| `RollingReleaseOffset` | string | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Mutually exclusive with `ReleasedUtc`; the block will not be automaticaly released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the block from external system. |
 | `Name` | string | optional | The name of the block in Mews. |
 | `Notes` | string | optional | Additional notes of the block. |

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -320,7 +320,7 @@ Updates information about the specified [Availability block](#availability-block
             "Name": { "Value": "Mr. John Snow block" },
             "FirstTimeUnitStartUtc": { "Value": "2021-07-05T00:00:00Z" },
             "LastTimeUnitStartUtc": { "Value": "2021-07-15T00:00:00Z" },
-            "ExternalIdentifier": {"Value": "123456798"}
+            "ExternalIdentifier": { "Value": "123456798" }
             "State": { "Value": "Confirmed" },
             "ReservationPurpose": { "Value": "Leisure" },
             "BookerId": { "Value": "bdc54ad5-e3bd-4393-80b9-f96d6f63f92e" },

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -363,14 +363,14 @@ Updates information about the specified [Availability block](#availability-block
 | `Budget` | [Currency](accountingitems.md#currency-value) update value | optional | The tentative budget for the total price of reservations (or `null` if not updated). |
 | `RollingReleaseOffset` | [String update value](_objects.md#string-update-value) | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Required if `ReleaseStrategy` is set to `RollingRelease`, ignored otherwise. |
 | `ReleasedUtc` | [String update value](_objects.md#string-update-value) | optional | The moment when the block and its availability is released, in UTC timezone ISO 8601 format. Required if `ReleaseStrategy` is set to `FixedRelease`, or used when `ReleaseStrategy` update is unspecified. |
-| `ReleaseStrategy` | [String update value](_objects.md#string-update-value) for [Release strategy](#release-strategy) | optional | The strategy for automatic release of the availability block (or `null` if not updated). |
+| `ReleaseStrategy` | [String update value](_objects.md#string-update-value) | optional | The strategy for automatic release of the availability block. If this property is not specified, the release strategy is not updated. |
 
 #### Release strategy
 
 The strategy for automatic release of the availability block.
 
 - `FixedRelease` - The availability block is released at a fixed time.
-- `RollingRelease` - Each availability ajdustment is released at a fixed offset from its start.
+- `RollingRelease` - Each availability adjustment is released at a fixed offset from its start.
 - `None` - The availability block is not automatically released.
 
 


### PR DESCRIPTION
#### Summary

https://mews.atlassian.net/browse/OPS-18782 Add Connector API documentation for missing AvailabilityBlock fields

Solves https://mews.atlassian.net/browse/CON-3730

Adds documentation for previously missing fields along with fields added in https://github.com/MewsSystems/mews/pull/57422

#### Follow style guide

[Style guide](https://mews.atlassian.net/wiki/x/KJAoCw)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
