### PR TITLE
Improve description of RollingReleaseOffset

### DIFF
--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -221,7 +221,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `FirstTimeUnitStartUtc` | string | required | Start of the time interval, expressed as the timestamp for the start of the first time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
 | `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last time unit, in UTC timezone ISO 8601 format. See [Time units](../concepts/time-units.md). |
 | `ReleasedUtc` | string | optional | The moment when the block and its availability is released in UTC timezone in ISO 8601 format. Mutually exclusive with `RollingReleaseOffset`; the block will not be automatically released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
-| `RollingReleaseOffset` | string | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Mutually exclusive with `ReleasedUtc`; the block will not be automatically released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
+| `RollingReleaseOffset` | string | optional | Exact offset from the start of availability adjustments to the moment the individual days in the adjustment should be released, in ISO 8601 duration format. Mutually exclusive with `ReleasedUtc`; the block will not be automatically released if neither `ReleasedUtc` nor `RollingReleaseOffsetUtc` is specified. |
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the block from external system. |
 | `Name` | string | optional | The name of the block in Mews. |
 | `Notes` | string | optional | Additional notes of the block. |


### PR DESCRIPTION
This issue was reported by RevControl. They mentioned that the current explanation doesn’t fully capture what actually happens, and they provided the below example to clarify.
 
{
           "Id": "e19297af-373e-4701-b4ea-afae0129bded",
            "AvailabilityBlockId": "aaaa654a4a94-4f96-9efc-86da-bd26d8db",
           "ResourceCategoryId": "1268c440-21c5-415d-bf58-ac87008b2bda",
           "FirstTimeUnitStartUtc": "2021-10-14T00:00:00Z",
           "LastTimeUnitStartUtc": "2021-10-17T00:00:00Z",
           "UnitCount": 6,
           "ActivityState": "Active",
           "UpdatedUtc": "2021-10-21T13:32:32Z"
       }

The 6 rooms allocated on October 14th released on October 13th The 6 rooms allocated on October 15th released on October 14th The 6 rooms allocated on October 16th released on October 15th The 6 rooms allocated on October 17th released on October 16th

I did some testing in my demo, and not all the rooms are released at the same time, which is why the option of One time release

#### Summary

#### Follow style guide

[Style guide](https://mews.atlassian.net/wiki/x/KJAoCw)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
