### PR TITLE
Get cancellation policies by reservations operation

### DIFF
--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -1022,3 +1022,18 @@ types:
   productdeleteparameters:
     file: products.md
     anchor: product-delete-parameters
+  cancellationpolicybyreservationresult:
+    file: cancellationpolicies.md
+    anchor: cancellationpolicybyreservationresult
+  cancellationpolicybyreservation:
+    file: cancellationpolicies.md
+    anchor: cancellation-policy-data-grouped-by-reservation
+  cancellationpolicyapplicabilityenum:
+    file: cancellationpolicies.md
+    anchor: cancellation-policy-applicability
+  cancellationfeeextentenum:
+    file: cancellationpolicies.md
+    anchor: cancellation-fee-extent
+  cancellationpolicybyreservationparameters:
+    file: cancellationpolicies.md
+    anchor: cancellationpolicybyreservationparameters

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 13th September 2024
+
+* Added operation [Get cancellation policies by reservations](../operations/cancellationpolicies.md#get-cancellation-policies-by-reservations).
+
 ## 9th September 2024
 * **Breaking:** In [Availability block response object](../operations/availabilityblocks.md#availability-block) `ReleasedUtc` property is no longer required. The breaking change was introduced on 8th of January 2024 with [rolling release offsets](https://releases.mews.com/en/introducing-rolling-release-dates-to-unlock-allotments-for-availability-blocks). The following operations are affected:
   * [Get all availability blocks](../operations/availabilityblocks.md#get-all-availability-blocks)

--- a/operations/README.md
+++ b/operations/README.md
@@ -229,6 +229,7 @@ This section describes all operations supported by the API, organised here by th
 | [Delete voucher codes](vouchercodes.md#delete-voucher-codes) | Delete voucher codes |
 | [Get all age categories](agecategories.md#get-all-age-categories) | Returns all age categories filtered by service |
 | [Get all cancellation policies](cancellationpolicies.md#get-all-cancellation-policies) | Returns all cancellation policies filtered by services, rate groups and other filters |
+| [Get cancellation policies by reservations](cancellationpolicies.md#get-cancellation-policies-by-reservations) | Returns cancellation policies for enterprise grouped by reservation |
 | [Get all products](products.md#get-all-products) | Returns all products filtered by services or product identifier |
 | [Delete products](products.md#delete-products) | Deletes specified products |
 | [Get product pricing](products.md#get-product-pricing) | **Restricted!** Returns prices for a product for a specified time interval |

--- a/operations/cancellationpolicies.md
+++ b/operations/cancellationpolicies.md
@@ -112,3 +112,98 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 
 * `TimeUnits`
 * `Products`
+
+## Get cancellation policies by reservations
+
+Gets cancellation policies for enterprise grouped by reservation for granular cancellation policies flow. This operation supports [Portfolio Access Tokens](../guidelines/multi-property.md).
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/cancellationPolicies/getByReservations`
+
+```javascript
+{
+  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+  "Client": "Sample Client 1.0.0",
+  "ReservationIds": [
+    "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "4d0201db-36f5-428b-8d11-4f0a65e960cc"
+  ]
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
+| `ReservationIds` | array of string | optional, max 100 items | List of reservation identifiers. |
+
+### Response
+
+```javascript
+{
+  "CancellationPolicies": [
+    {
+      "ReservationId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "Applicability": "Start",
+      "FeeExtents": [
+        "TimeUnits",
+        "Products"
+      ],
+      "ApplicabilityOffset": "P10DT20H30M",
+      "FeeMaximumTimeUnits": 1,
+      "AbsoluteFee": {
+        "Currency": "EUR",
+        "Value": 20
+      },
+      "RelativeFee": 0.1
+    },
+    {
+      "ReservationId": "4d0201db-36f5-428b-8d11-4f0a65e960cc",
+      "Applicability": "Start",
+      "FeeExtents": [
+        "TimeUnits",
+        "Products"
+      ],
+      "ApplicabilityOffset": "P10DT10H30M",
+      "FeeMaximumTimeUnits": 2,
+      "AbsoluteFee": {
+        "Currency": "EUR",
+        "Value": 15
+      },
+      "RelativeFee": 0.2
+    }
+  ]
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `CancellationPolicies` | array of [Cancellation policy data grouped by reservation.](cancellationpolicies.md#cancellation-policy-data-grouped-by-reservation) | required, max 1300 items | List of cancellation policies data grouped by reservation. |
+
+#### Cancellation policy data grouped by reservation.
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ReservationId` | string | required | Unique identifier of the reservation. |
+| `Applicability` | [Cancellation Policy Applicability](cancellationpolicies.md#cancellation-policy-applicability) | required | Applicability mode of the cancellation policy. |
+| `FeeExtents` | array of [Cancellation Fee Extent](cancellationpolicies.md#cancellation-fee-extent) | required | Extent for the cancellation fee, i.e. what should be in scope for the automatic payment. |
+| `ApplicabilityOffset` | string | required | Offset for order start (assuming Applicability is set to Start) from which the fee is applied. |
+| `FeeMaximumTimeUnits` | integer | optional | Maximum number of time units the cancellation fee is applicable to. |
+| `AbsoluteFee` | [Currency value (ver 2023-02-02)](_objects.md#currency-value-ver-2023-02-02) | required | Absolute value of the fee. |
+| `RelativeFee` | number | required | Relative value of the fee, as a percentage of the reservation price. |
+
+#### Cancellation Policy Applicability
+
+* `Creation`
+* `Start`
+* `StartDate`
+
+#### Cancellation Fee Extent
+
+* `Nothing`
+* `TimeUnits`
+* `Products`
+* `Everything`


### PR DESCRIPTION
#### Summary

New operation documentation: Get cancellation policies by reservations operation.

#### Follow style guide

[Style guide](https://mews.atlassian.net/wiki/x/KJAoCw)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
