### PR TITLE
OPS-18836 Add QuoteId to AvailabilityBlock

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,4 +1,11 @@
 # Changelog
+
+## 7th October 2024
+* Added `QuoteId` field in [Availability blocks](../operations/availabilityblocks.md)
+  * Extended [Add Availability blocks](../operations/availabilityblocks.md#add-availability-blocks) with `QuoteId`
+  * Extended [Update Availability blocks](../operations/availabilityblocks.md#update-availability-blocks) with `QuoteId`
+  * Added `QuoteId` to [AvailabilityBlock responses](../operations/availabilityblocks.md#availability-block).
+
 ## 27th September 2024
 * Mark filtering parameter `ServiceIds` as optional in [Get all age categories](../operations/agecategories.md#get-all-age-categories).
 

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -121,7 +121,8 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "RollingReleaseOffset": null,
             "ExternalIdentifier": "Block-0001",
             "Name": "Wedding group",
-            "Notes": "Have a nice stay"
+            "Notes": "Have a nice stay",
+            "QuoteId": null
         },
         {
             "Id": "82ce1bb4-78b2-4b4e-aef3-edfc28d26773",
@@ -144,7 +145,8 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "RollingReleaseOffset": "P-3DT4H",
             "ExternalIdentifier": "Block-0002",
             "Name": "Rolling release",
-            "Notes": null
+            "Notes": null,
+            "QuoteId": "67eaf3c8-81e0-4ffb-b5f2-2b61803feb9c"
         }
     ],
     "ServiceOrders": [
@@ -225,6 +227,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `ExternalIdentifier` | string | optional, max 255 characters | Identifier of the block from external system. |
 | `Name` | string | optional | The name of the block in Mews. |
 | `Notes` | string | optional | Additional notes of the block. |
+| `QuoteId` | string | optional | Unique identifier of the Mews Events quote associated with the availability block. |
 
 ## Add availability blocks
 
@@ -259,7 +262,8 @@ Adds availability blocks which are used to group related [Availability updates](
             "ReservationPurpose": null,
             "Notes": null,
             "State": "Confirmed",
-            "BookerId": null
+            "BookerId": null,
+            "QuoteId": null
         },
         {
             "ServiceId": "bd26d8db-86da-4f96-9efc-e5a4654a4a94",
@@ -277,7 +281,8 @@ Adds availability blocks which are used to group related [Availability updates](
             "ReservationPurpose": null,
             "Notes": null,
             "State": "Confirmed",
-            "BookerId": null
+            "BookerId": null,
+            "QuoteId": null
         }
     ]
 }
@@ -309,6 +314,7 @@ Adds availability blocks which are used to group related [Availability updates](
 | `Notes` | string | optional | Additional notes of the block. |
 | `State` | string [Availability block state](#availability-block-state) | required | State of the availability block. |
 | `BookerId` | string | optional | Unique identifier of the [Booker](customers.md#customer) as a creator of an availability block. |
+| `QuoteId` | string | optional | Unique identifier of the Mews Events quote associated with the availability block. |
 
 ### Response
 
@@ -372,7 +378,8 @@ Updates information about the specified [Availability block](#availability-block
                 }
             },
             "ReleasedUtc": { "Value": "2021-07-01T00:00:00Z" },
-            "ReleaseStrategy": { "Value": "None" }
+            "ReleaseStrategy": { "Value": "None" },
+            "QuoteId": { "Value": null }
         },
         {
             "AvailabilityBlockId": "82ce1bb4-78b2-4b4e-aef3-edfc28d26773",
@@ -390,7 +397,8 @@ Updates information about the specified [Availability block](#availability-block
                 }
             },
             "RollingReleaseOffset": { "Value": "P-3DT4H" },
-            "ReleaseStrategy": { "Value": "RollingRelease" }
+            "ReleaseStrategy": { "Value": "RollingRelease" },
+            "QuoteId": { "Value": "3a995033-3fbd-4b4c-9bc2-a60523d78bc5" }
         }
     ]
 }
@@ -421,6 +429,7 @@ Updates information about the specified [Availability block](#availability-block
 | `RollingReleaseOffset` | [String update value](_objects.md#string-update-value) | optional | Exact offset from the start of availability adjustments to the moment the availability adjustment should be released, in ISO 8601 duration format. Required if `ReleaseStrategy` is set to `RollingRelease`, ignored otherwise. |
 | `ReleasedUtc` | [String update value](_objects.md#string-update-value) | optional | The moment when the block and its availability is released, in UTC timezone ISO 8601 format. Required if `ReleaseStrategy` is set to `FixedRelease`, or used when `ReleaseStrategy` update is unspecified. |
 | `ReleaseStrategy` | [String update value](_objects.md#string-update-value) | optional | The strategy for automatic release of the availability block. If this property is not specified, the release strategy is not updated. |
+| `QuoteId` | [Guid update value](_objects.md#string-update-value) | optional | Unique identifier of the Mews Events quote associated with the availability block (or `null` if not updated). |
 
 #### Release strategy
 


### PR DESCRIPTION
#### Summary

Follow-up to https://github.com/MewsSystems/mews/pull/60012 - adds QuoteId field to AvailabilityBlock.

#### Follow style guide

[Style guide](https://mews.atlassian.net/wiki/x/KJAoCw)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
