### PR TITLE
Fix Type in outletbills/add

### DIFF
--- a/operations/outletbills.md
+++ b/operations/outletbills.md
@@ -74,7 +74,7 @@ Adds new outlet bills with their items.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Type` | string [Outlet item type](outletitems.md#outlet-item-type) | optional | Type of the item. |
+| `Type` | string [Outlet item type](outletitems.md#outlet-item-type) | required | Type of the item. |
 | `Name` | string | required | Name of the item. |
 | `UnitCount` | number | required | Unit count of the item. |
 | `UnitAmount` | [Amount parameters](orders.md#amount-parameters) | required | Unit amount of the item. |


### PR DESCRIPTION
the parameter Type is required and not optional as the documentation mentions. https://mews.slack.com/archives/C01TCGUJ5FV/p1728999190267759

#### Summary

#### Follow style guide

[Style guide](https://mews.atlassian.net/wiki/x/KJAoCw)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
