### PR TITLE
Increased AssignedRateIds to 10

### DIFF
--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -1360,3 +1360,6 @@ types:
   serviceoverbookinglimitcleardata:
     file: serviceoverbookinglimits.md
     anchor: service-overbooking-limits-clear-parameters
+  assignedrateids:
+    file: vouchers.md
+    anchor: assigned-rate-ids

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 20th November 2024
+* Increased `AssignedRateIds` maximum items to 10 in following operations:
+  * [Add vouchers](../operations/vouchers.md#add-vouchers).
+  * [Update vouchers](../operations/vouchers.md#update-vouchers).
+
 ## 19th November 2024
 * Added new restricted operation [Get all service ovebooking limits](serviceoverbookinglimits.md#get-all-service-overbooking-limits).
 * Added new restricted operation [Set service ovebooking limits](serviceoverbookinglimits.md#set-service-overbooking-limits).

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 20th November 2024
+## 26th November 2024
 * Increased `AssignedRateIds` maximum items to 10 in following operations:
   * [Add vouchers](../operations/vouchers.md#add-vouchers).
   * [Update vouchers](../operations/vouchers.md#update-vouchers).

--- a/operations/vouchers.md
+++ b/operations/vouchers.md
@@ -234,7 +234,7 @@ Adds the specified vouchers to the specified [Services](services.md#service). No
 | `Name` | string | required, max length 128 characters | Internal name of the voucher. |
 | `Type` | [Voucher Type](vouchers.md#voucher-type) | required | Type of the voucher. |
 | `CompanyId` | string | optional | Unique identifier of Company. |
-| `AssignedRateIds` | array of string | optional, max 5 items | Unique identifiers of Rates. |
+| `AssignedRateIds` | array of string | optional, max 10 items | Unique identifiers of Rates. |
 | `OccupiableIntervalStartUtc` | string | optional | Start of the interval in which the voucher can be applied. |
 | `OccupiableIntervalEndUtc` | string | optional | End of the interval in which the voucher can be applied. |
 | `ExternalIdentifier` | string | optional, max length 255 characters | Identifier of the voucher from external system. |
@@ -361,7 +361,7 @@ Updates information about the specified vouchers. Note this operation supports [
 | `Name` | [String update value](_objects.md#string-update-value) | optional, max length 128 characters | Internal name of the voucher (or `null` if the name should not be updated). |
 | `Type` | [VoucherTypeUpdateValue](_objects.md#string-update-value) | optional | Type of the voucher e.g. 'Public', 'PartnerCompany' or 'TravelAgency' (or `null` if the type should not be updated). |
 | `CompanyId` | [String update value](_objects.md#string-update-value) | optional | Unique identifier of Company (Company or Travel Agency) the voucher is related to. This is required for Type of `PartnerCompany` or `TravelAgency`. Use `null` if Company should not be updated. |
-| `AssignedRateIds` | [GuidIEnumerableUpdateValue](_object.md#array-of-strings-update-value) | optional, max length 5 characters | Unique identifiers of Rates (or `null` should it not be updated). |
+| `AssignedRateIds` | [GuidIEnumerableUpdateValue](_object.md#array-of-strings-update-value) | optional, max length 10 characters | Unique identifiers of Rates (or `null` should it not be updated). |
 | `OccupiableIntervalStartUtc` | [String update value](_objects.md#string-update-value) | optional | Start of the interval in which the voucher can be applied (or `null` if the start time should not be updated). |
 | `OccupiableIntervalEndUtc` | [String update value](_objects.md#string-update-value) | optional | End of the interval in which the voucher can be applied (or `null` if the end time should not be updated). |
 | `ExternalIdentifier` | [String update value](_objects.md#string-update-value) | optional, max length 255 characters | Identifier of the voucher from external system (or `null` if the identifier should not be updated). |

--- a/operations/vouchers.md
+++ b/operations/vouchers.md
@@ -371,6 +371,7 @@ Has same structure as [Array of strings update value](_objects.md#array-of-strin
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
+| `Value` | array of string | optional, max 10 items | Unique identifiers of Rates (or `null` should it not be updated). |
 
 ### Response
 

--- a/operations/vouchers.md
+++ b/operations/vouchers.md
@@ -361,10 +361,16 @@ Updates information about the specified vouchers. Note this operation supports [
 | `Name` | [String update value](_objects.md#string-update-value) | optional, max length 128 characters | Internal name of the voucher (or `null` if the name should not be updated). |
 | `Type` | [VoucherTypeUpdateValue](_objects.md#string-update-value) | optional | Type of the voucher e.g. 'Public', 'PartnerCompany' or 'TravelAgency' (or `null` if the type should not be updated). |
 | `CompanyId` | [String update value](_objects.md#string-update-value) | optional | Unique identifier of Company (Company or Travel Agency) the voucher is related to. This is required for Type of `PartnerCompany` or `TravelAgency`. Use `null` if Company should not be updated. |
-| `AssignedRateIds` | [GuidIEnumerableUpdateValue](_object.md#array-of-strings-update-value) | optional, max length 10 characters | Unique identifiers of Rates (or `null` should it not be updated). |
+| `AssignedRateIds` | [Assigned rate ids](vouchers.md#assigned-rate-ids) | optional | Unique identifiers of Rates (or `null` should it not be updated). |
 | `OccupiableIntervalStartUtc` | [String update value](_objects.md#string-update-value) | optional | Start of the interval in which the voucher can be applied (or `null` if the start time should not be updated). |
 | `OccupiableIntervalEndUtc` | [String update value](_objects.md#string-update-value) | optional | End of the interval in which the voucher can be applied (or `null` if the end time should not be updated). |
 | `ExternalIdentifier` | [String update value](_objects.md#string-update-value) | optional, max length 255 characters | Identifier of the voucher from external system (or `null` if the identifier should not be updated). |
+
+#### Assigned rate ids
+Has same structure as [Array of strings update value](_objects.md#array-of-strings-update-value).
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
 
 ### Response
 


### PR DESCRIPTION
### Summary

Increased AssignedRateIds to 10

<!-- Summarise the changes here in bullet points. -->

### Checklist

- [x] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [x] JSON examples updated
- [x] Properties in JSON examples are in the same order as in property tables
- [x] [Changelog] dated the day when PR merged
- [x] [Changelog] accurately describes all changes
- [x] [Changelog] highlights the affected endpoints or operations
- [x] [Changelog] highlights any deprecations
- [x] All hyperlinks tested
- [x] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [x] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
