### PR TITLE
Improve sorting + regenerate docs

### DIFF
--- a/_generator/sorting/operationSort.js
+++ b/_generator/sorting/operationSort.js
@@ -3,7 +3,8 @@ const sortPriority = {
   get: 2,
   add: 3,
   update: 4,
-  fallback: 5,
+  addFile: 5,
+  fallback: 6,
 };
 
 /**
@@ -44,7 +45,7 @@ function getOperationPriority(operation) {
     priority = sortPriority.get;
   }
   if (!priority && sortKey.startsWith('add')) {
-    priority = sortPriority.add;
+    priority = sortPriority.add + 0.5;
   }
   return priority || sortPriority.fallback;
 }

--- a/_generator/sorting/operationSort.js
+++ b/_generator/sorting/operationSort.js
@@ -43,5 +43,8 @@ function getOperationPriority(operation) {
   if (!priority && sortKey.startsWith('get')) {
     priority = sortPriority.get;
   }
+  if (!priority && sortKey.startsWith('add')) {
+    priority = sortPriority.add;
+  }
   return priority || sortPriority.fallback;
 }

--- a/operations/accounts.md
+++ b/operations/accounts.md
@@ -661,6 +661,53 @@ Updated customer data.
 | `AddFeesToInvoices` | boolean | required | Whether the company has an additional fee applied for invoicing or not. |
 | `AddTaxDeductedPaymentToInvoices` | boolean | required | Whether tax-deducted payments should be automatically added to invoices. |
 
+## Upload and link file to account
+
+Attaches the specified file to the account. 
+
+Allowed MIME types: `application/pdf`, `image/bmp`, `image/gif`, `image/jpeg`, `image/png`, `image/tiff`.
+
+Note this operation supports [Portfolio Access Tokens](../guidelines/multi-property.md).
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/accounts/addFile`
+
+```javascript
+{
+  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+  "Client": "Sample Client 1.0.0",
+  "AccountId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "Name": "document.pdf",
+  "Type": "application/pdf",
+  "ChainId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
+| `ChainId` | string | optional | Unique identifier of the chain. Required when using [Portfolio Access Tokens](../guidelines/multi-property.md), ignored otherwise. |
+| `AccountId` | string | required | Unique identifier of the account to which the file will be uploaded to. |
+| `Name` | string | required, max length 1000 characters | Uploaded file name. |
+| `Type` | string | required, max length 1000 characters | Content type of the uploaded file following defined by its MIME type. |
+| `Data` | string | required | Uploaded file data serialized in base64 format. |
+
+### Response
+
+```javascript
+{
+  "FileId": "f039f5b4-ff18-4510-9086-92b14a68ed78"
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `FileId` | string | required | Unique identifier of the uploaded file. |
+
 ## Merge accounts
 
 Merges two or more accounts of the same account type together. The given source accounts will be merged into the given target account and the merged account will keep the target account ID.
@@ -720,50 +767,3 @@ Merges two or more accounts of the same account type together. The given source 
 ```javascript
 {}
 ```
-
-## Upload and link file to account
-
-Attaches the specified file to the account. 
-
-Allowed MIME types: `application/pdf`, `image/bmp`, `image/gif`, `image/jpeg`, `image/png`, `image/tiff`.
-
-Note this operation supports [Portfolio Access Tokens](../guidelines/multi-property.md).
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/accounts/addFile`
-
-```javascript
-{
-  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-  "Client": "Sample Client 1.0.0",
-  "AccountId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "Name": "document.pdf",
-  "Type": "application/pdf",
-  "ChainId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
-}
-```
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `ChainId` | string | optional | Unique identifier of the chain. Required when using [Portfolio Access Tokens](../guidelines/multi-property.md), ignored otherwise. |
-| `AccountId` | string | required | Unique identifier of the account to which the file will be uploaded to. |
-| `Name` | string | required, max length 1000 characters | Uploaded file name. |
-| `Type` | string | required, max length 1000 characters | Content type of the uploaded file following defined by its MIME type. |
-| `Data` | string | required | Uploaded file data serialized in base64 format. |
-
-### Response
-
-```javascript
-{
-  "FileId": "f039f5b4-ff18-4510-9086-92b14a68ed78"
-}
-```
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `FileId` | string | required | Unique identifier of the uploaded file |

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -17,15 +17,10 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
   "Extent": {
     "Items": false
   },
-  "TimeFilter": null,
-  "StartUtc": null,
-  "EndUtc": null,
   "ClosedUtc": {
     "StartUtc": "2020-02-05T00:00:00Z",
     "EndUtc": "2020-02-10T00:00:00Z"
   },
-  "PaidUtc": null,
-  "DueUtc": null,
   "CreatedUtc": {
     "StartUtc": "2020-02-05T00:00:00Z",
     "EndUtc": "2020-02-10T00:00:00Z"
@@ -41,7 +36,6 @@ Returns all bills, optionally filtered by customers, identifiers and other filte
     "fe795f96-0b64-445b-89ed-c032563f2bac"
   ],
   "State": "Closed",
-  "CorrectionState": null,
   "EnterpriseIds": [
     "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "4d0201db-36f5-428b-8d11-4f0a65e960cc"
@@ -340,8 +334,7 @@ Creates a PDF version of the specified bill. In case it's not possible to return
   "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
   "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
   "Client": "Sample Client 1.0.0",
-  "BillId": "44eba542-193e-47c7-8077-abd7008eb206",
-  "BillPrintEventId": null
+  "BillId": "44eba542-193e-47c7-8077-abd7008eb206"
 }
 ```
 

--- a/operations/cancellationpolicies.md
+++ b/operations/cancellationpolicies.md
@@ -258,9 +258,7 @@ Gets cancellation policies for enterprise grouped by rate for granular cancellat
   "RateIds": [
     "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "4d0201db-36f5-428b-8d11-4f0a65e960cc"
-  ],
-  "ReservationStartUtc": null,
-  "ReservationEndUtc": null
+  ]
 }
 ```
 

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -804,6 +804,54 @@ Updates personal information of a customer. Note that if any of the fields is le
 | ~~`Address`~~ | ~~[Address](configuration.md#address)~~ | ~~optional~~ | **Deprecated!** Use `AddressId` instead.|
 | ~~`ActivityState`~~ | ~~string~~ | ~~optional~~ | ~~[Activity State](customers.md#activity-state) of customer record, i.e. whether active or deleted.~~ **Deprecated!** Use `IsActive` instead.|
 
+## Add customer file
+
+Attaches the specified file to the customer profile. 
+
+Allowed MIME types: `application/pdf`, `image/bmp`, `image/gif`, `image/jpeg`, `image/png`, `image/tiff`.
+
+Note this operation supports [Portfolio Access Tokens](../guidelines/multi-property.md).
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/customers/addFile`
+
+```javascript
+{
+  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+  "Client": "Sample Client 1.0.0",
+  "CustomerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "Name": "document.pdf",
+  "Type": "application/pdf",
+  "Data": "JVBERi0xLjAKMSAwIG9iajw8L1BhZ2VzIDIgMCBSPj5lbmRvYmogMiAwIG9iajw8L0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iaiAzIDAgb2JqPDwvTWVkaWFCb3hbMCAwIDMgM10+PmVuZG9iagp0cmFpbGVyPDwvUm9vdCAxIDAgUj4+Cg==",
+  "ChainId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
+| `ChainId` | string | optional | Unique identifier of the chain. Required when using [Portfolio Access Tokens](../guidelines/multi-property.md), ignored otherwise. |
+| `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
+| `Name` | string | required | Name of the file. |
+| `Type` | string | required | MIME type of the file (e.g. `application/pdf`). |
+| `Data` | string | required | Base64-encoded data of the file. |
+
+### Response
+
+```javascript
+{
+  "FileId": "f039f5b4-ff18-4510-9086-92b14a68ed78"
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `FileId` | string | required | Unique identifier of the uploaded file. |
+
 ## Search customers
 
 Searches for customers that are active at the moment in the enterprise (e.g. companions of checked-in reservations or paymasters).
@@ -919,51 +967,3 @@ Searches for customers that are active at the moment in the enterprise (e.g. com
 ```javascript
 {}
 ```
-
-## Add customer file
-
-Attaches the specified file to the customer profile. 
-
-Allowed MIME types: `application/pdf`, `image/bmp`, `image/gif`, `image/jpeg`, `image/png`, `image/tiff`.
-
-Note this operation supports [Portfolio Access Tokens](../guidelines/multi-property.md).
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/customers/addFile`
-
-```javascript
-{
-  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-  "Client": "Sample Client 1.0.0",
-  "CustomerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "Name": "document.pdf",
-  "Type": "application/pdf",
-  "Data": "JVBERi0xLjAKMSAwIG9iajw8L1BhZ2VzIDIgMCBSPj5lbmRvYmogMiAwIG9iajw8L0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iaiAzIDAgb2JqPDwvTWVkaWFCb3hbMCAwIDMgM10+PmVuZG9iagp0cmFpbGVyPDwvUm9vdCAxIDAgUj4+Cg==",
-  "ChainId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
-}
-```
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `ChainId` | string | optional | Unique identifier of the chain. Required when using [Portfolio Access Tokens](../guidelines/multi-property.md), ignored otherwise. |
-| `CustomerId` | string | required | Unique identifier of the [Customer](customers.md#customer). |
-| `Name` | string | required | Name of the file. |
-| `Type` | string | required | MIME type of the file (e.g. `application/pdf`). |
-| `Data` | string | required | Base64-encoded data of the file. |
-
-### Response
-
-```javascript
-{
-  "FileId": "f039f5b4-ff18-4510-9086-92b14a68ed78"
-}
-```
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `FileId` | string | required | Unique identifier of the uploaded file. |

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -859,6 +859,97 @@ Adds the specified reservations as a single group. If `GroupId` is specified, ad
 | `Identifier` | string | optional | Identifier of the reservation within the transaction. |
 | `Reservation` | [Reservation (ver 2017-04-12)](reservations.md#reservation-ver-2017-04-12) | required | The added reservation. |
 
+## Add reservation product
+
+Adds a new product order of the specified product to the reservation.
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/reservations/addProduct`
+
+```javascript
+{
+  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+  "Client": "Sample Client 1.0.0",
+  "ReservationId": "4d2aa234-5d30-472c-899f-ab45008c3479",
+  "ProductId": "47312820-2268-4f5c-864d-aa4100ed82bc",
+  "Count": 1,
+  "StartUtc": "2021-01-02T00:00:00Z",
+  "EndUtc": "2021-01-03T00:00:00Z",
+  "UnitAmount": {
+    "Currency": "GBP",
+    "GrossValue": 10,
+    "TaxCodes": [
+      "UK-S"
+    ]
+  }
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
+| `ReservationId` | string | required | Unique identifier of the reservation. |
+| `ProductId` | string | required | Unique identifier of the [Product](products.md#product). |
+| `Count` | integer | required | The amount of the products to be added. Note that if the product is charged e.g. per night, count 1 means a single product every night. Count 2 means two products every night. |
+| `UnitAmount` | [Amount parameters](orders.md#amount-parameters) | optional | Price of the product that overrides the price defined in Mews. |
+| `StartUtc` | string | optional | Product start in UTC timezone in ISO 8601 format. For products with charging Once and PerPerson must be set to same value as EndUtc. |
+| `EndUtc` | string | optional | Product end in UTC timezone in ISO 8601 format. For products with charging Once and PerPerson must be set to same value as StartUtc. |
+
+### Response
+
+```javascript
+{
+  "ItemIds": [
+    "ff81fd7a-29ba-4160-8e22-ab4300f67b23"
+  ]
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ItemIds` | array of string | optional |  |
+
+## Add reservation companion
+
+Adds a customer as a companion to the reservation. Succeeds only if there is space for the new companion (count of current companions is less than `AdultCount + ChildCount`). Note this operation supports [Portfolio Access Tokens](../guidelines/multi-property.md).
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/reservations/addCompanion`
+
+```javascript
+{
+  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+  "Client": "Sample Client 1.0.0",
+  "ReservationId": "e6ea708c-2a2a-412f-a152-b6c76ffad49b",
+  "CustomerId": "35d4b117-4e60-44a3-9580-c582117eff98"
+}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
+| `EnterpriseId` | string | optional | Unique identifier of the enterprise. Required when using [Portfolio Access Tokens](../guidelines/multi-property.md), ignored otherwise. |
+| `ReservationId` | string | required | Unique identifier of the `Reservation`. |
+| `CustomerId` | string | required | Unique identifier of the `Customer`. |
+
+### Response
+
+```javascript
+{}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `CompanionshipId` | string | required | Identifier of the created `Companionship` entity. |
+
 ## Update reservations
 
 Updates information about the specified reservations. Note that if any of the fields are sent as `null`, it won't clear the field in Mews. If the `Value` within the object is sent as `null`, the field will be cleared in Mews. Note this operation supports [Portfolio Access Tokens](../guidelines/multi-property.md).
@@ -1559,94 +1650,3 @@ Cancels all reservation with specified identifiers. Succeeds only if the reserva
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `ReservationIds` | array of string | required | Identifiers of the affected `Reservation` entities. |
-
-## Add reservation product
-
-Adds a new product order of the specified product to the reservation.
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/reservations/addProduct`
-
-```javascript
-{
-  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-  "Client": "Sample Client 1.0.0",
-  "ReservationId": "4d2aa234-5d30-472c-899f-ab45008c3479",
-  "ProductId": "47312820-2268-4f5c-864d-aa4100ed82bc",
-  "Count": 1,
-  "StartUtc": "2021-01-02T00:00:00Z",
-  "EndUtc": "2021-01-03T00:00:00Z",
-  "UnitAmount": {
-    "Currency": "GBP",
-    "GrossValue": 10,
-    "TaxCodes": [
-      "UK-S"
-    ]
-  }
-}
-```
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `ReservationId` | string | required | Unique identifier of the reservation. |
-| `ProductId` | string | required | Unique identifier of the [Product](products.md#product). |
-| `Count` | integer | required | The amount of the products to be added. Note that if the product is charged e.g. per night, count 1 means a single product every night. Count 2 means two products every night. |
-| `UnitAmount` | [Amount parameters](orders.md#amount-parameters) | optional | Price of the product that overrides the price defined in Mews. |
-| `StartUtc` | string | optional | Product start in UTC timezone in ISO 8601 format. For products with charging Once and PerPerson must be set to same value as EndUtc. |
-| `EndUtc` | string | optional | Product end in UTC timezone in ISO 8601 format. For products with charging Once and PerPerson must be set to same value as StartUtc. |
-
-### Response
-
-```javascript
-{
-  "ItemIds": [
-    "ff81fd7a-29ba-4160-8e22-ab4300f67b23"
-  ]
-}
-```
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `ItemIds` | array of string | optional |  |
-
-## Add reservation companion
-
-Adds a customer as a companion to the reservation. Succeeds only if there is space for the new companion (count of current companions is less than `AdultCount + ChildCount`). Note this operation supports [Portfolio Access Tokens](../guidelines/multi-property.md).
-
-### Request
-
-`[PlatformAddress]/api/connector/v1/reservations/addCompanion`
-
-```javascript
-{
-  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-  "Client": "Sample Client 1.0.0",
-  "ReservationId": "e6ea708c-2a2a-412f-a152-b6c76ffad49b",
-  "CustomerId": "35d4b117-4e60-44a3-9580-c582117eff98"
-}
-```
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `ClientToken` | string | required | Token identifying the client application. |
-| `AccessToken` | string | required | Access token of the client application. |
-| `Client` | string | required | Name and version of the client application. |
-| `EnterpriseId` | string | optional | Unique identifier of the enterprise. Required when using [Portfolio Access Tokens](../guidelines/multi-property.md), ignored otherwise. |
-| `ReservationId` | string | required | Unique identifier of the `Reservation`. |
-| `CustomerId` | string | required | Unique identifier of the `Customer`. |
-
-### Response
-
-```javascript
-{}
-```
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `CompanionshipId` | string | required | Identifier of the created `Companionship` entity. |


### PR DESCRIPTION
### Summary

- Adjust sorting to group all add* operations. Sort `addFile` operations below update operations
- Regenerate docs, excluding:
  - Rates
  - Source assignments, since regeneration reverts changes in https://github.com/MewsSystems/gitbook-connector-api/pull/682
- Request examples no longer include null values (this is change in OAS)

No changelog updates it seems.

### Checklist

- [x] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [x] JSON examples updated
- [x] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [x] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
