### PR TITLE
Fix links to Product order parameters

### DIFF
--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -455,7 +455,7 @@ types:
     file: reservations.md
     anchor: time-unit-amount-parameters
   productorderadditiondata:
-    file: products.md
+    file: orders.md
     anchor: product-order-parameters
   costparameters:
     file: _deprecated.md
@@ -1353,7 +1353,7 @@ types:
     anchor: serviceoverbookinglimitresult
   serviceoverbookinglimit:
     file: serviceoverbookinglimits.md
-    anchor: serviceoverbookinglimit
+    anchor: service-overbooking-limit
   serviceoverbookinglimitfilterparameters:
     file: serviceoverbookinglimits.md
     anchor: serviceoverbookinglimitfilterparameters

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -1471,7 +1471,7 @@ This operation supports [Portfolio Access Tokens](../guidelines/multi-property.m
 | `Notes` | string | optional | Additional notes. |
 | `TimeUnitAmount` | [Amount parameters](orders.md#amount-parameters) | optional | Amount of each night of the reservation. |
 | `TimeUnitPrices` | array of [Time unit amount parameters](reservations.md#time-unit-amount-parameters) | optional | Prices for time units of the reservation. E.g. prices for the first or second night. |
-| `ProductOrders` | array of [Product order parameters](products.md#product-order-parameters) | optional | Parameters of the products ordered together with the reservation. |
+| `ProductOrders` | array of [Product order parameters](orders.md#product-order-parameters) | optional | Parameters of the products ordered together with the reservation. |
 | `AvailabilityBlockId` | string | optional | Unique identifier of the `AvailabilityBlock` the reservation is assigned to. |
 | ~~`AdultCount`~~ | ~~integer~~ | ~~required~~ | **Deprecated!** Use `PersonCounts` instead.|
 | ~~`ChildCount`~~ | ~~integer~~ | ~~required~~ | **Deprecated!** Use `PersonCounts` instead.|

--- a/use-cases/events.md
+++ b/use-cases/events.md
@@ -60,7 +60,7 @@ Should you need to retrieve a list of all customer profiles created within a cer
 ## Adding revenue and payment items
 
 One of the expected functions of an Events integration is to push product order items to the correct customer profile in Mews. This can be done using the operation [Add order](../operations/orders.md#add-order). If the product item that is being posted already exists in Mews, use [Product order parameters](../operations/orders.md#product-order-parameters). If the product is a custom item that does not exist in Mews then use [Item parameters](../operations/orders.md#item-parameters). 
-Note that in order to use [Product order parameters](../operations/services.md#product-order-parameters), the property must first set up products under an Additional Service. Then, you will need to retrieve the products by calling [Get all products](../operations/products.md#get-all-products).
+Note that in order to use [Product order parameters](../operations/orders.md#product-order-parameters), the property must first set up products under an Additional Service. Then, you will need to retrieve the products by calling [Get all products](../operations/products.md#get-all-products).
 To ensure correct reporting, all revenue items posted into Mews using [Item parameters](../operations/orders.md#item-parameters) must be associated with their correct accounting category by sending the unique identifier of the accounting category in the request. Information about all the categories configured at each property can be retrieved using [Get all accounting categories](../operations/finance.md#get-all-accounting-categories). 
 
 | <div style="width:350px">'How to' use case</div> | API Operations |


### PR DESCRIPTION
#### Summary

Raised by TPSM: Links to Product order parameters from Reservations were incorrect. I also manually fixed link from Events.

#### Follow style guide

[Style guide](https://mews.atlassian.net/wiki/x/KJAoCw)

#### Check during review

- [ ] The changelog and potentially a deprecation entries are in place.
  - [ ] The changelog timestamp is date of merge to develop. 
- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [x] Correct formatting:
  - [x] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
