### PR TITLE
Add hybrid identifier for "Update rate price"

### DIFF
--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -1011,7 +1011,7 @@ types:
     anchor: age-category-price
   productpricingfilterparameters:
     file: products.md
-    anchor: product-pricing-parameters
+    anchor: product-pricing-filter-parameters
   productresult:
     file: products.md
     anchor: product-result
@@ -1489,3 +1489,6 @@ types:
   ratesetdata:
     file: rates.md
     anchor: set-rate-parameters
+  ratepricingfilterparameters:
+    file: rates.md
+    anchor: rate-pricing-filter-parameters

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ## 9th December 2024
 * Extended [Add external payment](../operations/payments.md#add-external-payment) request with support for all external payment types enabled by the enterprise.
 * Extended [Identity document](../operations/customers.md#identity-document) requests and responses with `IdentityDocumentSupportNumber` for Spanish identity cards in Spanish legal environments.
+* Introduced backward-compatible [Hybrid identifier](../operations/_objects.md#hybrid-identifier) string for request parameter `RateId` in [Update rate price](../operations/rates#update-rate-price) operation.
 
 ## 6th December 2024
 * New section [API Events](../events/README.md) added. Documentation-only, no changes to API.

--- a/operations/rates.md
+++ b/operations/rates.md
@@ -226,10 +226,10 @@ Returns prices for a given rate for a specified time interval. Prices will be re
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
+| `RateId` | string | required | Unique identifier of the `Rate`. |
+| `ProductId` | string | optional | Unique identifier of the `Product`. |
 | `FirstTimeUnitStartUtc` | string | required | Start of the time interval, expressed as the timestamp for the start of the first [time unit](../concepts/time-units.md), in UTC timezone ISO 8601 format. |
 | `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last [time unit](../concepts/time-units.md), in UTC timezone ISO 8601 format. The maximum size of time interval depends on the service's time unit: 367 hours if hours, 367 days if days, or 24 months if months. |
-| `RateId` | string | required | Unique identifier of the [Rate](rates.md#rate) whose prices should be returned. |
-| `ProductId` | string | optional | Unique identifier of the `Product`. |
 
 ### Response
 
@@ -556,11 +556,9 @@ Note that prices are defined daily, so when the server receives the UTC interval
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `FirstTimeUnitStartUtc` | string | required | Start of the time interval, expressed as the timestamp for the start of the first [time unit](../concepts/time-units.md), in UTC timezone ISO 8601 format. |
-| `LastTimeUnitStartUtc` | string | required | End of the time interval, expressed as the timestamp for the start of the last [time unit](../concepts/time-units.md), in UTC timezone ISO 8601 format. The maximum size of time interval depends on the service's time unit: 367 hours if hours, 367 days if days, or 24 months if months. |
-| `RateId` | string | required | Unique identifier of the base [Rate](rates.md#rate) to update. |
+| `RateId` | string [Hybrid identifier](_objects.md#hybrid-identifier) | required | Unique identifier of the `Rate`. |
 | `ProductId` | string | optional | Unique identifier of the `Product`. |
-| `PriceUpdates` | array of [Rate price update](rates.md#rate-price-update) | required, max 1000 items | Price updates. |
+| `PriceUpdates` | array of [Rate price update](rates.md#rate-price-update) | required, max 1000 items | Price adjustments for specific time intervals. |
 
 #### Rate price update
 


### PR DESCRIPTION
### Summary

Add backwards compatible hybrid identifier for "Update rate price".

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
