### PR TITLE
CON-4203: Improve + fix Title enum docs

### DIFF
--- a/_generator/template-schema.js
+++ b/_generator/template-schema.js
@@ -4,9 +4,8 @@ import {
   propertyDescription,
   propertyType,
 } from './jsonschema.js';
-import { getSchemaId } from './utils.js';
+import { getSchemaId, capitalize } from './utils.js';
 import { compareProperties } from './sorting/propertySort.js';
-import { capitalize } from './utils.js';
 
 /**
  * @typedef { import('oas/operation').Operation } Operation
@@ -58,9 +57,23 @@ function createEnumTemplateSchema(schema) {
     };
     entries.push(entry);
   }
+
+  const showDescription = schema['x-showDescription'] ?? false;
+  if (showDescription) {
+    console.log('showDescription', schema);
+  }
+  let description = schema.description;
+  if (showDescription && description) {
+    // Note that this relies on fact that our descriptions use \r\n\ while the filter adds \n\n.
+    const paragraphs = description.split('\n\n');
+    description = paragraphs[0];
+  } else {
+    description = '';
+  }
+
   return {
     enum: entries,
-    description: '', // blank out description since it'd be the same as in property tables
+    description, // blank out description since it'd be the same as in property tables
   };
 }
 

--- a/operations/accounts.md
+++ b/operations/accounts.md
@@ -562,7 +562,7 @@ Updated customer data.
 | `CompanyId` | string | optional | Unique identifier of `Company` the customer is associated with. |
 | `BirthDate` | string | optional | Date of birth in ISO 8601 format. |
 | `Sex` | string | optional | Sex of the customer. |
-| `Title` | string | optional | Title prefix of the customer. |
+| `Title` | [Title](customers.md#title) | optional | Title prefix of the customer. |
 | `PreferredLanguageCode` | string | optional | Language and culture code of the customer's preferred language. E.g. `en-US` or `fr-FR`. |
 | `Options` | [Customer options](accounts.md#customer-options) | required | Options of the customer. |
 | `Classifications` | [Customer classifications](accounts.md#customer-classifications) | required | Classifications of the customer. |

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -568,7 +568,7 @@ Options of the bill.
 | `LastName` | string | required | Last name of the customer. |
 | `FirstName` | string | optional | First name of the customer. |
 | `SecondLastName` | string | optional | Second last name of the customer. |
-| `TitlePrefix` | [Title](customers.md#title) | required | Title prefix of the customer. |
+| `TitlePrefix` | [Title](customers.md#title) | optional | Title prefix of the customer. |
 
 #### Bill owner data
 Additional information about owner of the bill. Can be a [Customer](customers.md#customer) or [Company](companies.md#company). Persisted at the time of closing of the bill.

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -191,7 +191,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `Id` | string | required | Unique identifier of the customer. |
 | `ChainId` | string | required | Unique identifier of the chain. |
 | `Number` | string | required | Number of the customer. |
-| `Title` | [Title](customers.md#title) | required | Title of the customer. |
+| `Title` | [Title](customers.md#title) | optional | Title of the customer. |
 | `Sex` | [Sex](customers.md#sex) | optional | Sex of the customer. |
 | `FirstName` | string | optional | First name of the customer. |
 | `LastName` | string | required | Last name of the customer. |
@@ -231,10 +231,13 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | ~~`ActivityState`~~ | ~~string~~ | ~~optional~~ | ~~[Activity State](customers.md#activity-state) of customer record, i.e. whether active or deleted.~~ **Deprecated!** Use `IsActive` instead.|
 
 #### Title
+Type of the title prefix of the customer.
 
-* `Mister`
-* `Miss`
-* `Misses`
+Note that the value should not be used as-is, but localized. For example, the value `Misses` should be displayed as `Mrs.` in English and `Fr.` in German.
+
+* `Mister` - Mr.
+* `Miss` - Ms.
+* `Misses` - Mrs.
 
 #### Sex
 
@@ -559,7 +562,7 @@ Adds a new customer to the system and returns details of the added customer. If 
 | `Id` | string | required | Unique identifier of the customer. |
 | `ChainId` | string | required | Unique identifier of the chain. |
 | `Number` | string | required | Number of the customer. |
-| `Title` | [Title](customers.md#title) | required | Title of the customer. |
+| `Title` | [Title](customers.md#title) | optional | Title of the customer. |
 | `Sex` | [Sex](customers.md#sex) | optional | Sex of the customer. |
 | `FirstName` | string | optional | First name of the customer. |
 | `LastName` | string | required | Last name of the customer. |
@@ -766,7 +769,7 @@ Updates personal information of a customer. Note that if any of the fields is le
 | `Id` | string | required | Unique identifier of the customer. |
 | `ChainId` | string | required | Unique identifier of the chain. |
 | `Number` | string | required | Number of the customer. |
-| `Title` | [Title](customers.md#title) | required | Title of the customer. |
+| `Title` | [Title](customers.md#title) | optional | Title of the customer. |
 | `Sex` | [Sex](customers.md#sex) | optional | Sex of the customer. |
 | `FirstName` | string | optional | First name of the customer. |
 | `LastName` | string | required | Last name of the customer. |


### PR DESCRIPTION
### Summary

Clarify usage of Title prefix enum and pull it into Customers resource.

Changes in the generator are related to adjustments in schema generation: I added explicit `x-showDescription` extension for enums, to distinguish when to render descriptions, as on most places we are just replicating the property description.

### Checklist

- [x] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
