### PR TITLE
Address for enterprises/getAll and removed deprecation

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 8th January 2025
+* Extended [Get all enterprises](../operations/enterprises.md#get-all-enterprises) response object with `Address`.
+* Removed deprecation of `Address` in [Enterprise](../operations/configuration.md#enterprise), this affects the following operations:
+  * [Get configuration](../operations/configuration.md#get-configuration)
+
 ## 7th January 2025
 * Extended [Get all reservations (ver 2023-06-06)](../operations/reservations.md) request with `AvailabilityBlockIds` request filtering parameter.
 

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -68,7 +68,6 @@ The table columns have the following meanings:
 | `CustomerId`<br>in [Add order](../operations/orders.md#add-order) | Replaced by `AccountId` | 24 May 2023 | |
 | `CustomerId` in [Bill](../operations/bills.md#bill) | Replaced by `AccountId` | 24 May 2023 | |
 | Extent `ResourceCategories`<br>in [Get all resources](../operations/resources.md#get-all-resources) | Use [Get all resource categories](../operations/resourcecategories.md#get-all-resource-categories) instead | 23 May 2023 | 10 Jan 2025 |
-| `Address` in [Enterprise](../operations/configuration.md#enterprise) | Replaced by `AddressId` | 17 Apr 2023 | 10 Jan 2025 |
 | `AmountDefault` in [Payment item](../operations/accountingitems.md#payment-item) | Replaced by `Original amount` | 11 Apr 2023 | | 
 | `AssigneeData` in [Get all bills ](../operations/bills.md#get-all-bills) | Replaced by [Owner data](../operations/bills.md#bill-owner-data) | 20 Feb 2023 | |
 | `ItalianFiscalCode`, `ItalianLotteryCode` <br>in [Get all bills](../operations/bills.md#response) | Retrievable in LegalIdentifiers [Bill customer data](../operations/bills.md#bill-customer-data) | 20 Feb 2023 | 10 Jan 2025 |

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -31,17 +31,6 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
 {
   "NowUtc": "2018-01-01T14:58:02Z",
   "Enterprise": {
-    "Address": {
-      "Id": "8c2c4371-5d42-40a9-b551-ab0b00d75076",
-      "Line1": "Anenské nám. 1",
-      "Line2": "Ahoj",
-      "City": "Prague",
-      "PostalCode": "110 00",
-      "CountryCode": "CZ",
-      "CountrySubdivisionCode": null,
-      "Latitude": 50.08518,
-      "Longitude": 14.414926
-    },
     "Currencies": [
       {
         "Currency": "GBP",
@@ -99,6 +88,17 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
     "Pricing": "Gross",
     "TaxPrecision": null,
     "AddressId": "c556f56e-713e-4102-9de5-0e853b5a8586",
+    "Address": {
+      "Id": "8c2c4371-5d42-40a9-b551-ab0b00d75076",
+      "Line1": "I.P. Pavlova 5",
+      "Line2": null,
+      "City": "Prague",
+      "PostalCode": "1200",
+      "CountryCode": "CZ",
+      "CountrySubdivisionCode": null,
+      "Latitude": 14.429645,
+      "Longitude": 50.075181
+    },
     "GroupNames": [
       "Connector API Group"
     ],
@@ -171,13 +171,13 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
 | `Pricing` | [Pricing](configuration.md#pricing) | required | Pricing of the enterprise. |
 | `TaxPrecision` | integer | optional | Tax precision used for financial calculations in the enterprise. If `null`, `Currency` precision is used. |
 | `AddressId` | string | required | Unique identifier of the `Address` of the enterprise. |
+| `Address` | [Address](configuration.md#address) | required | Address of the enterprise. |
 | `GroupNames` | array of string | required | A list of the group names of the enterprise. |
 | `Subscription` | [Enterprise subscription](enterprises.md#enterprise-subscription) | required | Subscription information of the enterprise. |
 | `Currencies` | array of [Accepted currency](configuration.md#accepted-currency) | required | Currencies accepted by the enterprise. |
 | `AccountingConfiguration` | [Accounting configuration](configuration.md#accounting-configuration) | optional | Configuration information containing financial information about the property. |
 | `IsPortfolio` | boolean | required | Whether the enterprise is a Portfolio enterprise (see [Multi-property guidelines](../guidelines/multi-property.md)). |
 | ~~`EditableHistoryInterval`~~ | ~~string~~ | ~~required~~ | **Deprecated!** Use `AccountingEditableHistoryInterval` and `OperationalEditableHistoryInterval` instead.|
-| ~~`Address`~~ | ~~[Address](configuration.md#address)~~ | ~~required~~ | **Deprecated!** Use `AddressId` instead.|
 
 #### Pricing
 

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -3,7 +3,7 @@
 
 ## Get all enterprises
 
-Returns all enterprises within scope of the `Access Token`, optionally filtered by enterprise identifiers and external identifiers. Note this operation uses [Pagination](../guidelines/pagination.md) and supports [Portfolio Access Tokens](../guidelines/multi-property.md).
+Returns all enterprises within scope of the `Access Token`, optionally filtered by enterprise identifiers and external identifiers. Note this operation uses [Pagination](../guidelines/pagination.md) and supports [Portfolio Access Tokens](../concepts/multi-property.md).
 
 ### Request
 
@@ -77,6 +77,17 @@ Returns all enterprises within scope of the `Access Token`, optionally filtered 
       "Pricing": "Gross",
       "TaxPrecision": 2,
       "AddressId": "31c505e9-9858-4d2f-9eab-afce011c4f47",
+      "Address": {
+        "Id": "8c2c4371-5d42-40a9-b551-ab0b00d75076",
+        "Line1": "I.P. Pavlova 5",
+        "Line2": null,
+        "City": "Prague",
+        "PostalCode": "1200",
+        "CountryCode": "CZ",
+        "CountrySubdivisionCode": null,
+        "Latitude": 14.429645,
+        "Longitude": 50.075181
+      },
       "GroupNames": [
         "Sample Group Name"
       ],
@@ -120,6 +131,7 @@ Returns all enterprises within scope of the `Access Token`, optionally filtered 
 | `Pricing` | [Pricing](configuration.md#pricing) | required | Pricing of the enterprise. |
 | `TaxPrecision` | integer | optional | Tax precision used for financial calculations in the enterprise. If `null`, `Currency` precision is used. |
 | `AddressId` | string | required | Unique identifier of the `Address` of the enterprise. |
+| `Address` | [Address](configuration.md#address) | required | Address of the enterprise. |
 | `GroupNames` | array of string | required | A list of the group names of the enterprise. |
 | `Subscription` | [Enterprise subscription](enterprises.md#enterprise-subscription) | required | Subscription information of the enterprise. |
 | `LinkedUtc` | string | required | Date and time when enterprise was added to the portfolio in UTC timezone in ISO 8601 format. |


### PR DESCRIPTION
### Summary

- Added `Address` to the enterprises/getAll
- Removed deprecation of a property, it can remain

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
