### PR TITLE
Remove restricted from operations table

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -120,12 +120,12 @@ This section describes all operations supported by the API, organised here by th
 | [Add credit card payment](payments.md#add-credit-card-payment) | Adds a new credit card payment to a bill of the specified customer |
 | [Add external payment](payments.md#add-external-payment) | Adds a new external payment to a bill of the specified customer |
 | [Add alternative payment](payments.md#add-alternative-payment) | Adds a new alternative payment to a specified customer |
-| [Get all payments](payments.md#get-all-payments) | **Restricted!** Returns all payments, filtered by various parameters |
+| [Get all payments](payments.md#get-all-payments) | Returns all payments, filtered by various parameters |
 | [Get all payment requests](paymentrequests.md#get-all-payment-requests) | Returns all payment requests |
 | [Add payment requests](paymentrequests.md#add-payment-requests) | Adds new payment requests for specified customers |
 | [Cancel payment requests](paymentrequests.md#cancel-payment-requests) | Cancels specified pending payment requests |
 | [Add outlet bills](outletbills.md#add-outlet-bills) | Adds new outlet bills with their items |
-| [Get all order items](orderitems.md#get-all-order-items) | **Restricted!** Returns all order items |
+| [Get all order items](orderitems.md#get-all-order-items) | Returns all order items |
 | [Refund payment](payments.md#refund-payment) | Refunds a specified payment |
 
 ## Loyalty


### PR DESCRIPTION
### Summary

Those endpoints are not restricted, we just forgot to remove word restrictions from the operations table

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
