### PR TITLE
Add documentation for payment terminal command data change

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 22nd January 2025
+* [Get all active commands](../operations/commands.md#get-all-commands)¨
+  * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
+  * **Deprecated:** `CustomerId` and `FullName` in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
+  * Extended [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object
+* [Get all commands by ids](../operations/commands.md#get-all-commands-by-ids)
+  * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
+  * **Deprecated:** `CustomerId` and `FullName` in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
+  * Extended [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object
+
 ## 21st January 2025
 * [Get all customers](../operations/customers.md#get-all-customers):
   * **Deprecated** operation extent `Documents`. Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead.
@@ -21,13 +31,6 @@
   * Extended request object with `AccountIds` filtering parameter.
 * [Update resource access tokens](../operations/resourceaccesstokens.md#update-resource-access-tokens): 
   * Extended request object with `Value` parameter.
-* **Breaking:** In [Payment temrinal command data reponse object](../operations/commands.md#payment-terminal-command-data) `CustomerId` and `FullName` is no longer required and are deprecated. Following operations are affected
-  * [Get all active commands](../operations/commands.md#get-all-commands)
-  * [Get all commands by ids](../operations/commands.md#get-all-commands-by-ids)
-* [Get all active commands](../operations/commands.md#get-all-commands)
-  * Extended [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object
-* [Get all commands by ids](../operations/commands.md#get-all-commands-by-ids)
-  * Extended [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object
 
 ## 16th January 2025
 * [Get all availability blocks](../operations/availabilityblocks.md#get-all-availability-blocks):

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,15 +2,13 @@
 
 ## 22nd January 2025
 * [Get all commands](../operations/commands.md#get-all-commands):
-
-  * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
-  * **Deprecated:** `CustomerId` and `FullName` in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
+  * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) response object.
+  * **Deprecated:** `CustomerId` and `FullName` in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) response object.
   * Extended [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) with `AccountId` and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command).
-
 * [Get all commands by ids](../operations/commands.md#get-all-commands-by-ids):
-  * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
-  * **Deprecated:** `CustomerId` and `FullName` in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
-  * Extended [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object
+  * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) response object.
+  * **Deprecated:** `CustomerId` and `FullName` in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) response object.
+  * Extended [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object
 
 ## 21st January 2025
 * [Get all customers](../operations/customers.md#get-all-customers):

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,11 +1,13 @@
 # Changelog
 
 ## 22nd January 2025
-* [Get all active commands](../operations/commands.md#get-all-commands)¨
+* [Get all commands](../operations/commands.md#get-all-commands):
+
   * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
   * **Deprecated:** `CustomerId` and `FullName` in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
-  * Extended [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object
-* [Get all commands by ids](../operations/commands.md#get-all-commands-by-ids)
+  * Extended [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) with `AccountId` and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command).
+
+* [Get all commands by ids](../operations/commands.md#get-all-commands-by-ids):
   * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
   * **Deprecated:** `CustomerId` and `FullName` in [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object.
   * Extended [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 21th January 2025
+* **Breaking:** In [Payment temrinal command data reponse object](../operations/commands.md#payment-terminal-command-data) `CustomerId` and `FullName` is no longer required and are deprecated. Following operations are affected
+  * [Get all active commands](../operations/commands.md#get-all-commands) 
+  * [Get all commands by ids](../operations/commands.md#get-all-commands-by-ids)
+* [Get all active commands](../operations/commands.md#get-all-commands)
+  * Extended [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object
+* [Get all commands by ids](../operations/commands.md#get-all-commands-by-ids)
+  * Extended [Payment temrinal command data](../operations/commands.md#payment-terminal-command-data) response object with `AccountId` property and [`AccountData`](../operations/commands.md#account-data-for-payment-terminal-command) object 
+
 ## 16th January 2025
 * [Get all availability blocks](../operations/availabilityblocks.md#get-all-availability-blocks):
   * Extended [Availability block](../operations/availabilityblocks.md#availability-block) response object with `PickupDistribution` property.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22nd January 2025
+## 23rd January 2025
 * [Get all commands](../operations/commands.md#get-all-commands):
   * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) response object.
   * **Deprecated:** `CustomerId` and `FullName` in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) response object.

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -41,6 +41,8 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
+| `CustmerId`, `FullName` <br> in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) | Replaced by `AccountId` and [AccountData](../operations/commands.md#account-data-for-payment-terminal-command) | 21 Jan 2025 | - |
+| Extent `Rates`<br>in [Get all availability blocks](../operations/availabilityblocks.md#get-all-availability-blocks) | Use [Get all rates](../operations/rates.md#get-all-rates) instead | 10 Jan Feb 2025 | 10 Jan 2026 |
 | Extent `ServiceOrders`<br>in [Get all availability blocks](../operations/availabilityblocks.md#get-all-availability-blocks) | Use [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06) instead | 10 Jan 2025 | 10 Jan 2026 |
 | Extent `Rates`<br>in [Get all availability blocks](../operations/availabilityblocks.md#get-all-availability-blocks) | Use [Get all rates](../operations/rates.md#get-all-rates) instead | 10 Jan Feb 2025 | 10 Jan 2026 |
 | `ElectronicInvoiceIdentifier` in [Company](../operations/companies.md#company) | Replaced by `AdditionalTaxIdentifier` | 30 Aug 2024 | - |

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -41,7 +41,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
-| `CustomerId`, `FullName` <br> in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) | Replaced by `AccountId` and [AccountData](../operations/commands.md#account-data-for-payment-terminal-command) | 21 Jan 2025 | 10 Jan 2027 |
+| `CustomerId`, `FullName` <br> in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) | Replaced by `AccountId` and [AccountData](../operations/commands.md#account-data-for-payment-terminal-command) | 23 Jan 2025 | 10 Jan 2027 |
 | `Documents` <br>in [Get all customers](../operations/customers.md#get-all-customers) and [Search customers](../operations/customers.md#search-customers) response | Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead | 9th Jan 2025 | 10 Jan 2026 |
 | Extent `Documents`<br>in [Get all customers](../operations/customers.md#get-all-customers) | Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead | 9th Jan 2025 | 10 Jan 2026 |
 | `Passport`, `IdentityCard`, `Visa`, `DriversLicense` <br>in [Search customers](../operations/customers.md#customer), [Get all customers](../operations/customers.md#get-all-customers) and [Get all companionships](../operations/companionships.md#get-all-companionships) under extent `Customers` | Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead | 9th Jan 2025 | 10 Jan 2026 |

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -41,7 +41,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
-| `CustmerId`, `FullName` <br> in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) | Replaced by `AccountId` and [AccountData](../operations/commands.md#account-data-for-payment-terminal-command) | 21 Jan 2025 | 10 Jan 2027 |
+| `CustomerId`, `FullName` <br> in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) | Replaced by `AccountId` and [AccountData](../operations/commands.md#account-data-for-payment-terminal-command) | 21 Jan 2025 | 10 Jan 2027 |
 | `Documents` <br>in [Get all customers](../operations/customers.md#get-all-customers) and [Search customers](../operations/customers.md#search-customers) response | Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead | 9th Jan 2025 | 10 Jan 2026 |
 | Extent `Documents`<br>in [Get all customers](../operations/customers.md#get-all-customers) | Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead | 9th Jan 2025 | 10 Jan 2026 |
 | `Passport`, `IdentityCard`, `Visa`, `DriversLicense` <br>in [Search customers](../operations/customers.md#customer), [Get all customers](../operations/customers.md#get-all-customers) and [Get all companionships](../operations/companionships.md#get-all-companionships) under extent `Customers` | Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead | 9th Jan 2025 | 10 Jan 2026 |

--- a/deprecations/README.md
+++ b/deprecations/README.md
@@ -41,7 +41,7 @@ The table columns have the following meanings:
 
 | Feature | Comments | Deprecated | Discontinued |
 | :-- | :-- | :-- | :-- |
-| `CustmerId`, `FullName` <br> in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) | Replaced by `AccountId` and [AccountData](../operations/commands.md#account-data-for-payment-terminal-command) | 21 Jan 2025 | - |
+| `CustmerId`, `FullName` <br> in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) | Replaced by `AccountId` and [AccountData](../operations/commands.md#account-data-for-payment-terminal-command) | 21 Jan 2025 | 10 Jan 2027 |
 | `Documents` <br>in [Get all customers](../operations/customers.md#get-all-customers) and [Search customers](../operations/customers.md#search-customers) response | Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead | 9th Jan 2025 | 10 Jan 2026 |
 | Extent `Documents`<br>in [Get all customers](../operations/customers.md#get-all-customers) | Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead | 9th Jan 2025 | 10 Jan 2026 |
 | `Passport`, `IdentityCard`, `Visa`, `DriversLicense` <br>in [Search customers](../operations/customers.md#customer), [Get all customers](../operations/customers.md#get-all-customers) and [Get all companionships](../operations/companionships.md#get-all-companionships) under extent `Customers` | Use [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents) instead | 9th Jan 2025 | 10 Jan 2026 |

--- a/operations/commands.md
+++ b/operations/commands.md
@@ -104,10 +104,33 @@ Returns all commands the are still active from the client application point of v
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `PaymentTerminalId` | string | required | Identifier of the payment terminal. |
-| `CustomerId` | string | required | Identifier of the [Customer](customers.md#customer). |
+| `AccountId` | string | required | Unique identifier of the [Account](accounts.md#account). |
+| `AccountData` | [Account data for payment terminal command](payments.md#account-data-for-payment-terminal-command) | required | Account data for the payment terminal command. |
+| ~~`CustomerId`~~ | ~~string~~ | ~~required~~ | **Deprecated!** Use `AccountId` instead.|
+| ~~`FullName`~~ | ~~string~~ | ~~optional~~ | **Deprecated!** Use `AccountData.Customer.FullName`, if `AccountData.Discriminator` is `Customer`, instead.|
 | `BillId` | string | optional | Identifier of the [Bill](bills.md#bill). |
 | `Amount` | [Currency value](accountingitems.md#currency-value) | required | Amount to be processed. | 
 | `PaymentTerminalData` | string | optional | Custom JSON data. |
+
+#### Account data for payment terminal command
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Discriminator` | [Account type](accounts.md#account-type) | required | Type of the account. |
+| `Customer` | [Customer data for payment terminal command.](payments.md#customer-data-for-payment-terminal-command) | optional | Customer data if the `Discriminator` is `Customer`. |
+| `Company` | [Company data for payment terminal command.](payments.md#company-data-for-payment-terminal-command) | optional | Company data if the `Discriminator` is `Company`. |
+
+#### Customer data for payment terminal command.
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `FullName` | string | required | Full name of the customer. |
+
+#### Company data for payment terminal command.
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Name` | string | required | Name of the company. |
 
 #### Passport scanner command data
 

--- a/operations/commands.md
+++ b/operations/commands.md
@@ -106,7 +106,7 @@ Returns all commands the are still active from the client application point of v
 | `PaymentTerminalId` | string | required | Identifier of the payment terminal. |
 | `AccountId` | string | required | Unique identifier of the [Account](accounts.md#account). |
 | `AccountData` | [Account data for payment terminal command](payments.md#account-data-for-payment-terminal-command) | required | Account data for the payment terminal command. |
-| ~~`CustomerId`~~ | ~~string~~ | ~~required~~ | **Deprecated!** Use `AccountId` instead.|
+| ~~`CustomerId`~~ | ~~string~~ | ~~optional~~ | **Deprecated!** Use `AccountId` instead.|
 | ~~`FullName`~~ | ~~string~~ | ~~optional~~ | **Deprecated!** Use `AccountData.Customer.FullName`, if `AccountData.Discriminator` is `Customer`, instead.|
 | `BillId` | string | optional | Identifier of the [Bill](bills.md#bill). |
 | `Amount` | [Currency value](accountingitems.md#currency-value) | required | Amount to be processed. | 


### PR DESCRIPTION
### Summary
- Deprecating CustomerId and FullName in PaymentTerminalCommandData 
- Making `CustomerId` as non required, breaking change introduced by https://github.com/MewsSystems/mews/pull/61938/files and replaced with `AccountId` and `AccountData`

### Checklist

- [x] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [x] JSON examples updated
- [x] Properties in JSON examples are in the same order as in property tables
- [x] [Changelog] dated the day when PR merged
- [x] [Changelog] accurately describes all changes
- [x] [Changelog] highlights the affected endpoints or operations
- [x] [Changelog] highlights any deprecations
- [x] All hyperlinks tested
- [x] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [x] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
