### PR TITLE
CON-5206 Add documentation fo RequestedRateCode property in  reservations/getAll/2023-06-06 endpoint

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 24th January 2025
+* Extended [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06) object with `RequestedRateCode` property.
+
 ## 23rd January 2025
 * [Get all commands](../operations/commands.md#get-all-commands):
   * **Breaking:** `CustomerId` and `FullName` is no longer required in [Payment terminal command data](../operations/commands.md#payment-terminal-command-data) response object.

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -156,7 +156,8 @@ Returns all reservations within scope of the Access Token, filtered according to
           "AgeCategoryId": "ab58c939-be30-4a60-8f75-ae1600c60c9f",
           "Count": 2
         }
-      ]
+      ],
+      "RequestedRateCode": null
     }
   ],
   "Cursor": "9b59b50d-bd32-4ce5-add8-09ea0e1300e7"
@@ -210,6 +211,7 @@ Returns all reservations within scope of the Access Token, filtered according to
 | `Purpose` | [Reservation purpose](reservations.md#reservation-purpose) | optional | Purpose of the reservation. |
 | `QrCodeData` | string | optional | QR code data of the reservation. |
 | `PersonCounts` | array of [Age category parameters](reservations.md#age-category-parameters) | required | Number of people per age category the reservation was booked for. |
+| `RequestedRateCode` | string | optional | Rate code requested at the time of booking, as provided by an external system (e.g., channel manager or PMS). |
 | ~~`StartUtc`~~ | ~~string~~ | ~~required~~ | ~~Reservation start or check-in time (if it's earlier than scheduled start) in UTC timezone in ISO 8601 format.~~ **Deprecated!** Use `ScheduledStartUtc` and `ActualStartUtc` instead.|
 | ~~`EndUtc`~~ | ~~string~~ | ~~required~~ | ~~Scheduled end time of reservation in UTC timezone in ISO 8601 format~~ **Deprecated!** Use `ScheduledEndUtc` and `ActualEndUtc` instead.|
 


### PR DESCRIPTION
### Summary

<!-- Summarise the changes here in bullet points. -->

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
