### PR TITLE
CON-5778 Sex Field in Customers/update should be marked as Optional

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,7 +2,7 @@
 
 ## 25th February 2025
 * [Update customer](../operations/customers.md#update-customer):
-  * Mark `Title` and `Sex` as optional in [Update customer](../operations/customers.md#update-customer) request parameters.
+  * Mark `Title` and `Sex` as optional in [Update customer](../operations/customers.md#update-customer) request parameters (documentation only, no changes in API functionality).
 
 ## 21st February 2025
 * [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06):

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 25th February 2025
+## 27th February 2025
 * [Update customer](../operations/customers.md#update-customer):
-  * Mark `Title` and `Sex` as optional in [Update customer](../operations/customers.md#update-customer) request parameters (documentation only, no changes in API functionality).
+  * Corrected `Title` and `Sex` in request parameters to be optional.Documentation only, no changes to API functionality.
 
 ## 21st February 2025
 * [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06):

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 25th February 2025
+* [Update customer](../operations/customers.md#update-customer):
+  * Mark `Title` and `Sex` as optional in [Update customer](../operations/customers.md#update-customer) request parameters.
+
 ## 21st February 2025
 * [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06):
   * Extended request object with `ActualEndUtc` filtering parameter.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,7 +2,8 @@
 
 ## 27th February 2025
 * [Update customer](../operations/customers.md#update-customer):
-  * Corrected `Title` and `Sex` in request parameters to be optional.Documentation only, no changes to API functionality.
+  * Corrected `Title` and `Sex` in request parameters to be optional. Documentation only, no changes to API functionality.
+
 
 ## 21st February 2025
 * [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06):

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 21st February 2025
+## 20th February 2025
 * [Update customer](../operations/customers.md#update-customer):
   * Mark `Title` and `Sex` as optional in [Update customer](../operations/customers.md#update-customer) request parameters.
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 21st February 2025
+* [Update customer](../operations/customers.md#update-customer):
+  * Mark `Title` and `Sex` as optional in [Update customer](../operations/customers.md#update-customer) request parameters.
+
 ## 19th February 2025
 * [Delete company contracts](../operations/companycontracts.md#delete-company-contracts):
   * Included support for [Portfolio Access Tokens](../guidelines/authentication.md#portfolio-access-tokens).

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,7 +4,6 @@
 * [Update customer](../operations/customers.md#update-customer):
   * Corrected `Title` and `Sex` in request parameters to be optional. Documentation only, no changes to API functionality.
 
-
 ## 21st February 2025
 * [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06):
   * Extended request object with `ActualEndUtc` filtering parameter.

--- a/operations/customers.md
+++ b/operations/customers.md
@@ -622,12 +622,12 @@ Updates personal information of a customer. Note that if any of the fields is le
 | `Client` | string | required | Name and version of the client application. |
 | `ChainId` | string | optional | Unique identifier of the chain. Required when using `PortfolioAccessTokens`, ignored otherwise. |
 | `CustomerId` | string | required | Unique identifier of the `Customer` to be updated. |
-| `Title` | [Title](customers.md#title) | required | New title. |
+| `Title` | [Title](customers.md#title) | optional | New title. |
 | `FirstName` | string | optional | New first name. |
 | `LastName` | string | optional | New last name. |
 | `SecondLastName` | string | optional | New second last name. |
 | `NationalityCode` | string | optional | New nationality code as ISO 3166-1 code of the `Country`. |
-| `Sex` | [Sex](customers.md#sex) | required | Sex of the customer. |
+| `Sex` | [Sex](customers.md#sex) | optional | Sex of the customer. |
 | `BirthDate` | string | optional | New birth date in ISO 8601 format. |
 | `BirthPlace` | string | optional | New birth place. |
 | `Occupation` | string | optional | Occupation of the customer. |


### PR DESCRIPTION
### Summary

set title and sex as optional in `Customers/Update `endpoint

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
