### PR TITLE
Enforcing exact address

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1st April 2025
+* All newly introduced operations from this date onward will require the address to exactly match the format specified in the documentation (e.g. case sensitive, trailing slash at the end, ...). If the address does not match, the server will respond with a `404 Not Found` error.
+
 ## 21st March 2025
 * Updated [Migration guide: Get all reservations](../deprecations/migration-guide-get-reservations.md). Specified  replacement for `ChannelManager`. Documentation-only. No change to API.
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 1st April 2025
-* All newly introduced operations from this date onward will require the address to exactly match the format specified in the documentation (e.g. case sensitive, trailing slash at the end, ...). If the address does not match, the server will respond with a `404 Not Found` error.
+* Newly introduced operations from this date onward require the address to match the format specified in the documentation (e.g. correct casing, no trailing slash at the end). If the address does not match, the server will respond with a `404 Not Found` error.
+
 
 ## 21st March 2025
 * Updated [Migration guide: Get all reservations](../deprecations/migration-guide-get-reservations.md). Specified  replacement for `ChannelManager`. Documentation-only. No change to API.

--- a/guidelines/requests.md
+++ b/guidelines/requests.md
@@ -10,7 +10,7 @@ The API accepts only `HTTP POST` requests with `Content-Type` set to `applicatio
 * **Resource** - Resource or domain entity which is the target of the action, always pluralized \(e.g. bills, reservations\)
 * **Action** - Name of the action to be performed on the resource \(e.g. getAll, add, delete\)
 
-The operation address **must match the format specified in the documentation**. It is case-sensitive and cannot include a trailing slash or any additional characters. If the address does not match, the server will respond with `404 Not Found` error.
+> **Exact address**: The operation address **must match the specified format exactly**. It is case-sensitive and must not include a trailing slash or any additional characters. If the address does not match the expected format, the server will return a `404 Not Found` error.
 
 ## Body
 

--- a/guidelines/requests.md
+++ b/guidelines/requests.md
@@ -10,7 +10,7 @@ The API accepts only `HTTP POST` requests with `Content-Type` set to `applicatio
 * **Resource** - Resource or domain entity which is the target of the action, always pluralized \(e.g. bills, reservations\)
 * **Action** - Name of the action to be performed on the resource \(e.g. getAll, add, delete\)
 
-> The requested address must exactly match the format specified in the documentation. It is case-sensitive and cannot include a trailing slash or any additional characters. If the address does not match, the server will respond with a` 404 Not Found` error.
+The operation address **must match the format specified in the documentation**. It is case-sensitive and cannot include a trailing slash or any additional characters. If the address does not match, the server will respond with `404 Not Found` error.
 
 ## Body
 

--- a/guidelines/requests.md
+++ b/guidelines/requests.md
@@ -10,6 +10,8 @@ The API accepts only `HTTP POST` requests with `Content-Type` set to `applicatio
 * **Resource** - Resource or domain entity which is the target of the action, always pluralized \(e.g. bills, reservations\)
 * **Action** - Name of the action to be performed on the resource \(e.g. getAll, add, delete\)
 
+> The requested address must exactly match the format specified in the documentation. It is case-sensitive and cannot include a trailing slash or any additional characters. If the address does not match, the server will respond with a` 404 Not Found` error.
+
 ## Body
 
 All API operations require the inclusion of `ClientToken`, `AccessToken` and `Client` in the request. These parameters authenticate incoming requests. For more details, see [Authentication](authentication.md).


### PR DESCRIPTION
### Summary

Enforcing address to exactly match how it's described in the docs

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
