### PR TITLE
CON-7106: Expose IsDefault in rates/getAll

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 19th May 2025
+* [Get all rates](../operations/rates.md#get-all-rates):
+  * Extended [Rate](../operations/rates.md#rate) response object with `IsDefault` property.
+
 ## 12th May 2025
 * Re-formatted 2025 and 2024 changelog entries to follow current format, for easier search. Documentation-only, no change to API. 
 * Clarified [Scope of restrictions](../concepts/restrictions.md#scope-of-restrictions). Documentation-only, no change to API.  

--- a/operations/rates.md
+++ b/operations/rates.md
@@ -129,6 +129,7 @@ Extent of data to be returned.
 | `IsActive` | boolean | required | Indicates if this rate is active. |
 | `IsEnabled` | boolean | required | Indicates if this rate is currently available to customers. |
 | `IsPublic` | boolean | required | Indicates if this rate is publicly available. |
+| `IsDefault` | boolean | required | Indicates if this rate is the default rate for the service. Assigned automatically to the first rate of a service. |
 | `Type` | [Rate type](rates.md#rate-type) | required | Type of the rate. |
 | `Names` | [Localized text](_objects.md#localized-text) | required | All translations of the name. |
 | `ShortName` | string | optional | Short name of the rate (in the default language). |
@@ -682,6 +683,7 @@ Adds new Rates or updates existing ones if they are matched by `Id` or `External
       "IsActive": true,
       "IsEnabled": true,
       "IsPublic": true,
+      "IsDefault": false,
       "Type": "Public",
       "Name": null,
       "Names": {
@@ -709,6 +711,7 @@ Adds new Rates or updates existing ones if they are matched by `Id` or `External
       "IsActive": true,
       "IsEnabled": false,
       "IsPublic": false,
+      "IsDefault": false,
       "Type": "Private",
       "Name": null,
       "Names": {


### PR DESCRIPTION
### Summary

Document `IsDefault` property in `rates/getAll`.

<!-- Summarise the changes here in bullet points. -->

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
