### PR TITLE
MMP-11683-orderitems-getall

### DIFF
--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -1874,3 +1874,21 @@ types:
   billingautomationdeleteparameters:
     file: billingautomations.md
     anchor: billing-automation-delete-parameters
+  producttypeenum:
+    file: orderitems.md
+    anchor: product-type
+  orderitemallowancediscountdata:
+    file: orderitems.md
+    anchor: allowance-discount-data
+  orderitemallowancebreakagedata:
+    file: orderitems.md
+    anchor: allowance-breakage-data
+  orderitemallowancecontrabreakagedata:
+    file: orderitems.md
+    anchor: allowance-breakage-contra-revenue-data
+  orderitemallowancelossdata:
+    file: orderitems.md
+    anchor: allowance-loss-data
+  orderitemallowancecontralossdata:
+    file: orderitems.md
+    anchor: allowance-loss-contra-revenue-data

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26th May 2025
+* [Get all orderitems](../operations/orderitems.md#get-all-order-items):
+    * Extended [Order item data](../operations/orderitems#order-item-data) response object with `allowances` order items data.
+
 ## 22nd May 2025
 * [Get all customers](../operations/customers.md#get-all-customers):  
 * [Search customers](../operations/customers.md#search-customers):

--- a/operations/companies.md
+++ b/operations/companies.md
@@ -515,7 +515,7 @@ Credit rating to define creditworthiness of the company.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `Basic` | [CreditRatingBasicUpdateValue](_objects.md#string-update-value) | optional | Credit status of a company (or `null` if the credit status should not be updated). |
+| `Basic` | [Credit rating basic update value](_objects.md#string-update-value) | optional | Credit status of a company (or `null` if the credit status should not be updated). |
 
 ### Response
 

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -67,6 +67,7 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
     "IsPortfolio": false,
     "Id": "851df8c8-90f2-4c4a-8e01-a4fc46b25178",
     "ExternalIdentifier": null,
+    "HoldingKey": "CA123",
     "ChainId": "8ddea57b-6a5c-4eec-8c4c-24467dce118e",
     "CreatedUtc": "2015-07-07T13:33:17Z",
     "UpdatedUtc": "2015-07-07T13:33:17Z",
@@ -151,6 +152,7 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the enterprise. |
 | `ExternalIdentifier` | string | optional, max length 255 characters | Identifier of the enterprise from external system. |
+| `HoldingKey` | string | optional, max length 255 characters | Identifies an enterprise in the external system of a holding company. The holding company may administer multiple portfolios. |
 | `ChainId` | string | required | Unique identifier of the chain to which the enterprise belongs. |
 | `CreatedUtc` | string | required | Creation date and time of the enterprise in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Creation date and time of the enterprise in UTC timezone in ISO 8601 format. |

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -56,6 +56,7 @@ Returns all enterprises within scope of the `Access Token`, optionally filtered 
       "LinkedUtc": "2023-06-01T00:00:00Z",
       "Id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "ExternalIdentifier": "Enterprise2023",
+      "HoldingKey": "CA123",
       "ChainId": "2f6be44e-9881-4b12-aefe-afce011a9d67",
       "CreatedUtc": "2022-03-23T17:12:06Z",
       "UpdatedUtc": "2022-03-23T17:12:06Z",
@@ -111,6 +112,7 @@ Returns all enterprises within scope of the `Access Token`, optionally filtered 
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the enterprise. |
 | `ExternalIdentifier` | string | optional, max length 255 characters | Identifier of the enterprise from external system. |
+| `HoldingKey` | string | optional, max length 255 characters | Identifies an enterprise in the external system of a holding company. The holding company may administer multiple portfolios. |
 | `ChainId` | string | required | Unique identifier of the chain to which the enterprise belongs. |
 | `CreatedUtc` | string | required | Creation date and time of the enterprise in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Creation date and time of the enterprise in UTC timezone in ISO 8601 format. |

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -358,6 +358,8 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 * `AllowanceDiscount`
 * `AllowanceBreakage`
 * `AllowanceContraBreakage`
+* `AllowanceLoss`
+* `AllowanceContraLoss`
 
 #### Order item options
 Options of the order item.
@@ -374,11 +376,21 @@ Additional order item data.
 | `Discriminator` | [Order item data discriminator](orderitems.md#order-item-data-discriminator) | required | Discriminator pointing to the fields within this object that contains additional data. |
 | `Rebate` | [Rebate data](orderitems.md#rebate-data) | optional | Contains additional data in the case of rebate item. |
 | `Product` | [Product data](orderitems.md#product-data) | optional | Contains additional data in the case of product item. |
+| `AllowanceDiscount` | [Allowance Discount Data](orderitems.md#allowance-discount-data) | optional | Contains additional data in the case of allowance discount. |
+| `AllowanceBreakage` | [Allowance Breakage Data](orderitems.md#allowance-breakage-data) | optional | Contains additional data in the case of allowance breakage (profit). |
+| `AllowanceContraBreakage` | [Allowance Breakage Contra Revenue Data](orderitems.md#allowance-breakage-contra-revenue-data) | optional | Contains additional data in the case of allowance breakage contra revenue. |
+| `AllowanceLoss` | [Allowance Loss Data](orderitems.md#allowance-loss-data) | optional | Contains additional data in the case of allowance loss. |
+| `AllowanceContraLoss` | [Allowance Loss Contra Revenue Data](orderitems.md#allowance-loss-contra-revenue-data) | optional | Contains additional data in the case of allowance breakage contra revenue. |
 
 #### Order item data discriminator
 
-* `Rebate`
-* `Product`
+* `Rebate` - Rebate.
+* `Product` - Product.
+* `AllowanceDiscount` - Allowance discount.
+* `AllowanceBreakage` - Profit of the allowance product.
+* `AllowanceBreakageContraRevenue` - Accounting balance for profit of the allowance product.
+* `AllowanceLoss` - Loss of the allowance product.
+* `AllowanceLossContraRevenue` - Accounting balance for loss of the allowance product.
 
 #### Rebate data
 
@@ -393,6 +405,53 @@ Additional order item data.
 | :-- | :-- | :-- | :-- |
 | `ProductId` | string | required | Unique identifier of the [Product](products.md#product). |
 | `AgeCategoryId` | string | optional | Unique identifier of the [Age Category](agecategories.md#age-category). |
+| `ProductType` | [Product type](orderitems.md#product-type) | required | Type of Product, e.g. whether allowance or product. |
+
+#### Product type
+
+* `Product`
+* `Allowance`
+
+#### Allowance Discount Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
+| `DiscountedOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been discounted by current item. |
+| `DiscountedProductId` | string | optional | Unique identifier of the [Product](products.md#product) which has been been discounted by current item. |
+
+#### Allowance Breakage Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
+| `ContraBreakageOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which balances current item. |
+
+#### Allowance Breakage Contra Revenue Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
+| `BreakageOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been balanced by current item. |
+
+#### Allowance Loss Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
+| `ContraLossOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which balances current item. |
+
+#### Allowance Loss Contra Revenue Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
+| `LossOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been balanced by current item. |
 
 #### Tax exemption reason type
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -417,41 +417,31 @@ Additional order item data.
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
-| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
 | `DiscountedOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been discounted by current item. |
-| `DiscountedProductId` | string | optional | Unique identifier of the [Product](products.md#product) which has been been discounted by current item. |
 
 #### Allowance Breakage Data
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
-| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
-| `ContraBreakageOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which balances current item. |
 
 #### Allowance Breakage Contra Revenue Data
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
-| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
-| `BreakageOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been balanced by current item. |
 
 #### Allowance Loss Data
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
-| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
-| `ContraLossOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which balances current item. |
 
 #### Allowance Loss Contra Revenue Data
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
-| `AllowanceProductId` | string | required | Unique identifier of the allowance [Product](products.md#product) which credit been been consumed by current item. |
-| `LossOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been balanced by current item. |
 
 #### Tax exemption reason type
 

--- a/operations/vouchers.md
+++ b/operations/vouchers.md
@@ -359,7 +359,7 @@ Updates information about the specified vouchers. Note this operation supports [
 | :-- | :-- | :-- | :-- |
 | `VoucherId` | string | required | Unique identifier of the Voucher. |
 | `Name` | [String update value](_objects.md#string-update-value) | optional, max length 128 characters | Internal name of the voucher (or `null` if the name should not be updated). |
-| `Type` | [VoucherTypeUpdateValue](_objects.md#string-update-value) | optional | Type of the voucher e.g. 'Public', 'PartnerCompany' or 'TravelAgency' (or `null` if the type should not be updated). |
+| `Type` | [Voucher Type update value](_objects.md#string-update-value) | optional | Type of the voucher e.g. 'Public', 'PartnerCompany' or 'TravelAgency' (or `null` if the type should not be updated). |
 | `CompanyId` | [String update value](_objects.md#string-update-value) | optional | Unique identifier of Company (Company or Travel Agency) the voucher is related to. This is required for Type of `PartnerCompany` or `TravelAgency`. Use `null` if Company should not be updated. |
 | `AssignedRateIds` | [Assigned rate ids](vouchers.md#assigned-rate-ids) | optional | Unique identifiers of Rates (or `null` should it not be updated). |
 | `OccupiableIntervalStartUtc` | [String update value](_objects.md#string-update-value) | optional | Start of the interval in which the voucher can be applied (or `null` if the start time should not be updated). |


### PR DESCRIPTION
### Summary

Added 2 new order item types for allowances (loss, contraloss)
Added 5 new values for discriminator of order item data related to allowances
Added 5 new dto's used for the new order item data discriminators

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
