### PR TITLE
Extend ProductClassifications with Fee

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 26th May 2025
+* Extended [product classifications](../operations/products.md#product-classifications) with `Fee`.
+
 ## 22nd May 2025
 * [Get all customers](../operations/customers.md#get-all-customers):  
 * [Search customers](../operations/customers.md#search-customers):

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 26th May 2025
-* Extended [product classifications](../operations/products.md#product-classifications) with `Fee`.
+## 27th May 2025
+* [Get all products](../operations/products.md#get-all-products):
+  * Extended [product classifications](../operations/products.md#product-classifications) with `Fee`.
 
 ## 22nd May 2025
 * [Get all customers](../operations/customers.md#get-all-customers):  

--- a/operations/products.md
+++ b/operations/products.md
@@ -81,7 +81,8 @@ Returns all products offered together with the specified services. Note this ope
         "Food": false,
         "Beverage": false,
         "Wellness": false,
-        "CityTax": false
+        "CityTax": false,
+        "Fee": false
       },
       "Price": {
         "GrossValue": 25,
@@ -133,7 +134,8 @@ Returns all products offered together with the specified services. Note this ope
         "Food": false,
         "Beverage": false,
         "Wellness": false,
-        "CityTax": false
+        "CityTax": false,
+        "Fee": false
       },
       "Price": {
         "GrossValue": 25,
@@ -224,6 +226,7 @@ Returns all products offered together with the specified services. Note this ope
 | `Beverage` | boolean | required | Product is classified as beverage. |
 | `Wellness` | boolean | required | Product is classified as wellness. |
 | `CityTax` | boolean | required | Product is classified as city tax. |
+| `Fee` | boolean | required | Product is classified as fee. |
 
 #### Product pricing
 


### PR DESCRIPTION
### Summary

ProductClassifications are extended with new `Fee` value. Updating documents for it.

Change has just been merged to develop, will probably be available today afternoon / tomorrow morning.

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
