### PR TITLE
CON-6558: Added TaxIdentifier to Bill customer data

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2nd June 2025
+* [Get all bills](../operations/bills.md#get-all-bills):
+  * Extended response object [Bill customer data](../operations/bills.md#bill-customer-data) with `TaxIdentifier` property.
+
 ## 28th May 2025
 * [Get All Loyalty Memberships](../operations/loyaltymemberships.md#get-all-loyalty-memberships)
   * Extended request with `ProviderMembershipId` property.

--- a/operations/bills.md
+++ b/operations/bills.md
@@ -605,6 +605,7 @@ Options of the bill.
 | `FirstName` | string | optional | First name of the customer. |
 | `SecondLastName` | string | optional | Second last name of the customer. |
 | `TitlePrefix` | [Title](customers.md#title) | optional | Title prefix of the customer. |
+| `TaxIdentifier` | string | optional | Tax identifier of the customer. |
 
 #### Bill owner data
 Additional information about owner of the bill. Can be a [Customer](customers.md#customer) or [Company](companies.md#company). Persisted at the time of closing of the bill.


### PR DESCRIPTION
### Summary

Extended Bill customer data used in Get all bills with new property.

### Checklist

- [x] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
