### PR TITLE
Order items extended with allowances data

### DIFF
--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -1907,21 +1907,12 @@ types:
   loyaltymembershipstateupdatevalue:
     file: loyaltymemberships.md
     anchor: loyalty-membership-state-update-value
-  producttypeenum:
-    file: orderitems.md
-    anchor: product-type
-  orderitemallowancediscountdata:
-    file: orderitems.md
-    anchor: allowance-discount-data
-  orderitemallowancebreakagedata:
-    file: orderitems.md
-    anchor: allowance-breakage-data
-  orderitemallowancecontrabreakagedata:
-    file: orderitems.md
-    anchor: allowance-contra-breakage-data
-  orderitemallowancelossdata:
-    file: orderitems.md
-    anchor: allowance-loss-data
-  orderitemallowancecontralossdata:
-    file: orderitems.md
-    anchor: allowance-contra-loss-data
+  multipleratecapacityoffsetupdateparameters:
+    file: rates.md
+    anchor: multipleratecapacityoffsetupdateparameters
+  ratecapacityoffsetupdateparameters:
+    file: rates.md
+    anchor: ratecapacityoffsetupdateparameters
+  decimalupdatevalue:
+    file: _objects.md
+    anchor: decimal-update-value

--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -1916,3 +1916,15 @@ types:
   decimalupdatevalue:
     file: _objects.md
     anchor: decimal-update-value
+  producttypeenum:
+    file: orderitems.md
+    anchor: product-type
+  orderitemallowancediscountdata:
+    file: orderitems.md
+    anchor: allowance-discount-data
+  orderitemallowanceprofitsdata:
+    file: orderitems.md
+    anchor: allowance-profits-data
+  allowanceprofittypeenum:
+    file: orderitems.md
+    anchor: allowance-profit-type

--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -1907,3 +1907,21 @@ types:
   loyaltymembershipstateupdatevalue:
     file: loyaltymemberships.md
     anchor: loyalty-membership-state-update-value
+  producttypeenum:
+    file: orderitems.md
+    anchor: product-type
+  orderitemallowancediscountdata:
+    file: orderitems.md
+    anchor: allowance-discount-data
+  orderitemallowancebreakagedata:
+    file: orderitems.md
+    anchor: allowance-breakage-data
+  orderitemallowancecontrabreakagedata:
+    file: orderitems.md
+    anchor: allowance-contra-breakage-data
+  orderitemallowancelossdata:
+    file: orderitems.md
+    anchor: allowance-loss-data
+  orderitemallowancecontralossdata:
+    file: orderitems.md
+    anchor: allowance-contra-loss-data

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5th June 2025
+* [Get all orderitems](../operations/orderitems.md#get-all-order-items):
+    * Extended [Order item data](../operations/orderitems#order-item-data) response object with `allowances` order items data.
+
 ## 2nd June 2025
 * [Get all bills](../operations/bills.md#get-all-bills):
   * Extended response object [Bill customer data](../operations/bills.md#bill-customer-data) with `TaxIdentifier` property.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,8 +1,44 @@
 # Changelog
 
-## 5th June 2025
+## 27th June 2025
 * [Get all orderitems](../operations/orderitems.md#get-all-order-items):
     * Extended [Order item data](../operations/orderitems#order-item-data) response object with `allowances` order items data.
+
+## 20th June 2025
+* [Get all resource blocks](../operations/resourceblocks.md#resource-block):
+  * Extended response object to include `DeletedUtc` field.
+* [Get reservation channel manager details](../operations/reservations.md#get-reservation-channel-manager-details):
+  * Extended response object [Reservation channel manager details](../operations/reservations.md#reservation-channel-manager-details) with `ChannelManagerGroupNumber`.
+
+## 19th June 2025
+* [Update rate capacity offset pricing](rates.md#update-rate-capacity-offset-pricing):
+  * Added new operation for updating rate capacity offset pricing.
+
+## 16th June 2025
+* [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06):
+  * Extended request object with `PartnerCompanyIds` and `TravelAgencyIds` filtering parameters.
+
+## 13th June 2025
+* [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents):
+  * **Change in behavior**: The identity document `Number` property is an empty string when the number is not collected in certain regions, such as The Netherlands.
+* [Add identity documents](../operations/identitydocuments.md#add-identity-documents):
+  * **Change in behavior**: If identity document number is not collected in certain regions, such as The Netherlands, use an empty string for the `Number` property.
+* [Update identity documents](../operations/identitydocuments.md#update-identity-documents):
+* [Add customer](../operations/customers.md#add-customer):
+* [Update customer](../operations/customers.md#update-customer):
+  * **Change in behavior**: If identity document number is not collected in certain regions, such as The Netherlands, do not use the optional `Number` property.
+* [Get configuration](../operations/configuration.md#get-configuration):
+  * Extended response object with `IsIdentityDocumentNumberRequired` property.
+
+## 6th June 2025
+* [Get configuration](../operations/configuration.md#get-configuration):
+  * Extended response object [Enterprise](configuration.md#enterprise) with `HoldingKey`and `ChainName`properties.
+* [Get all enterprises](../operations/enterprises.md#get-all-enterprises):
+  * Extended response object [Enterprise](enterprises.md#enterprise) with `HoldingKey`and `ChainName`properties.
+  
+## 5th June 2025
+* [Get all products](../operations/products.md#get-all-products):
+  * Extended [product classifications](../operations/products.md#product-classifications) with `Fee`.
 
 ## 2nd June 2025
 * [Get all bills](../operations/bills.md#get-all-bills):

--- a/operations/README.md
+++ b/operations/README.md
@@ -230,6 +230,7 @@ This section describes all operations supported by the API, organised here by th
 | [Add rates](rates.md#add-rates) | Adds new rates to the enterprise |
 | [Set rates](rates.md#set-rates) | **Restricted!** Adds new or updates existing rates |
 | [Delete rates](rates.md#delete-rates) | Deletes specified rates |
+| [Update rate capacity offset pricing](rates.md#update-rate-capacity-offset-pricing) | Updates capacity offset based pricing for specified rates |
 | [Get rate pricing](rates.md#get-rate-pricing) | Returns prices of a rate in the specified interval |
 | [Update rate price](rates.md#update-rate-price) | Updates price of a rate in the specified intervals |
 | [Get all rate groups](rategroups.md#get-all-rate-groups) | Returns all rate groups filtered by rate groups or other filters |

--- a/operations/configuration.md
+++ b/operations/configuration.md
@@ -67,7 +67,9 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
     "IsPortfolio": false,
     "Id": "851df8c8-90f2-4c4a-8e01-a4fc46b25178",
     "ExternalIdentifier": null,
+    "HoldingKey": "CA123",
     "ChainId": "8ddea57b-6a5c-4eec-8c4c-24467dce118e",
+    "ChainName": "Connector API Chain",
     "CreatedUtc": "2015-07-07T13:33:17Z",
     "UpdatedUtc": "2015-07-07T13:33:17Z",
     "Name": "Connector API Hotel",
@@ -134,7 +136,8 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
     "CreatedUtc": "2023-10-01T11:48:57Z",
     "UpdatedUtc": "2023-10-28T11:48:57Z"
   },
-  "PaymentCardStorage": null
+  "PaymentCardStorage": null,
+  "IsIdentityDocumentNumberRequired": true
 }
 ```
 
@@ -144,6 +147,7 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
 | `Enterprise` | [Enterprise](configuration.md#enterprise) | required | The enterprise (e.g. hotel, hostel) associated with the access token. |
 | `Service` | [Service](services.md#service) | optional | The reservable service (e.g. accommodation, parking) associated with the access token of the service scoped integration. |
 | `PaymentCardStorage` | [Payment card storage](configuration.md#payment-card-storage) | optional | Contains information about payment card storage. |
+| `IsIdentityDocumentNumberRequired` | boolean | required | Whether the identity documents for this enterprise include the value of identity document number as required by the legal environment. When `false`, the number is not required, and an empty string can be used in write operations. In read operations, an empty string is returned when an empty string was provided for the number. |
 
 #### Enterprise
 
@@ -151,7 +155,9 @@ Returns the enterprise configuration. For single-enterprise Access Tokens, this 
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the enterprise. |
 | `ExternalIdentifier` | string | optional, max length 255 characters | Identifier of the enterprise from external system. |
+| `HoldingKey` | string | optional, max length 255 characters | Identifies an enterprise in the external system of a holding company. The holding company may administer multiple portfolios. |
 | `ChainId` | string | required | Unique identifier of the chain to which the enterprise belongs. |
+| `ChainName` | string | required | Name of the `Chain` to which the enterprise belongs. |
 | `CreatedUtc` | string | required | Creation date and time of the enterprise in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Creation date and time of the enterprise in UTC timezone in ISO 8601 format. |
 | `Name` | string | required | Name of the enterprise. |

--- a/operations/enterprises.md
+++ b/operations/enterprises.md
@@ -56,7 +56,9 @@ Returns all enterprises within scope of the `Access Token`, optionally filtered 
       "LinkedUtc": "2023-06-01T00:00:00Z",
       "Id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "ExternalIdentifier": "Enterprise2023",
+      "HoldingKey": "CA123",
       "ChainId": "2f6be44e-9881-4b12-aefe-afce011a9d67",
+      "ChainName": "Connector API Chain",
       "CreatedUtc": "2022-03-23T17:12:06Z",
       "UpdatedUtc": "2022-03-23T17:12:06Z",
       "Name": "Sample Portfolio Hotel",
@@ -111,7 +113,9 @@ Returns all enterprises within scope of the `Access Token`, optionally filtered 
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the enterprise. |
 | `ExternalIdentifier` | string | optional, max length 255 characters | Identifier of the enterprise from external system. |
+| `HoldingKey` | string | optional, max length 255 characters | Identifies an enterprise in the external system of a holding company. The holding company may administer multiple portfolios. |
 | `ChainId` | string | required | Unique identifier of the chain to which the enterprise belongs. |
+| `ChainName` | string | required | Name of the chain to which the enterprise belongs. |
 | `CreatedUtc` | string | required | Creation date and time of the enterprise in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Creation date and time of the enterprise in UTC timezone in ISO 8601 format. |
 | `Name` | string | required | Name of the enterprise. |

--- a/operations/identitydocuments.md
+++ b/operations/identitydocuments.md
@@ -84,7 +84,7 @@ Returns all identity documents for the specified customers, with additional filt
 | `Id` | string | required | Unique identifier of the document. |
 | `CustomerId` | string | required | Identifier of the `Customer`. |
 | `Type` | [Document type](reservations.md#document-type) | required | Type of the document. |
-| `Number` | string | required | Number of the document (e.g. passport number). |
+| `Number` | string | required | Number of the document (e.g. passport number). The value is an empty string when the number is not collected in certain regions, such as The Netherlands. |
 | `ExpirationDate` | string | optional | Expiration date in ISO 8601 format. |
 | `IssuanceDate` | string | optional | Date of issuance in ISO 8601 format. |
 | `IssuingCountryCode` | string | optional | ISO 3166-1 code of the `Country`. |
@@ -134,7 +134,7 @@ Adds identity documents. This operation supports [Portfolio Access Tokens](../co
 | :-- | :-- | :-- | :-- |
 | `CustomerId` | string | required | Identifier of the `Customer`. |
 | `Type` | [Document type](reservations.md#document-type) | required | Type of the document. |
-| `Number` | string | required | Number of the document (e.g. passport number). |
+| `Number` | string | required | Number of the document (e.g. passport number). If the number is not collected in certain regions, such as The Netherlands, use an empty string. In all other cases, a value should be supplied. |
 | `ExpirationDate` | string | optional | Expiration date in ISO 8601 format. |
 | `IssuanceDate` | string | optional | Date of issuance in ISO 8601 format. |
 | `IssuingCountryCode` | string | optional | ISO 3166-1 code of the `Country`). |

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -377,20 +377,14 @@ Additional order item data.
 | `Rebate` | [Rebate data](orderitems.md#rebate-data) | optional | Contains additional data in the case of rebate item. |
 | `Product` | [Product data](orderitems.md#product-data) | optional | Contains additional data in the case of product item. |
 | `AllowanceDiscount` | [Allowance Discount Data](orderitems.md#allowance-discount-data) | optional | Contains additional data in the case of allowance discount item. |
-| `AllowanceBreakage` | [Allowance Breakage Data](orderitems.md#allowance-breakage-data) | optional | Contains additional data in the case of allowance breakage (profit) item. |
-| `AllowanceContraBreakage` | [Allowance Contra Breakage Data](orderitems.md#allowance-contra-breakage-data) | optional | Contains additional data in the case of allowance contra breakage item. Balances allowance breakage item. |
-| `AllowanceLoss` | [Allowance Loss Data](orderitems.md#allowance-loss-data) | optional | Contains additional data in the case of allowance loss item. |
-| `AllowanceContraLoss` | [Allowance Contra Loss Data](orderitems.md#allowance-contra-loss-data) | optional | Contains additional data in the case of allowance contra breakage item. |
+| `AllowanceProfits` | [Allowance Profits Data](orderitems.md#allowance-profits-data) | optional | Contains additional data in the case of allowance profits item. |
 
 #### Order item data discriminator
 
 * `Rebate` - Rebate.
 * `Product` - Product.
 * `AllowanceDiscount` - Allowance discount.
-* `AllowanceBreakage` - Profit of the allowance product.
-* `AllowanceContraBreakage` - Accounting balance for profit of the allowance product.
-* `AllowanceLoss` - Loss of the allowance product.
-* `AllowanceContraLoss` - Accounting balance for loss of the allowance product.
+* `AllowanceProfits` - Allowance profits.
 
 #### Rebate data
 
@@ -416,32 +410,22 @@ Additional order item data.
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
 | `DiscountedOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been discounted by current item. |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
 
-#### Allowance Breakage Data
+#### Allowance Profits Data
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+| `AllowanceProfitType` | [Allowance profit type](orderitems.md#allowance-profit-type) | required | Type of allowance profit. |
 
-#### Allowance Contra Breakage Data
+#### Allowance profit type
 
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
-
-#### Allowance Loss Data
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
-
-#### Allowance Contra Loss Data
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+* `AllowanceBreakage` - Profit of the allowance product.
+* `AllowanceContraBreakage` - Accounting balance for profit of the allowance product.
+* `AllowanceLoss` - Loss of the allowance product.
+* `AllowanceContraLoss` - Accounting balance for loss of the allowance product.
 
 #### Tax exemption reason type
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -358,6 +358,8 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 * `AllowanceDiscount`
 * `AllowanceBreakage`
 * `AllowanceContraBreakage`
+* `AllowanceLoss`
+* `AllowanceContraLoss`
 
 #### Order item options
 Options of the order item.
@@ -374,11 +376,21 @@ Additional order item data.
 | `Discriminator` | [Order item data discriminator](orderitems.md#order-item-data-discriminator) | required | Discriminator pointing to the fields within this object that contains additional data. |
 | `Rebate` | [Rebate data](orderitems.md#rebate-data) | optional | Contains additional data in the case of rebate item. |
 | `Product` | [Product data](orderitems.md#product-data) | optional | Contains additional data in the case of product item. |
+| `AllowanceDiscount` | [Allowance Discount Data](orderitems.md#allowance-discount-data) | optional | Contains additional data in the case of allowance discount item. |
+| `AllowanceBreakage` | [Allowance Breakage Data](orderitems.md#allowance-breakage-data) | optional | Contains additional data in the case of allowance breakage (profit) item. |
+| `AllowanceContraBreakage` | [Allowance Contra Breakage Data](orderitems.md#allowance-contra-breakage-data) | optional | Contains additional data in the case of allowance contra breakage item. Balances allowance breakage item. |
+| `AllowanceLoss` | [Allowance Loss Data](orderitems.md#allowance-loss-data) | optional | Contains additional data in the case of allowance loss item. |
+| `AllowanceContraLoss` | [Allowance Contra Loss Data](orderitems.md#allowance-contra-loss-data) | optional | Contains additional data in the case of allowance contra breakage item. |
 
 #### Order item data discriminator
 
-* `Rebate`
-* `Product`
+* `Rebate` - Rebate.
+* `Product` - Product.
+* `AllowanceDiscount` - Allowance discount.
+* `AllowanceBreakage` - Profit of the allowance product.
+* `AllowanceContraBreakage` - Accounting balance for profit of the allowance product.
+* `AllowanceLoss` - Loss of the allowance product.
+* `AllowanceContraLoss` - Accounting balance for loss of the allowance product.
 
 #### Rebate data
 
@@ -393,6 +405,43 @@ Additional order item data.
 | :-- | :-- | :-- | :-- |
 | `ProductId` | string | required | Unique identifier of the [Product](products.md#product). |
 | `AgeCategoryId` | string | optional | Unique identifier of the [Age Category](agecategories.md#age-category). |
+| `ProductType` | [Product type](orderitems.md#product-type) | required | Type of Product, e.g. whether allowance or product. |
+
+#### Product type
+
+* `Product`
+* `Allowance`
+
+#### Allowance Discount Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+| `DiscountedOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been discounted by current item. |
+
+#### Allowance Breakage Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+
+#### Allowance Contra Breakage Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+
+#### Allowance Loss Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+
+#### Allowance Contra Loss Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
 
 #### Tax exemption reason type
 

--- a/operations/products.md
+++ b/operations/products.md
@@ -81,7 +81,8 @@ Returns all products offered together with the specified services. Note this ope
         "Food": false,
         "Beverage": false,
         "Wellness": false,
-        "CityTax": false
+        "CityTax": false,
+        "Fee": false
       },
       "Price": {
         "GrossValue": 25,
@@ -133,7 +134,8 @@ Returns all products offered together with the specified services. Note this ope
         "Food": false,
         "Beverage": false,
         "Wellness": false,
-        "CityTax": false
+        "CityTax": false,
+        "Fee": false
       },
       "Price": {
         "GrossValue": 25,
@@ -224,6 +226,7 @@ Returns all products offered together with the specified services. Note this ope
 | `Beverage` | boolean | required | Product is classified as beverage. |
 | `Wellness` | boolean | required | Product is classified as wellness. |
 | `CityTax` | boolean | required | Product is classified as city tax. |
+| `Fee` | boolean | required | Product is classified as fee. |
 
 #### Product pricing
 

--- a/operations/rates.md
+++ b/operations/rates.md
@@ -561,7 +561,7 @@ Note that prices are defined daily, so when the server receives the UTC interval
 | `Client` | string | required | Name and version of the client application. |
 | `RateId` | string [Hybrid identifier](_objects.md#hybrid-identifier) | required | Unique identifier of the `Rate`. |
 | `ProductId` | string | optional | Unique identifier of the `Product`. |
-| `PriceUpdates` | array of [Rate price update](rates.md#rate-price-update) | required, max 1000 items | Price adjustments for specific time intervals. |
+| `PriceUpdates` | array of [Rate price update](rates.md#rate-price-update) | required, max 50 items | Price adjustments for specific time intervals. |
 
 #### Rate price update
 
@@ -571,6 +571,66 @@ Note that prices are defined daily, so when the server receives the UTC interval
 | `Value` | number | optional | New value of the rate on the interval. If not specified, removes all adjustments within the interval. |
 | `FirstTimeUnitStartUtc` | string | optional | Start of the time interval, expressed as the timestamp for the start of the first [time unit](../concepts/time-units.md), in UTC timezone ISO 8601 format. |
 | `LastTimeUnitStartUtc` | string | optional | End of the time interval, expressed as the timestamp for the start of the last [time unit](../concepts/time-units.md), in UTC timezone ISO 8601 format. The maximum size of time interval depends on the service's time unit: 367 hours if hours, 367 days if days, or 24 months if months. |
+
+### Response
+
+```javascript
+{}
+```
+
+## Update rate capacity offset pricing
+
+Updates capacity offset based pricing for specified rates. This operation supports [Portfolio Access Tokens](../concepts/multi-property.md).
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/rates/updateCapacityOffset`
+
+```javascript
+{
+  "CapacityOffsetUpdates": [
+    {
+      "RateId": "ed4b660b-19d0-434b-9360-a4de2ea42eda",
+      "NegativeOccupancyAdjustment": {
+        "Value": 10
+      },
+      "ExtraOccupancyAdjustment": {
+        "Value": 20
+      }
+    },
+    {
+      "RateId": "b7e6a1c2-4f3a-4e2b-9c1d-2a5e7b8c9d0f",
+      "ExtraOccupancyAdjustment": {
+        "Value": 15
+      }
+    }
+  ]
+}
+```
+
+Parameters for updating rate capacity offsets in an enterprise.
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
+| `EnterpriseId` | string | optional | Unique identifier of the enterprise. Required when using [Portfolio Access Tokens](../concepts/multi-property.md), ignored otherwise. |
+| `CapacityOffsetUpdates` | array of [RateCapacityOffsetUpdateParameters](rates.md#ratecapacityoffsetupdateparameters) | required, max 1000 items | A list of rate capacity offset updates to apply. |
+
+#### RateCapacityOffsetUpdateParameters
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `RateId` | string | required | The unique identifier of the `Rate` to update. |
+| `NegativeOccupancyAdjustment` | [Decimal update value](rates.md#decimal-update-value) | optional | Amount added to the price when occupancy is less than the Space Category Capacity. Use a negative value to provide a discount for under-occupancy. Set to 'null' if not updated. |
+| `ExtraOccupancyAdjustment` | [Decimal update value](rates.md#decimal-update-value) | optional | Amount added to the price when the Space Category Capacity is exceeded. |
+
+#### Decimal update value
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Value` | number | required | Value which is to be updated. |
 
 ### Response
 

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -28,6 +28,12 @@ Returns all reservations within scope of the Access Token, filtered according to
   "AccountIds": [
     "fadd5bb6-b428-45d5-94f8-fd0d89fece6d"
   ],
+  "PartnerCompanyIds": [
+    "c021013e-4930-4592-8e32-91b0b1fc9663"
+  ],
+  "TravelAgencyIds": [
+    "a793d381-65a2-4fa6-9514-00c4c5bfe607"
+  ],
   "Numbers": [
     "50",
     "51",
@@ -86,6 +92,8 @@ Returns all reservations within scope of the Access Token, filtered according to
 | `ServiceIds` | array of string | optional, max 1000 items | Unique identifiers of the [Services](services.md#service). If not provided, all bookable services are used. |
 | `ReservationGroupIds` | array of string | optional, max 1000 items | Unique identifiers of [Reservation groups](reservations.md#reservation-group). |
 | `AccountIds` | array of string | optional, max 1000 items | Unique identifiers of accounts (currently only [Customers](customers.md#customer), in the future also [Companies](companies.md#company)) the reservation is associated with. |
+| `PartnerCompanyIds` | array of string | optional, max 100 items | Unique identifiers of the `Companies` on behalf of which the reservations were made. |
+| `TravelAgencyIds` | array of string | optional, max 100 items | Identifier of the Travel Agencies (`Company`) that mediated the reservations. |
 | `Numbers` | array of string | optional, max 1000 items | Reservation confirmation numbers. |
 | `ChannelNumbers` | array of string | optional, max 100 items | Numbers or references used by a Channel (OTA, GDS, CRS, etc.) in case the reservation group originates there, e.g. Booking.com confirmation numbers. |
 | `AssignedResourceIds` | array of string | optional, max 1000 items | Unique identifiers of the [Resources](resources.md#resource) assigned to the reservations. |
@@ -118,8 +126,8 @@ Returns all reservations within scope of the Access Token, filtered according to
       "Origin": "Connector",
       "CommanderOrigin": null,
       "OriginDetails": null,
-      "CreatedUtc": "2023-04-23T14:00:00Z",
-      "UpdatedUtc": "2023-04-23T14:00:00Z",
+      "CreatedUtc": "2023-03-23T16:00:00Z",
+      "UpdatedUtc": "2023-04-22T17:00:00Z",
       "CancelledUtc": null,
       "VoucherId": null,
       "BusinessSegmentId": null,
@@ -135,18 +143,18 @@ Returns all reservations within scope of the Access Token, filtered according to
       "RequestedResourceCategoryId": "773d5e42-de1e-43a0-9ce6-f940faf2303f",
       "AssignedResourceId": "20e00c32-d561-4008-8609-82d8aa525714",
       "AvailabilityBlockId": "5ee074b1-6c86-48e8-915f-c7aa4702086f",
-      "PartnerCompanyId": null,
-      "TravelAgencyId": null,
+      "PartnerCompanyId": "c021013e-4930-4592-8e32-91b0b1fc9663",
+      "TravelAgencyId": "a793d381-65a2-4fa6-9514-00c4c5bfe607",
       "AssignedResourceLocked": false,
       "ChannelNumber": "TW48ZP",
       "ChannelManagerNumber": "",
       "CancellationReason": null,
       "ReleasedUtc": null,
       "StartUtc": "2023-04-23T14:00:00Z",
-      "EndUtc": "2023-04-23T14:00:00Z",
+      "EndUtc": "2023-04-25T12:00:00Z",
       "ScheduledStartUtc": "2023-04-23T14:00:00Z",
       "ActualStartUtc": null,
-      "ScheduledEndUtc": null,
+      "ScheduledEndUtc": "2023-04-25T12:00:00Z",
       "ActualEndUtc": null,
       "Purpose": "Leisure",
       "QrCodeData": null,
@@ -700,7 +708,8 @@ Returns channel manager-related details for the specified reservations. Note thi
       "RequestedRateCode": "XyZ123AbC789",
       "ChannelManagerName": "HotelConnect",
       "ChannelNumber": "HC1234",
-      "ChannelManagerNumber": "9E5F7BC3B6F0102",
+      "ChannelManagerGroupNumber": "9E5F7BC3B6F0102",
+      "ChannelManagerNumber": "1",
       "CreatedUtc": "2025-03-10T15:30:00Z"
     },
     {
@@ -708,7 +717,8 @@ Returns channel manager-related details for the specified reservations. Note thi
       "RequestedRateCode": "LmN456OpQ012",
       "ChannelManagerName": "GlobalRes",
       "ChannelNumber": "GR5678",
-      "ChannelManagerNumber": "461190401CD25FE",
+      "ChannelManagerGroupNumber": "461190401CD25FE",
+      "ChannelManagerNumber": "1",
       "CreatedUtc": "2025-03-11T09:45:00Z"
     }
   ]
@@ -727,6 +737,7 @@ Returns channel manager-related details for the specified reservations. Note thi
 | `RequestedRateCode` | string | required | Rate code requested by the channel manager for this reservation. |
 | `ChannelManagerName` | string | optional | Name of the Channel Manager associated with this reservation. |
 | `ChannelNumber` | string | optional | Number of the reservation within the Channel (i.e. OTA, GDS, CRS, etc) in case the reservation group originates there (e.g. Booking.com confirmation number). |
+| `ChannelManagerGroupNumber` | string | optional | Number of the reservation group within a Channel Manager. |
 | `ChannelManagerNumber` | string | optional | Unique number of the reservation within the reservation group. |
 | `CreatedUtc` | string | required | The timestamp when the Channel Manager reservation was created. |
 

--- a/operations/resourceblocks.md
+++ b/operations/resourceblocks.md
@@ -77,6 +77,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "StartUtc": "2016-01-01T10:00:00Z",
             "Type": "InternalUse",
             "UpdatedUtc": "2016-03-29T22:02:34Z",
+            "DeletedUtc": null,
             "Name": "Resource block 1",
             "Notes": "Note"
         },
@@ -85,10 +86,11 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
             "CreatedUtc": "2016-03-29T15:14:06Z",
             "EndUtc": "2016-01-01T16:00:00Z",
             "Id": "4d98ad40-a726-409e-8bf3-2c12ff3c0331",
-            "IsActive": true,
+            "IsActive": false,
             "StartUtc": "2016-01-01T10:00:00Z",
             "Type": "OutOfOrder",
             "UpdatedUtc": "2016-03-29T15:14:06Z",
+            "DeletedUtc": "2016-02-01T16:00:00Z",
             "Name": "Resource block 2",
             "Notes": null
         }
@@ -112,6 +114,7 @@ Note this operation uses [Pagination](../guidelines/pagination.md) and supports 
 | `EndUtc` | string | required | End of the block in UTC timezone in ISO 8601 format. |
 | `CreatedUtc` | string | required | Creation date and time of the block in UTC timezone in ISO 8601 format. |
 | `UpdatedUtc` | string | required | Last update date and time of the block in UTC timezone in ISO 8601 format. |
+| `DeletedUtc` | string | optional | Date and time when the block was deleted (for inactive ones) in UTC timezone in ISO 8601 format. |
 | `Name` | string | required | Name of the resource block. |
 | `Notes` | string | optional | Note describing the resource block. |
 


### PR DESCRIPTION
### Summary

Breaking changes that we need to discuss regarding extension of order items data with allowances data.

Added 2 new order item types for allowances (`AllowanceLoss`, `AllowanceContraLoss`).
Added 5 new values for discriminator of order item data related to allowances ( `AllowanceDiscount`, `AllowanceBreakage` , `AllowanceContraBreakage`, `AllowanceLoss`, `AllowanceContraLoss`).
Added 5 new dto's used for the new order item data discriminators.

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
