### PR TITLE
CON-6193: Add TravelAgencyIds and CompanyIds req parameters

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 16th June 2025
+* [Get all reservations (ver 2023-06-06)](../operations/reservations.md#get-all-reservations-ver-2023-06-06):
+  * Extended request object with `PartnerCompanyIds` and `TravelAgencyIds` filtering parameters.
+
 ## 13th June 2025
 * [Get all identity documents](../operations/identitydocuments.md#get-all-identity-documents):
   * **Change in behavior**: The identity document `Number` property is an empty string when the number is not collected in certain regions, such as The Netherlands.

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -28,6 +28,12 @@ Returns all reservations within scope of the Access Token, filtered according to
   "AccountIds": [
     "fadd5bb6-b428-45d5-94f8-fd0d89fece6d"
   ],
+  "PartnerCompanyIds": [
+    "c021013e-4930-4592-8e32-91b0b1fc9663"
+  ],
+  "TravelAgencyIds": [
+    "a793d381-65a2-4fa6-9514-00c4c5bfe607"
+  ],
   "Numbers": [
     "50",
     "51",
@@ -120,8 +126,8 @@ Returns all reservations within scope of the Access Token, filtered according to
       "Origin": "Connector",
       "CommanderOrigin": null,
       "OriginDetails": null,
-      "CreatedUtc": "2023-04-23T14:00:00Z",
-      "UpdatedUtc": "2023-04-23T14:00:00Z",
+      "CreatedUtc": "2023-03-23T16:00:00Z",
+      "UpdatedUtc": "2023-04-22T17:00:00Z",
       "CancelledUtc": null,
       "VoucherId": null,
       "BusinessSegmentId": null,
@@ -137,18 +143,18 @@ Returns all reservations within scope of the Access Token, filtered according to
       "RequestedResourceCategoryId": "773d5e42-de1e-43a0-9ce6-f940faf2303f",
       "AssignedResourceId": "20e00c32-d561-4008-8609-82d8aa525714",
       "AvailabilityBlockId": "5ee074b1-6c86-48e8-915f-c7aa4702086f",
-      "PartnerCompanyId": null,
-      "TravelAgencyId": null,
+      "PartnerCompanyId": "c021013e-4930-4592-8e32-91b0b1fc9663",
+      "TravelAgencyId": "a793d381-65a2-4fa6-9514-00c4c5bfe607",
       "AssignedResourceLocked": false,
       "ChannelNumber": "TW48ZP",
       "ChannelManagerNumber": "",
       "CancellationReason": null,
       "ReleasedUtc": null,
       "StartUtc": "2023-04-23T14:00:00Z",
-      "EndUtc": "2023-04-23T14:00:00Z",
+      "EndUtc": "2023-04-25T12:00:00Z",
       "ScheduledStartUtc": "2023-04-23T14:00:00Z",
       "ActualStartUtc": null,
-      "ScheduledEndUtc": null,
+      "ScheduledEndUtc": "2023-04-25T12:00:00Z",
       "ActualEndUtc": null,
       "Purpose": "Leisure",
       "QrCodeData": null,

--- a/operations/reservations.md
+++ b/operations/reservations.md
@@ -86,6 +86,8 @@ Returns all reservations within scope of the Access Token, filtered according to
 | `ServiceIds` | array of string | optional, max 1000 items | Unique identifiers of the [Services](services.md#service). If not provided, all bookable services are used. |
 | `ReservationGroupIds` | array of string | optional, max 1000 items | Unique identifiers of [Reservation groups](reservations.md#reservation-group). |
 | `AccountIds` | array of string | optional, max 1000 items | Unique identifiers of accounts (currently only [Customers](customers.md#customer), in the future also [Companies](companies.md#company)) the reservation is associated with. |
+| `PartnerCompanyIds` | array of string | optional, max 100 items | Unique identifiers of the `Companies` on behalf of which the reservations were made. |
+| `TravelAgencyIds` | array of string | optional, max 100 items | Identifier of the Travel Agencies (`Company`) that mediated the reservations. |
 | `Numbers` | array of string | optional, max 1000 items | Reservation confirmation numbers. |
 | `ChannelNumbers` | array of string | optional, max 100 items | Numbers or references used by a Channel (OTA, GDS, CRS, etc.) in case the reservation group originates there, e.g. Booking.com confirmation numbers. |
 | `AssignedResourceIds` | array of string | optional, max 1000 items | Unique identifiers of the [Resources](resources.md#resource) assigned to the reservations. |


### PR DESCRIPTION
### Summary

Add TravelAgencyIds and CompanyIds req parameters to Get all reservations.
 
### Checklist

- [x] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [x] JSON examples updated
- [x] Properties in JSON examples are in the same order as in property tables
- [x] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
