### PR TITLE
Order items extended with allowances data

### DIFF
--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -1916,3 +1916,15 @@ types:
   decimalupdatevalue:
     file: _objects.md
     anchor: decimal-update-value
+  producttypeenum:
+    file: orderitems.md
+    anchor: product-type
+  orderitemallowancediscountdata:
+    file: orderitems.md
+    anchor: allowance-discount-data
+  orderitemallowanceprofitsdata:
+    file: orderitems.md
+    anchor: allowance-profits-data
+  allowanceprofittypeenum:
+    file: orderitems.md
+    anchor: allowance-profit-type

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 27th June 2025
+* [Get all orderitems](../operations/orderitems.md#get-all-order-items):
+    * Extended [Order item data](../operations/orderitems#order-item-data) response object with `allowances` order items data.
+
 ## 20th June 2025
 * [Get all resource blocks](../operations/resourceblocks.md#resource-block):
   * Extended response object to include `DeletedUtc` field.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## 1st July 2025
-* [Get all orderitems](../operations/orderitems.md#get-all-order-items):
-    * Extended [Order item data](../operations/orderitems#order-item-data) response object with `allowances` order items data.
+* [Get all order items](../operations/orderitems.md#get-all-order-items):
+    * Extended [Order item data](../operations/orderitems#order-item-data) response object with `AllowanceDiscount` and `AllowanceProfits` fields.
 
 ## 20th June 2025
 * [Get all resource blocks](../operations/resourceblocks.md#resource-block):

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 27th June 2025
+## 1st July 2025
 * [Get all orderitems](../operations/orderitems.md#get-all-order-items):
     * Extended [Order item data](../operations/orderitems#order-item-data) response object with `allowances` order items data.
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -358,8 +358,6 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 * `AllowanceDiscount`
 * `AllowanceBreakage`
 * `AllowanceContraBreakage`
-* `AllowanceLoss`
-* `AllowanceContraLoss`
 
 #### Order item options
 Options of the order item.

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -376,8 +376,8 @@ Additional order item data.
 | `Discriminator` | [Order item data discriminator](orderitems.md#order-item-data-discriminator) | required | Discriminator pointing to the fields within this object that contains additional data. |
 | `Rebate` | [Rebate data](orderitems.md#rebate-data) | optional | Contains additional data in the case of rebate item. |
 | `Product` | [Product data](orderitems.md#product-data) | optional | Contains additional data in the case of product item. |
-| `AllowanceDiscount` | [Allowance Discount Data](orderitems.md#allowance-discount-data) | optional | Contains additional data in the case of allowance discount item. |
-| `AllowanceProfits` | [Allowance Profits Data](orderitems.md#allowance-profits-data) | optional | Contains additional data in the case of allowance profits item. |
+| `AllowanceDiscount` | [Allowance discount data](orderitems.md#allowance-discount-data) | optional | Contains additional data in the case of allowance discount item. |
+| `AllowanceProfits` | [Allowance profits data](orderitems.md#allowance-profits-data) | optional | Contains additional data in the case of allowance profits item. |
 
 #### Order item data discriminator
 
@@ -406,14 +406,14 @@ Additional order item data.
 * `Product`
 * `Allowance`
 
-#### Allowance Discount Data
+#### Allowance discount data
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `DiscountedOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been discounted by current item. |
 | `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
 
-#### Allowance Profits Data
+#### Allowance profits data
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -358,6 +358,8 @@ Returns all order items. At least one of the `OrderItemIds`, `ServiceOrderIds`, 
 * `AllowanceDiscount`
 * `AllowanceBreakage`
 * `AllowanceContraBreakage`
+* `AllowanceLoss`
+* `AllowanceContraLoss`
 
 #### Order item options
 Options of the order item.
@@ -374,11 +376,15 @@ Additional order item data.
 | `Discriminator` | [Order item data discriminator](orderitems.md#order-item-data-discriminator) | required | Discriminator pointing to the fields within this object that contains additional data. |
 | `Rebate` | [Rebate data](orderitems.md#rebate-data) | optional | Contains additional data in the case of rebate item. |
 | `Product` | [Product data](orderitems.md#product-data) | optional | Contains additional data in the case of product item. |
+| `AllowanceDiscount` | [Allowance Discount Data](orderitems.md#allowance-discount-data) | optional | Contains additional data in the case of allowance discount item. |
+| `AllowanceProfits` | [Allowance Profits Data](orderitems.md#allowance-profits-data) | optional | Contains additional data in the case of allowance profits item. |
 
 #### Order item data discriminator
 
-* `Rebate`
-* `Product`
+* `Rebate` - Rebate.
+* `Product` - Product.
+* `AllowanceDiscount` - Allowance discount.
+* `AllowanceProfits` - Allowance profits.
 
 #### Rebate data
 
@@ -393,6 +399,33 @@ Additional order item data.
 | :-- | :-- | :-- | :-- |
 | `ProductId` | string | required | Unique identifier of the [Product](products.md#product). |
 | `AgeCategoryId` | string | optional | Unique identifier of the [Age Category](agecategories.md#age-category). |
+| `ProductType` | [Product type](orderitems.md#product-type) | required | Type of Product, e.g. whether allowance or product. |
+
+#### Product type
+
+* `Product`
+* `Allowance`
+
+#### Allowance Discount Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `DiscountedOrderItemId` | string | required | Unique identifier of [Order item](orderitems.md#order-item) which has been discounted by current item. |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+
+#### Allowance Profits Data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `AllowanceProductOrderItemId` | string | required | Unique identifier of the allowance product [Order item](orderitems.md#order-item) which credit has been consumed by current item. |
+| `AllowanceProfitType` | [Allowance profit type](orderitems.md#allowance-profit-type) | required | Type of allowance profit. |
+
+#### Allowance profit type
+
+* `AllowanceBreakage` - Profit of the allowance product.
+* `AllowanceContraBreakage` - Accounting balance for profit of the allowance product.
+* `AllowanceLoss` - Loss of the allowance product.
+* `AllowanceContraLoss` - Accounting balance for loss of the allowance product.
 
 #### Tax exemption reason type
 

--- a/operations/orderitems.md
+++ b/operations/orderitems.md
@@ -399,7 +399,7 @@ Additional order item data.
 | :-- | :-- | :-- | :-- |
 | `ProductId` | string | required | Unique identifier of the [Product](products.md#product). |
 | `AgeCategoryId` | string | optional | Unique identifier of the [Age Category](agecategories.md#age-category). |
-| `ProductType` | [Product type](orderitems.md#product-type) | required | Type of Product, e.g. whether allowance or product. |
+| `ProductType` | [Product type](orderitems.md#product-type) | optional | Type of Product, e.g. whether allowance or product. |
 
 #### Product type
 


### PR DESCRIPTION
### Summary

Breaking changes that we need to discuss regarding extension of order items data with allowances data.

Added 2 new order item types for allowances (AllowanceLoss, AllowanceContraLoss).
Added 2 new values for discriminator of order item data related to allowances (AllowanceDiscount, AllowanceProfits).
Added 2 new dto's used for the new order item data discriminators.
Added enum for profits (AllowanceContraBreakage, AllowanceLoss, AllowanceContraLoss).

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
