### PR TITLE
CON-7483: Generate docs for polymorphic requests

### DIFF
--- a/_generator/collect-jsonschema.js
+++ b/_generator/collect-jsonschema.js
@@ -27,11 +27,12 @@ export function collectJsonSchema(jsonSchema, path, accumulator) {
   jsonSchema['x-schema-paths'].push(path);
 
   if (jsonSchema.oneOf?.length > 1) {
-    adjustOneOfRootSchema(jsonSchema);
+    jsonSchema['x-oneOfRoot'] = true;
     const surrogateSchemaId = path.join('-');
     accumulator.add(surrogateSchemaId, jsonSchema);
   }
-  const composedSchemas = pickComposedSchema(jsonSchema);
+  const composedSchemas =
+    jsonSchema.anyOf || jsonSchema.oneOf || jsonSchema.allOf;
   for (const item of composedSchemas) {
     collectSchemas(item, nestedPath, accumulator);
   }

--- a/_generator/collect-jsonschema.js
+++ b/_generator/collect-jsonschema.js
@@ -1,0 +1,44 @@
+import { getSchemaId, hasProperties, log } from './utils.js';
+import { pickComposedSchema } from './jsonschema.js';
+import { collectSchemas } from './collect-schemas.js';
+
+/**
+ * @typedef { import('oas/operation').Operation } Operation
+ * @typedef { import('openapi-types').OpenAPIV3.SchemaObject } SchemaObject
+ * @typedef { import('openapi-types').OpenAPIV3.ResponseObject } ResponseObject
+ * @typedef { import('openapi-types').OpenAPIV3.Document } OASDocument
+ * @typedef { import('oas').default } Oas
+ * @typedef { import('./types.js').TemplateSchema } TemplateSchema
+ * @typedef { import('./types.js').TemplateProperty } TemplateProperty
+ * @typedef { import('./types.js').TemplateEnumEntry } TemplateEnumEntry
+ * @typedef { import('./types-resolver.js').SchemasAccumulator } SchemasAccumulator
+ */
+
+/**
+ * Traverse JSON schema, collect all nested schemas
+ * @param {SchemaObject} jsonSchema
+ * @param {string[]} path
+ * @param {SchemasAccumulator} accumulator
+ * @returns {SchemasAccumulator}
+ **/
+export function collectJsonSchema(jsonSchema, path, accumulator) {
+  const nestedPath = [...path];
+  jsonSchema['x-schema-paths'] ??= [];
+  jsonSchema['x-schema-paths'].push(path);
+
+  if (jsonSchema.oneOf?.length > 1) {
+    adjustOneOfRootSchema(jsonSchema);
+    const surrogateSchemaId = path.join('-');
+    accumulator.add(surrogateSchemaId, jsonSchema);
+  }
+  const composedSchemas = pickComposedSchema(jsonSchema);
+  for (const item of composedSchemas) {
+    collectSchemas(item, nestedPath, accumulator);
+  }
+  return accumulator;
+}
+
+function adjustOneOfRootSchema(schema) {
+  schema.description =
+    'The following schemas are mutually exclusive. Only one of them can be used at a time.';
+}

--- a/_generator/collect-jsonschema.js
+++ b/_generator/collect-jsonschema.js
@@ -38,8 +38,3 @@ export function collectJsonSchema(jsonSchema, path, accumulator) {
   }
   return accumulator;
 }
-
-function adjustOneOfRootSchema(schema) {
-  schema.description =
-    'The following schemas are mutually exclusive. Only one of them can be used at a time.';
-}

--- a/_generator/collect-schemas.js
+++ b/_generator/collect-schemas.js
@@ -12,6 +12,12 @@ import { getSchemaId, hasProperties, log } from './utils.js';
  * @typedef { import('./types-resolver.js').SchemasAccumulator } SchemasAccumulator
  */
 
+const knownSchemaWithoutProperties = new Set([
+  'unit',
+  'hybrididentifier',
+  'localizedstrings',
+]);
+
 /**
  * Traverse schema, collect all nested schemas
  * @param {SchemaObject} schema
@@ -31,7 +37,7 @@ export function collectSchemas(schema, path, accumulator) {
     nestedPath.push(schemaId);
   }
 
-  if (schemaId && !include) {
+  if (schemaId && !include && !knownSchemaWithoutProperties.has(schemaId)) {
     log.warn('Skipping schema without properties:', schemaId);
   }
 

--- a/_generator/index.js
+++ b/_generator/index.js
@@ -17,7 +17,7 @@ import { loadDiscoveredTypes, saveDiscoveredTypes } from './types-resolver.js';
 
 const config = loadConfig();
 
-const oasNormalizer = new OASNormalize(config.oasPath);
+const oasNormalizer = new OASNormalize(config.oasPath, { enablePaths: true });
 await oasNormalizer.validate();
 const oasDefinition = await oasNormalizer.convert();
 const oasWrapper = new Oas(oasDefinition);

--- a/_generator/jsonschema.js
+++ b/_generator/jsonschema.js
@@ -22,7 +22,7 @@ function pickSingularComposedSchema(schema) {
   }
 }
 
-function pickComposedSchema(schema) {
+export function pickComposedSchema(schema) {
   return schema.anyOf || schema.oneOf || schema.allOf;
 }
 

--- a/_generator/page.js
+++ b/_generator/page.js
@@ -130,7 +130,7 @@ function prepareTemplateData(tagName, oasOperations, pageContext) {
         operation.getResponseByStatusCode(200).content['application/json'];
       const responseExample = response.example || {};
       const responseSchemas = collectSchemas(
-        response,
+        response.schema,
         [operationId, 'response'],
         resolver.createSectionSchemasAccumulator()
       );

--- a/_generator/template-schema.js
+++ b/_generator/template-schema.js
@@ -4,7 +4,7 @@ import {
   propertyDescription,
   propertyType,
 } from './jsonschema.js';
-import { getSchemaId, capitalize } from './utils.js';
+import { getSchemaId, capitalize, log } from './utils.js';
 import { compareProperties } from './sorting/propertySort.js';
 
 /**
@@ -112,6 +112,13 @@ export function createTemplateSchema(schema) {
   }
   const description = schema.description?.trim() ?? '';
   const deprecatedMessage = schema.deprecatedMessage ?? '';
+
+  let title = schema.title;
+  if (!title) {
+    log.error(`Schema "${schemaId}" is missing title`, schema);
+    title = schemaId;
+  }
+
   const templateSchema = {
     path: [...path],
     id: schemaId,

--- a/_generator/template-schema.js
+++ b/_generator/template-schema.js
@@ -120,6 +120,7 @@ export function createTemplateSchema(schema) {
     deprecatedMessage,
     enum: schema.enum,
     deprecated: schema.deprecated ?? false,
+    oneOfRoot: schema['x-oneOfRoot'] ?? false,
     properties,
     ...baseObject,
   };

--- a/_generator/templates/parameters.edge
+++ b/_generator/templates/parameters.edge
@@ -3,7 +3,7 @@
 @end
 {{{ schema.description }}}
 @if(schema.oneOfRoot)
-The operation supports the following mutually exclusive parameters.
+This operation accepts one of the following mutually exclusive parameter sets.
 @end
 
 @if(schema.properties)

--- a/_generator/templates/parameters.edge
+++ b/_generator/templates/parameters.edge
@@ -3,7 +3,7 @@
 @end
 {{{ schema.description }}}
 @if(schema.oneOfRoot)
-The operation supports the following mutually exclusive parameters. Only one of them can be used at a time.
+The operation supports the following mutually exclusive parameters.
 @end
 
 @if(schema.properties)

--- a/_generator/templates/parameters.edge
+++ b/_generator/templates/parameters.edge
@@ -2,6 +2,9 @@
 #### {{ schema.title }}{{-- {#{{ schemaId }}} --}}
 @end
 {{{ schema.description }}}
+@if(schema.oneOfRoot)
+The operation supports the following mutually exclusive parameters. Only one of them can be used at a time.
+@end
 
 @if(schema.properties)
 | Property | Type | Contract | Description |

--- a/_generator/types.d.ts
+++ b/_generator/types.d.ts
@@ -7,6 +7,7 @@ export type TemplateSchema = {
   deprecated: boolean;
   deprecatedMessage: string;
   properties?: TemplateProperty[];
+  oneOfRoot?: boolean;
 };
 
 export type TemplateOperation = {

--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -1958,3 +1958,33 @@ types:
   allowanceprofittypeenum:
     file: orderitems.md
     anchor: allowance-profit-type
+  fiscalMachineCommands_getAll-request:
+    file: commands.md
+    anchor: get-all-commands-filter-parameters
+  commandsgetallfilterbycommandidparameters:
+    file: commands.md
+    anchor: get-all-commands-by-unique-identifiers
+  commandsgetallfilterbystatesparameters:
+    file: commands.md
+    anchor: get-all-commands-by-device-identifiers-and-states
+  fiscalmachinecommanddatav20250623result:
+    file: commands.md
+    anchor: fiscalmachinecommanddatav20250623result
+  fiscalmachinecommanddatav20250623:
+    file: commands.md
+    anchor: fiscal-machine-command-data-ver-2025-06-23
+  billv20250623:
+    file: commands.md
+    anchor: bill-ver-2025-06-23
+  fiscalmachineadditionaldata:
+    file: commands.md
+    anchor: fiscalmachineadditionaldata
+  fiscalmachinedatadiscriminatorenum:
+    file: commands.md
+    anchor: fiscal-machine-data-discriminator
+  italianfiscalmachinedatav20250623:
+    file: commands.md
+    anchor: italian-fiscal-machine-data
+  italianfiscalmachinepayloadv20250623:
+    file: commands.md
+    anchor: italian-fiscal-machine-payload

--- a/operations/commands.md
+++ b/operations/commands.md
@@ -1,6 +1,136 @@
 <!-- AUTOMATICALLY GENERATED, DO NOT MODIFY -->
 # Commands
 
+## Get all fiscal machine commands
+
+> ### Restricted!
+> This operation is currently in beta-test and as such it is subject to change.
+
+Returns fiscal machine commands. The commands can be filtered either by unique command identifiers, or by `Device` unique identifiers and command states. Note this operation supports [Portfolio Access Tokens](../concepts/multi-property.md).
+
+### Request
+
+`[PlatformAddress]/api/connector/v1/fiscalMachineCommands/getAll`
+
+```javascript
+{}
+```
+
+The operation supports the following mutually exclusive parameters.
+
+#### Get all commands by unique identifiers
+Filter commands by their unique identifiers.
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
+| `CommandIds` | array of string | required, max 1000 items |  |
+| `EnterpriseIds` | array,null | required, max 1000 items | Unique identifiers of the Enterprises. If not specified, the operation returns data for all enterprises within scope of the Access Token. |
+| `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
+
+#### Get all commands by device identifiers and states
+Filter commands by the unique identifiers of `Device` and states, with optional filtering by their update interval.
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `ClientToken` | string | required | Token identifying the client application. |
+| `AccessToken` | string | required | Access token of the client application. |
+| `Client` | string | required | Name and version of the client application. |
+| `DeviceIds` | array of string | required, max 100 items |  |
+| `States` | array of [Command state](commands.md#command-state) | required |  |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | required, max length 3 months |  |
+| `EnterpriseIds` | array,null | required, max 1000 items | Unique identifiers of the Enterprises. If not specified, the operation returns data for all enterprises within scope of the Access Token. |
+| `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned. |
+
+### Response
+
+```javascript
+{}
+```
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Commands` | array of [Fiscal machine command data (ver. 2025-06-23)](commands.md#fiscal-machine-command-data-ver-2025-06-23) | optional |  |
+| `Cursor` | string | optional |  |
+
+#### Fiscal machine command data (ver. 2025-06-23)
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Id` | string | required | Unique identifier of the command. |
+| `State` | [Command state](commands.md#command-state) | required | State of the command. |
+| `CreatedUtc` | string | required | Creation date and time of the command. |
+| `Creator` | [Profile data](_objects.md#profile-data) | optional | Creator of the command. |
+| `FiscalMachineId` | string | required | Identifier of the fiscal machine. |
+| `ApiUrl` | string | required | URL of the fiscal machine API. |
+| `FiscalMachineData` | string | required | Custom JSON data. |
+| `TaxIdentifier` | string | optional | Tax identifier to be used for fiscalization. |
+| `Device` | [Device](devices.md#device) | required | Device that the command should be executed on. |
+| `Bill` | [Bill (ver 2025-06-23)](commands.md#bill-ver-2025-06-23) | required | The issued bill that should be fiscalized. |
+| `CommandData` | [FiscalMachineAdditionalData](commands.md#fiscalmachineadditionaldata) | optional | Additional data of the fiscal machine. |
+
+#### Bill (ver 2025-06-23)
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Id` | string | required | Unique identifier of the bill. |
+| `Name` | string | optional | Name of the bill. |
+| `EnterpriseId` | string | required | Unique identifier of the `Enterprise`. |
+| `AccountId` | string | required | Unique identifier of the account (`Customer` or `Company`) the bill is issued to. |
+| `AssociatedAccountIds` | array of string | optional | Unique identifiers of the `Customers` or `Companies` that are associated to the bill. |
+| `CounterId` | string | optional | Unique identifier of the bill `Counter`. |
+| `State` | [Bill state](bills.md#bill-state) | required | Whether the bill is `Open` or `Closed`. |
+| `Type` | [Bill type](bills.md#bill-type) | required | After a bill is closed, the Bill Type is set to `Receipt` or `Invoice`. `Receipt` indicates that the bill has been fully paid and the balance is zero. `Invoice` indicates that the bill has not yet been fully paid but an invoice has been issued. Prior to closing, Bill Type should not be used. |
+| `Number` | string | optional | Number of the bill. |
+| `VariableSymbol` | string | optional | Variable symbol of the bill. |
+| `CreatedUtc` | string | required | Date and time of the bill creation in UTC timezone in ISO 8601 format. |
+| `UpdatedUtc` | string | required | Date and time when the bill was last updated, in UTC timezone in ISO 8601 format. |
+| `IssuedUtc` | string | optional | Date and time of the bill issuance in UTC timezone in ISO 8601 format. |
+| `TaxedUtc` | string | optional | Taxation date of the bill in UTC timezone in ISO 8601 format. |
+| `PaidUtc` | string | optional | Date when the bill was paid in UTC timezone in ISO 8601 format. |
+| `DueUtc` | string | optional | Bill due date and time in UTC timezone in ISO 8601 format. |
+| `LastReminderDateUtc` | string | optional | Date and time when an email reminder to pay an invoice was last sent, in UTC timezone in ISO 8601 format. |
+| `PurchaseOrderNumber` | string | optional | Unique number of the purchase order from the buyer. |
+| `Notes` | string | optional | Additional notes. |
+| `Options` | [Bill options](bills.md#bill-options) | optional | Options of the bill. |
+| `Owner` | [Associated account bill data](bills.md#associated-account-bill-data) | optional | Additional information about owner of the bill. Can be a `Customer` or `Company`. Persisted at the time of closing of the bill. |
+| `AssociatedAccountsData` | array of [Associated account bill data](bills.md#associated-account-bill-data) | optional | Additional information about the associated account of the bill. Can be a `Customer` or `Company`. Persisted at the time of closing of the bill. Currently only one account can be associated with a bill, but this may be extended in future. |
+| `EnterpriseData` | [Bill enterprise data](bills.md#bill-enterprise-data) | optional | Additional information about the enterprise issuing the bill, including bank account details. Persisted at the time of closing of the bill. |
+| `CorrectionState` | [Bill correction state](bills.md#bill-correction-state) | required | Whether the bill is a regular bill or a corrective bill. |
+| `CorrectionType` | [Bill correction type](bills.md#bill-correction-type) | optional | Type of correction. |
+| `CorrectedBillId` | string | optional | The ID of the bill that the corrective bill corrects. If the corrected bill was deleted, this field is `null`. |
+
+#### FiscalMachineAdditionalData
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Discriminator` | [Fiscal machine data discriminator](commands.md#fiscal-machine-data-discriminator) | optional | Type of additional data for Italian fiscal machine. |
+| `ItalianFiscalMachineData` | [Italian fiscal machine data](commands.md#italian-fiscal-machine-data) | optional | Fiscal machine data for Italian fiscal machine. |
+| `ItalianFiscalMachinePayload` | [Italian fiscal machine payload.](commands.md#italian-fiscal-machine-payload) | optional | Fiscal machine payload for Italian fiscal machine. |
+
+#### Fiscal machine data discriminator
+
+* `ItalianFiscalMachineData`
+* `ItalianFiscalMachinePayload`
+
+#### Italian fiscal machine data
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `IsRefund` | boolean | required | Indicates if the transaction is a refund. |
+| `RebatedReceiptNumber` | string | optional | Number of the rebated receipt. |
+| `RebatedReceiptSequence` | string | optional | Sequence of the rebated receipt. |
+| `RebatedReceiptDateTimeUtc` | string | optional | Date and time of the rebated receipt in UTC. |
+| `PrinterSerialNumber` | string | optional | Serial number of the printer. |
+
+#### Italian fiscal machine payload.
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `Payload` | string | required | Base64-encoded data of the file to be printed. |
+
 ## Get all commands by ids
 
 Returns all commands by their identifiers.


### PR DESCRIPTION
### Summary

Add support for polymorphic request body into generator. Also regenerated `commands.md` to show how it works with `fiscalMachineCommands/getAll`, but the docs here are incomplete (missing examples) – I will tackle that in a stacked PR, where I will also update the changelog.

Implementation-wise, I decided to create a separate method for handling request body with `oneOf` to avoid regressions, so this is currently treated as a special case.

The phrase "The operation supports the following mutually exclusive parameters." is hard-coded in the template. I tried to pass the description via OAS into the parent abstract class, but it replaced the descriptions' of derived concrete classes.

### Checklist

- [x] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
