### PR TITLE
CON-8032 Add providerMembershipId to loyaltyMembership/update endpoint

### DIFF
--- a/operations/loyaltymemberships.md
+++ b/operations/loyaltymemberships.md
@@ -277,7 +277,7 @@ Updates information about the specified loyalty memberships. Note this operation
 | `State` | [Loyalty membership state update value](loyaltymemberships.md#loyalty-membership-state-update-value) | optional | State of the loyalty membership, (or `null` if the state should not be updated). |
 | `IsPrimary` | [Bool update value](_objects.md#bool-update-value) | optional | Boolean value defining the primary loyalty membership for the account (or `null` if the value should not be updated). |
 | `Code` | [String update value](_objects.md#string-update-value) | optional | Code of the loyalty membership. (or `null` if the code should not be updated). |
-| `ProviderMembershipId` | [String update value](_objects.md#string-update-value) | optional | Provider-assigned identifier for the loyalty membership. (or `null` if the value should not be updated). |
+| `ProviderMembershipId` | [String update value](_objects.md#string-update-value) | optional, max length 100 characters | Loyalty membership identifier assigned by the external loyalty provider's system (or `null` if the value should not be updated). |
 | `Points` | [Number update value](_objects.md#number-update-value) | optional | The loyalty points the account has in the loyalty membership (or `null` if the points should not be updated). |
 | `ExpirationDate` | [String update value](_objects.md#string-update-value) | optional | Expiration date of the loyalty membership in UTC timezone in ISO 8601 format (or `null` if the date should not be updated). |
 | `Url` | [String update value](_objects.md#string-update-value) | optional | URL of the loyalty membership (or `null` if the URL should not be updated). |


### PR DESCRIPTION
### Summary

https://mews.atlassian.net/browse/CON-8032: Add providerMembershipId to loyaltyMembership/update endpoint

Just regenerated the documentation so the new property in the update method is added to the docs

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
