### PR TITLE
CON-8194: Add PaymentOrigin to payments/getAll

### DIFF
--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -2070,3 +2070,6 @@ types:
   dependenttaxratestrategy:
     file: taxations.md
     anchor: dependent-tax-rate-strategy-data
+  paymentoriginenum:
+    file: payments.md
+    anchor: payment-origin

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12th August 2025
+* [Get all payments](../operations/payments.md#get-all-payments)
+  * Extended [Payment](../operations/payments.md#payment) response object with `PaymentOrigin` property.
+
 ## 5th August 2025
 * [Get all exports](../operations/exports.md#get-all-exports):
   * Export file URLs now expire after 10 minutes and are regenerated with each request.

--- a/operations/payments.md
+++ b/operations/payments.md
@@ -163,7 +163,8 @@ Returns all payments in the system, filtered by various parameters. At least one
         "Invoice": null,
         "External": null,
         "Ghost": null
-      }
+      },
+      "Origin": "Terminal"
     },
     {
       "Id": "be922eb7-bc5f-4877-b847-1120c0c2acd2",
@@ -216,7 +217,8 @@ Returns all payments in the system, filtered by various parameters. At least one
       "Identifier": "",
       "Type": "CashPayment",
       "Kind": "Payment",
-      "Data": null
+      "Data": null,
+      "Origin": "PointOfSales"
     }
   ],
   "Cursor": "be922eb7-bc5f-4877-b847-1120c0c2acd2"
@@ -255,6 +257,7 @@ Returns all payments in the system, filtered by various parameters. At least one
 | `Type` | [Payment type](payments.md#payment-type) | required | Payment type, e.g. whether credit card or cash. |
 | `Kind` | [Payment kind](payments.md#payment-kind) | optional | Payment kind, e.g. whether payment or refund. Value provided only for payments processed by Mews Payments. |
 | `Data` | [Payment data](payments.md#payment-data) | optional | Additional payment data. |
+| `Origin` | [Payment origin](payments.md#payment-origin) | optional | Payment origin indicating how the payment was initiated. |
 
 #### Payment state
 
@@ -391,6 +394,23 @@ Returns all payments in the system, filtered by various parameters. At least one
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `OriginalPaymentId` | string | required | Unique identifier of the original payment. |
+
+#### Payment origin
+
+* `Other` - Fallback value unmapped in the current version of the API.
+* `System`
+* `Operations`
+* `AutomaticPayment`
+* `PaymentRequest`
+* `BookingEngine`
+* `Api` - Connector API.
+* `Terminal`
+* `ChannelManager`
+* `OnlineCheckout`
+* `BillBalancing`
+* `OnlineCheckin`
+* `PointOfSales`
+* `PaymentToInvoiceLinking`
 
 ## Add external payment
 

--- a/operations/payments.md
+++ b/operations/payments.md
@@ -164,7 +164,7 @@ Returns all payments in the system, filtered by various parameters. At least one
         "External": null,
         "Ghost": null
       },
-      "Origin": "Terminal"
+      "PaymentOrigin": "Terminal"
     },
     {
       "Id": "be922eb7-bc5f-4877-b847-1120c0c2acd2",
@@ -218,7 +218,7 @@ Returns all payments in the system, filtered by various parameters. At least one
       "Type": "CashPayment",
       "Kind": "Payment",
       "Data": null,
-      "Origin": "PointOfSales"
+      "PaymentOrigin": "PointOfSales"
     }
   ],
   "Cursor": "be922eb7-bc5f-4877-b847-1120c0c2acd2"
@@ -257,7 +257,7 @@ Returns all payments in the system, filtered by various parameters. At least one
 | `Type` | [Payment type](payments.md#payment-type) | required | Payment type, e.g. whether credit card or cash. |
 | `Kind` | [Payment kind](payments.md#payment-kind) | optional | Payment kind, e.g. whether payment or refund. Value provided only for payments processed by Mews Payments. |
 | `Data` | [Payment data](payments.md#payment-data) | optional | Additional payment data. |
-| `Origin` | [Payment origin](payments.md#payment-origin) | optional | Payment origin indicating how the payment was initiated. |
+| `PaymentOrigin` | [Payment origin](payments.md#payment-origin) | optional | Payment origin indicating how the payment was initiated. |
 
 #### Payment state
 


### PR DESCRIPTION
### Summary

Add PaymentOrigin enum to payments/getAll.

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
