### PR TITLE
CON-2239: Migrate reservation groups to docs generator

### DIFF
--- a/_generator/config.yaml
+++ b/_generator/config.yaml
@@ -51,7 +51,7 @@ tags:
   # - productserviceorders
   - rategroups
   - rates
-  # - reservationgroups
+  - reservationgroups
   - reservations
   # - resourceaccesstokens
   # - resourceblocks

--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -2073,3 +2073,12 @@ types:
   paymentoriginenum:
     file: payments.md
     anchor: payment-origin
+  reservationgroupresult:
+    file: reservationgroups.md
+    anchor: reservationgroupresult
+  reservationgroup:
+    file: reservationgroups.md
+    anchor: reservation-group
+  reservationgroupfilterparameters:
+    file: reservationgroups.md
+    anchor: reservationgroupfilterparameters

--- a/operations/reservationgroups.md
+++ b/operations/reservationgroups.md
@@ -1,3 +1,4 @@
+<!-- AUTOMATICALLY GENERATED, DO NOT MODIFY -->
 # Reservation groups
 
 ## Get all reservation groups
@@ -10,24 +11,24 @@ Returns all reservation groups, filtered by unique identifiers and other filters
 
 ```javascript
 {
-    "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
-    "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
-    "Client": "Sample Client 1.0.0",
-    "EnterpriseIds": [
-        "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        "4d0201db-36f5-428b-8d11-4f0a65e960cc"
-    ],
-    "ReservationGroupIds": [
-        "fe795f96-0b64-445b-89ed-c032563f2bac"
-    ],
-    "UpdatedUtc": {
-        "StartUtc": "2023-04-27T11:48:57Z",
-        "EndUtc": "2023-04-27T11:48:57Z"
-    },
-    "Limitation":{
-        "Cursor": "e7f26210-10e7-462e-9da8-ae8300be8ab7",
-        "Count": 100
-    }
+  "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
+  "AccessToken": "C66EF7B239D24632943D115EDE9CB810-EA00F8FD8294692C940F6B5A8F9453D",
+  "Client": "Sample Client 1.0.0",
+  "EnterpriseIds": [
+    "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "4d0201db-36f5-428b-8d11-4f0a65e960cc"
+  ],
+  "ReservationGroupIds": [
+    "fe795f96-0b64-445b-89ed-c032563f2bac"
+  ],
+  "UpdatedUtc": {
+    "StartUtc": "2023-04-27T11:48:57Z",
+    "EndUtc": "2023-04-27T11:48:57Z"
+  },
+  "Limitation": {
+    "Cursor": "e7f26210-10e7-462e-9da8-ae8300be8ab7",
+    "Count": 100
+  }
 }
 ```
 
@@ -36,39 +37,39 @@ Returns all reservation groups, filtered by unique identifiers and other filters
 | `ClientToken` | string | required | Token identifying the client application. |
 | `AccessToken` | string | required | Access token of the client application. |
 | `Client` | string | required | Name and version of the client application. |
-| `EnterpriseIds` | array of string | optional, max 1000 items | Unique identifiers of the [Enterprises](enterprises.md#enterprise). If not specified, the operation returns data for all enterprises within scope of the Access Token. |
-| `ReservationGroupIds` | array of string | optional, max 1000 items | Unique identifiers of the [Reservation Group](#reservation-group). Required if no other filter is provided. |
-| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the [Reservation Group](#reservation-group) was updated. Required if no other filter is provided. |
-| `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of reservation groups returned. |
+| `EnterpriseIds` | array of string | optional, max 1000 items | Unique identifiers of the Enterprises. If not specified, the operation returns data for all enterprises within scope of the Access Token. |
+| `ReservationGroupIds` | array of string | optional, max 1000 items | Unique identifiers of the `ReservationGroup`. Required if no other filter is provided. |
+| `UpdatedUtc` | [Time interval](_objects.md#time-interval) | optional, max length 3 months | Interval in which the `ReservationGroup` was updated. Required if no other filter is provided. |
+| `Limitation` | [Limitation](../guidelines/pagination.md#limitation) | required | Limitation on the quantity of data returned and optional Cursor for the starting point of data. |
 
 ### Response
 
 ```javascript
 {
-    "ReservationGroups": [
-        {
-            "Id": "769fc613-838f-41a7-ac2a-aff100c3189f",
-            "EnterpriseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "Name": "Mr and Mrs smith wedding",
-            "ChannelManager": "2023-04-27T11:48:57Z",
-            "ChannelManagerGroupNumber": "152fg645-834f-63a7-he6a-vsy845c4753a"
-        }
-    ],
-    "Cursor": "723jd664-235f-36a4-tg6d-gfy850c645f"
+  "ReservationGroups": [
+    {
+      "Id": "769fc613-838f-41a7-ac2a-aff100c3189f",
+      "EnterpriseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "Name": "Mr and Mrs smith wedding",
+      "ChannelManager": "2023-04-27T11:48:57Z",
+      "ChannelManagerGroupNumber": "152fg645-834f-63a7-he6a-vsy845c4753a"
+    }
+  ],
+  "Cursor": "723jd664-235f-36a4-tg6d-gfy850c645f"
 }
 ```
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `ReservationGroups` | array of [Reservation Groups](#reservation-group) | required | The filtered reservation groups. |
-| `Cursor` | string | required | Unique identifier of the last and hence oldest reservation group returned. This can be used in [Limitation](../guidelines/pagination.md#limitation) in a subsequent request to fetch the next batch of older reservation groups. |
+| `ReservationGroups` | array of [Reservation Group](reservationgroups.md#reservation-group) | required, max 1000 items | The filtered reservation groups. |
+| `Cursor` | string | optional | Unique identifier of the last and hence oldest reservation group returned. This can be used in `Limitation` in a subsequent request to fetch the next batch of older reservation groups. |
 
 #### Reservation Group
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `Id` | string | required | Unique identifier of the reservation group. |
-| `EnterpriseId` | string | required | Unique identifier of the [Enterprise](enterprises.md#enterprise) the reservation group belongs to. |
 | `Name` | string | optional | Name of the reservation group, might be empty or same for multiple groups. |
 | `ChannelManager` | string | optional | Name of the corresponding channel manager. |
 | `ChannelManagerGroupNumber` | string | optional | Identifier of the channel manager. |
+| `EnterpriseId` | string | required | Unique identifier of the `Enterprise` the reservation group belongs to. |


### PR DESCRIPTION
### Summary

Only enable and regenerate docs for reservation groups, no changes to the contract.

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
