### PR TITLE
Generate new documentation for AvailabilityBlocks/add endpoint

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 17th September 2025
+* [Add availability blocks](../operations/availabilityblocks.md#add-availability-blocks):
+  * Extended [Availability block parameters](../operations/availabilityblocks.md#availability-block-parameters) request object with `PickupDistribution` parameter.
+
 ## 15th September 2025
 * [Get all resource blocks](../operations/resourceblocks.md#get-all-resource-blocks):
   * **Deprecated:** `Extent` parameter in request object.

--- a/operations/availabilityblocks.md
+++ b/operations/availabilityblocks.md
@@ -319,6 +319,7 @@ Adds availability blocks which are used to group related `Availability updates`.
 | `QuoteId` | string | optional | Unique identifier of the Mews Events quote associated with the availability block. |
 | `PurchaseOrderNumber` | string | optional | Unique number of the purchase order. This number is propagated to any newly picked up `Reservation` within the block. |
 | `BusinessSegmentId` | string | optional | Unique identifier of the business segment. |
+| `PickupDistribution` | [Pickup distribution](availabilityblocks.md#pickup-distribution) | optional | Pickup distribution. Defaults to `AllInOneGroup` if not specified. |
 
 ### Response
 


### PR DESCRIPTION
### Summary

Changes related to this task (https://mews.atlassian.net/browse/OPS-27544) involved updating the `"availabilityblocks/add"` endpoint to extend the request DTO with a new pickupDistribution option, enabling partners.

In this PR:
- Generated documentation for the new property in the `AvailabilityBlockAddParameters `DTO
- Add new entry to Changelog for this update

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] [Changelog] dated the day when PR merged
- [ ] [Changelog] accurately describes all changes
- [ ] [Changelog] highlights the affected endpoints or operations
- [ ] [Changelog] highlights any deprecations
- [ ] All hyperlinks tested
- [ ] [Deprecation Table](https://github.com/MewsSystems/gitbook-connector-api/blob/master/deprecations/README.md) updated if any deprecations
- [ ] [SUMMARY.md](https://github.com/MewsSystems/gitbook-connector-api/blob/master/SUMMARY.md) updated if new pages added

[Changelog]: https://github.com/MewsSystems/gitbook-connector-api/blob/master/changelog/README.md
